### PR TITLE
Fix template instantiation capitalization

### DIFF
--- a/gtwrap/template_instantiator.py
+++ b/gtwrap/template_instantiator.py
@@ -124,9 +124,14 @@ def instantiate_name(original_name, instantiations):
     namespaces, but I find that too verbose.
     """
     inst_name = ''
+    instantiated_names = []
+    for inst in instantiations:
+        # Ensure the first character of the type is capitalized
+        name = inst.instantiated_name()
+        # Using `capitalize` on the complete causes other caps to be lower case
+        instantiated_names.append(name.replace(name[0], name[0].capitalize()))
 
-    return "{}{}".format(original_name, "".join(
-        [inst.instantiated_name().capitalize() for inst in instantiations]))
+    return "{}{}".format(original_name, "".join(instantiated_names))
 
 
 class InstantiatedMethod(parser.Method):


### PR DESCRIPTION
Make sure `size_t` becomes `Size_t` and `Cal3_S2` remains `Cal3_S2`.