### PR TITLE
New utils to reduce boilerplate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,61 +3,40 @@ cmake_minimum_required(VERSION 3.12)
 # Set the project name and version
 project(GTwrap VERSION 1.0)
 
-##############################
+# ##############################################################################
 # General configuration
 
 # Sets the path to the interface parser.
 set(GTWRAP_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
-set(WRAP_PYTHON_VERSION "Default"
-    CACHE STRING
-    "The Python version to use for wrapping")
+set(WRAP_PYTHON_VERSION
+    "Default"
+    CACHE STRING "The Python version to use for wrapping")
 
-# Unset these cached variables to avoid surprises when the python
-# in the current environment are different from the cached!
-unset(PYTHON_EXECUTABLE CACHE)
-unset(PYTHON_INCLUDE_DIR CACHE)
-unset(PYTHON_MAJOR_VERSION CACHE)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/GtwrapUtils.cmake)
+gtwrap_get_python_version(${WRAP_PYTHON_VERSION})
 
-# Allow override from command line
-if(WRAP_PYTHON_VERSION STREQUAL "Default")
-    # Check for Python3 or Python2 in order
-    find_package(Python COMPONENTS Interpreter Development)
-
-    set(WRAP_PYTHON_VERSION "${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}"
-        CACHE
-        STRING
-        "The version of Python to build the wrappers against."
-        FORCE)
-
-else()
-    find_package(Python ${WRAP_PYTHON_VERSION}
-                 COMPONENTS Interpreter Development
-                 EXACT
-                 REQUIRED)
-endif()
-
-
-##############################
+# ##############################################################################
 # Install the CMake file to be used by other projects
 if(WIN32 AND NOT CYGWIN)
-    set(SCRIPT_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/CMake")
+  set(SCRIPT_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/CMake")
 else()
-    set(SCRIPT_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib/cmake")
+  set(SCRIPT_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib/cmake")
 endif()
 
 configure_file(cmake/PybindWrap.cmake.in
                ${CMAKE_CURRENT_SOURCE_DIR}/cmake/PybindWrap.cmake @ONLY)
 # Install scripts
-install(FILES
-    cmake/PybindWrap.cmake cmake/gtwrapConfig.cmake
-    DESTINATION "${SCRIPT_INSTALL_DIR}/gtwrap")
+install(FILES cmake/PybindWrap.cmake cmake/gtwrapConfig.cmake
+              cmake/GtwrapUtils.cmake
+        DESTINATION "${SCRIPT_INSTALL_DIR}/gtwrap")
 
-
-##############################
+# ##############################################################################
 # Install the Python package
-find_package(Python ${WRAP_PYTHON_VERSION}
-             COMPONENTS Interpreter REQUIRED)
+find_package(
+  Python ${WRAP_PYTHON_VERSION}
+  COMPONENTS Interpreter
+  REQUIRED)
 
 # Detect virtualenv and set Pip args accordingly
 # https://www.scivision.dev/cmake-install-python-package/
@@ -67,7 +46,7 @@ else()
   set(_pip_args "--user")
 endif()
 
-# We install in development mode (-e flag) so any updates
-# to the package are automatically propagated.
+# We install in development mode (-e flag) so any updates to the package are
+# automatically propagated.
 execute_process(COMMAND ${Python_EXECUTABLE} -m pip install -e . ${_pip_args}
                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/cmake/GtwrapUtils.cmake
+++ b/cmake/GtwrapUtils.cmake
@@ -1,0 +1,51 @@
+# Utilities to help with wrapping.
+
+# Set the Python version for the wrapper and set the paths to the executable and
+# include/library directories. WRAP_PYTHON_VERSION can be "Default" or a
+# specific major.minor version.
+function(gtwrap_get_python_version WRAP_PYTHON_VERSION)
+  # Unset these cached variables to avoid surprises when the python in the
+  # current environment are different from the cached!
+  unset(Python_EXECUTABLE CACHE)
+  unset(Python_INCLUDE_DIRS CACHE)
+  unset(Python_VERSION_MAJOR CACHE)
+  unset(Python_VERSION_MINOR CACHE)
+
+  # Allow override
+  if(${WRAP_PYTHON_VERSION} STREQUAL "Default")
+    # Check for Python3 or Python2 in order
+    find_package(Python COMPONENTS Interpreter Development)
+
+    set(WRAP_PYTHON_VERSION
+        "${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}"
+        CACHE STRING "The version of Python to build the wrappers against."
+              FORCE)
+
+    # message("========= ${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}")
+    # message("========= WRAP_PYTHON_VERSION=${WRAP_PYTHON_VERSION}")
+    # message("========= Python_EXECUTABLE=${Python_EXECUTABLE}")
+
+  else()
+    find_package(
+      Python ${WRAP_PYTHON_VERSION}
+      COMPONENTS Interpreter Development
+      EXACT REQUIRED)
+  endif()
+
+  set(WRAP_PYTHON_VERSION
+      ${WRAP_PYTHON_VERSION}
+      PARENT_SCOPE)
+  set(Python_FOUND
+      ${Python_FOUND}
+      PARENT_SCOPE)
+  set(Python_EXECUTABLE
+      ${Python_EXECUTABLE}
+      PARENT_SCOPE)
+  set(Python_INCLUDE_DIRS
+      ${Python_INCLUDE_DIRS}
+      PARENT_SCOPE)
+  set(Python_LIBRARY_DIRS
+      ${Python_LIBRARY_DIRS}
+      PARENT_SCOPE)
+
+endfunction()

--- a/cmake/gtwrapConfig.cmake
+++ b/cmake/gtwrapConfig.cmake
@@ -1,5 +1,14 @@
-# This config file modifies CMAKE_MODULE_PATH so that the wrap cmake files may be included
-# This file also allows the use of `find_package(gtwrap)` in CMake.
+# This config file modifies CMAKE_MODULE_PATH so that the wrap cmake files may
+# be included This file also allows the use of `find_package(gtwrap)` in CMake.
 
 set(GTWRAP_DIR "${CMAKE_CURRENT_LIST_DIR}")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+
+if(WIN32 AND NOT CYGWIN)
+  set(SCRIPT_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/CMake")
+else()
+  set(SCRIPT_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib/cmake")
+endif()
+
+include(${SCRIPT_INSTALL_DIR}/gtwrap/PybindWrap.cmake)
+include(${SCRIPT_INSTALL_DIR}/gtwrap/GtwrapUtils.cmake)


### PR DESCRIPTION
This PR does 2 things:

1. Add a new `gtwrap_get_python_version` function to remove the need to constantly duplicate the `find_package(Python ...)` function. It also sets the necessary variables in the calling CMake code to allow for proper wrapping.
2. Include `PybindWrap` by default so we only need to do `find_package(gtwrap)` and we have everything we need.