### PR TITLE
Consistent cmake minimum required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.9)
 
 # Set the project name and version
 project(GTwrap VERSION 1.0)


### PR DESCRIPTION
Set minimum support version to 3.9 to be consistent.