### PR TITLE
adding pickle support for select classes using serialization

### DIFF
--- a/gtwrap/pybind_wrapper.py
+++ b/gtwrap/pybind_wrapper.py
@@ -182,6 +182,7 @@ class PybindWrapper(object):
                 '{wrapped_ctors}'
                 '{wrapped_methods}'
                 '{wrapped_static_methods}'
+                '{wrapped_pickle}'
                 '{wrapped_properties};\n'.format(
                     shared_ptr_type=('boost' if self.use_boost else 'std'),
                     cpp_class=cpp_class,
@@ -192,6 +193,7 @@ class PybindWrapper(object):
                     wrapped_ctors=self.wrap_ctors(instantiated_class),
                     wrapped_methods=self.wrap_methods(instantiated_class.methods, cpp_class),
                     wrapped_static_methods=self.wrap_methods(instantiated_class.static_methods, cpp_class),
+                    wrapped_pickle=wrap_pickle(cpp_class),
                     wrapped_properties=self.wrap_properties(instantiated_class.properties, cpp_class),
                 ))
 
@@ -206,6 +208,7 @@ class PybindWrapper(object):
                 '{wrapped_ctors}'
                 '{wrapped_methods}'
                 '{wrapped_static_methods}'
+                '{wrapped_pickle}'
                 '{wrapped_properties};\n'.format(
                     shared_ptr_type=('boost' if self.use_boost else 'std'),
                     cpp_class=cpp_class,
@@ -215,6 +218,7 @@ class PybindWrapper(object):
                     wrapped_ctors=self.wrap_ctors(stl_class),
                     wrapped_methods=self.wrap_methods(stl_class.methods, cpp_class),
                     wrapped_static_methods=self.wrap_methods(stl_class.static_methods, cpp_class),
+                    wrapped_pickle=wrap_pickle(cpp_class),
                     wrapped_properties=self.wrap_properties(stl_class.properties, cpp_class),
                 ))
 
@@ -318,3 +322,35 @@ class PybindWrapper(object):
             wrapped_namespace=wrapped_namespace,
             boost_class_export=boost_class_export,
         )
+
+def wrap_pickle(cpp_class):
+    """Wrap to enable pickling on the generated Python class.
+    
+    Pickling is supported by reusing the serialization functionality already build in to many GTSAM types.
+
+    Ref: https://pybind11.readthedocs.io/en/stable/advanced/classes.html#pickling-support
+    """
+    if cpp_class not in [
+        "gtsam::Cal3Bundler",
+        "gtsam::PinholeCamera<gtsam::Cal3Bundler>", 
+        "gtsam::Pose3", 
+        "gtsam::Rot3", 
+        "gtsam::SfmTrack",
+        "gtsam::Unit3", 
+    ]:
+        # TODO: fix this check by just checking if serialization is supported.
+        return ""
+    return textwrap.dedent('''
+            .def(py::pickle(
+                [](const {cpp_class} &a){{ // __getstate__
+                    /* Returns a string that encodes the state of the object */
+                    return py::make_tuple(gtsam::serialize(a));
+                }},
+                [](py::tuple t){{ // __setstate__
+                    {cpp_class} obj;
+                    gtsam::deserialize(t[0].cast<std::string>(), obj);
+                    return obj;
+                }}
+            ))
+            ''').format(cpp_class=cpp_class)
+

--- a/gtwrap/pybind_wrapper.py
+++ b/gtwrap/pybind_wrapper.py
@@ -75,6 +75,16 @@ class PybindWrapper(object):
                         []({class_inst} self, string serialized){{
                             gtsam::deserialize(serialized, *self);
                         }}, py::arg("serialized"))
+                    .def(py::pickle(
+                        [](const {cpp_class} &a){{ // __getstate__
+                            /* Returns a string that encodes the state of the object */
+                            return py::make_tuple(gtsam::serialize(a));
+                        }},
+                        [](py::tuple t){{ // __setstate__
+                            {cpp_class} obj;
+                            gtsam::deserialize(t[0].cast<std::string>(), obj);
+                            return obj;
+                        }}))
                     '''.format(class_inst=cpp_class + '*'))
 
         is_method = isinstance(method, instantiator.InstantiatedMethod)
@@ -182,7 +192,6 @@ class PybindWrapper(object):
                 '{wrapped_ctors}'
                 '{wrapped_methods}'
                 '{wrapped_static_methods}'
-                '{wrapped_pickle}'
                 '{wrapped_properties};\n'.format(
                     shared_ptr_type=('boost' if self.use_boost else 'std'),
                     cpp_class=cpp_class,
@@ -193,7 +202,6 @@ class PybindWrapper(object):
                     wrapped_ctors=self.wrap_ctors(instantiated_class),
                     wrapped_methods=self.wrap_methods(instantiated_class.methods, cpp_class),
                     wrapped_static_methods=self.wrap_methods(instantiated_class.static_methods, cpp_class),
-                    wrapped_pickle=wrap_pickle(cpp_class),
                     wrapped_properties=self.wrap_properties(instantiated_class.properties, cpp_class),
                 ))
 
@@ -208,7 +216,6 @@ class PybindWrapper(object):
                 '{wrapped_ctors}'
                 '{wrapped_methods}'
                 '{wrapped_static_methods}'
-                '{wrapped_pickle}'
                 '{wrapped_properties};\n'.format(
                     shared_ptr_type=('boost' if self.use_boost else 'std'),
                     cpp_class=cpp_class,
@@ -218,7 +225,6 @@ class PybindWrapper(object):
                     wrapped_ctors=self.wrap_ctors(stl_class),
                     wrapped_methods=self.wrap_methods(stl_class.methods, cpp_class),
                     wrapped_static_methods=self.wrap_methods(stl_class.static_methods, cpp_class),
-                    wrapped_pickle=wrap_pickle(cpp_class),
                     wrapped_properties=self.wrap_properties(stl_class.properties, cpp_class),
                 ))
 
@@ -322,35 +328,4 @@ class PybindWrapper(object):
             wrapped_namespace=wrapped_namespace,
             boost_class_export=boost_class_export,
         )
-
-def wrap_pickle(cpp_class):
-    """Wrap to enable pickling on the generated Python class.
-    
-    Pickling is supported by reusing the serialization functionality already build in to many GTSAM types.
-
-    Ref: https://pybind11.readthedocs.io/en/stable/advanced/classes.html#pickling-support
-    """
-    if cpp_class not in [
-        "gtsam::Cal3Bundler",
-        "gtsam::PinholeCamera<gtsam::Cal3Bundler>", 
-        "gtsam::Pose3", 
-        "gtsam::Rot3", 
-        "gtsam::SfmTrack",
-        "gtsam::Unit3", 
-    ]:
-        # TODO: fix this check by just checking if serialization is supported.
-        return ""
-    return textwrap.dedent('''
-            .def(py::pickle(
-                [](const {cpp_class} &a){{ // __getstate__
-                    /* Returns a string that encodes the state of the object */
-                    return py::make_tuple(gtsam::serialize(a));
-                }},
-                [](py::tuple t){{ // __setstate__
-                    {cpp_class} obj;
-                    gtsam::deserialize(t[0].cast<std::string>(), obj);
-                    return obj;
-                }}
-            ))
-            ''').format(cpp_class=cpp_class)
 

--- a/gtwrap/pybind_wrapper.py
+++ b/gtwrap/pybind_wrapper.py
@@ -85,7 +85,7 @@ class PybindWrapper(object):
                             gtsam::deserialize(t[0].cast<std::string>(), obj);
                             return obj;
                         }}))
-                    '''.format(class_inst=cpp_class + '*'))
+                    '''.format(class_inst=cpp_class + '*', cpp_class=cpp_class))
 
         is_method = isinstance(method, instantiator.InstantiatedMethod)
         is_static = isinstance(method, parser.StaticMethod)

--- a/tests/expected-python/geometry_pybind.cpp
+++ b/tests/expected-python/geometry_pybind.cpp
@@ -47,6 +47,16 @@ PYBIND11_MODULE(geometry_py, m_) {
     [](gtsam::Point2* self, string serialized){
         gtsam::deserialize(serialized, *self);
     }, py::arg("serialized"))
+.def(py::pickle(
+    [](const gtsam::Point2 &a){{ // __getstate__
+        /* Returns a string that encodes the state of the object */
+        return py::make_tuple(gtsam::serialize(a));
+    }},
+    [](py::tuple t){ // __setstate__
+        gtsam::Point2 obj;
+        gtsam::deserialize(t[0].cast<std::string>(), obj);
+        return obj;
+    }))
 ;
 
     py::class_<gtsam::Point3, std::shared_ptr<gtsam::Point3>>(m_gtsam, "Point3")
@@ -61,7 +71,16 @@ PYBIND11_MODULE(geometry_py, m_) {
     [](gtsam::Point3* self, string serialized){
         gtsam::deserialize(serialized, *self);
     }, py::arg("serialized"))
-
+.def(py::pickle(
+    [](const gtsam::Point3 &a){ // __getstate__
+        /* Returns a string that encodes the state of the object */
+        return py::make_tuple(gtsam::serialize(a));
+    },
+    [](py::tuple t){ // __setstate__
+        gtsam::Point3 obj;
+        gtsam::deserialize(t[0].cast<std::string>(), obj);
+        return obj;
+    }))
         .def_static("staticFunction",[](){return gtsam::Point3::staticFunction();})
         .def_static("StaticFunctionRet",[]( double z){return gtsam::Point3::StaticFunctionRet(z);}, py::arg("z"));
 

--- a/tests/expected-python/geometry_pybind.cpp
+++ b/tests/expected-python/geometry_pybind.cpp
@@ -81,6 +81,7 @@ PYBIND11_MODULE(geometry_py, m_) {
         gtsam::deserialize(t[0].cast<std::string>(), obj);
         return obj;
     }))
+    
         .def_static("staticFunction",[](){return gtsam::Point3::staticFunction();})
         .def_static("StaticFunctionRet",[]( double z){return gtsam::Point3::StaticFunctionRet(z);}, py::arg("z"));
 

--- a/tests/expected-python/geometry_pybind.cpp
+++ b/tests/expected-python/geometry_pybind.cpp
@@ -81,7 +81,7 @@ PYBIND11_MODULE(geometry_py, m_) {
         gtsam::deserialize(t[0].cast<std::string>(), obj);
         return obj;
     }))
-    
+
         .def_static("staticFunction",[](){return gtsam::Point3::staticFunction();})
         .def_static("StaticFunctionRet",[]( double z){return gtsam::Point3::StaticFunctionRet(z);}, py::arg("z"));
 

--- a/tests/expected-python/geometry_pybind.cpp
+++ b/tests/expected-python/geometry_pybind.cpp
@@ -48,10 +48,10 @@ PYBIND11_MODULE(geometry_py, m_) {
         gtsam::deserialize(serialized, *self);
     }, py::arg("serialized"))
 .def(py::pickle(
-    [](const gtsam::Point2 &a){{ // __getstate__
+    [](const gtsam::Point2 &a){ // __getstate__
         /* Returns a string that encodes the state of the object */
         return py::make_tuple(gtsam::serialize(a));
-    }},
+    },
     [](py::tuple t){ // __setstate__
         gtsam::Point2 obj;
         gtsam::deserialize(t[0].cast<std::string>(), obj);


### PR DESCRIPTION
This PR will enable some python types for GTSAM to be pickled. Popular frameworks like numpy and pytorch already support pickling. This addition will enable better compatibility with multi-processing in Python and direct use in frameworks like Dask.