### PR TITLE
CMake variable for matlab.h include directory

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -32,11 +32,8 @@ jobs:
           sudo pip3 install -r requirements.txt
 
       - name: Build
-        run: |
-          mkdir build && cd build
-          cmake ..
-          cd ..
-      
+        run: cmake .
+
       - name: Test
           cd tests
           # Use Pytest to run all the tests.

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -35,6 +35,7 @@ jobs:
         run: cmake .
 
       - name: Test
+        run: |
           cd tests
           # Use Pytest to run all the tests.
           pytest

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -31,8 +31,13 @@ jobs:
           sudo pip3 install -U pip setuptools
           sudo pip3 install -r requirements.txt
 
-      - name: Build and Test
+      - name: Build
         run: |
+          mkdir build && cd build
+          cmake ..
+          cd ..
+      
+      - name: Test
           cd tests
           # Use Pytest to run all the tests.
           pytest

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -31,11 +31,9 @@ jobs:
           sudo pip3 install -U pip setuptools
           sudo pip3 install -r requirements.txt
 
-      - name: Build
-        run: cmake .
-
-      - name: Test
+      - name: Build and Test
         run: |
+          cmake .
           cd tests
           # Use Pytest to run all the tests.
           pytest

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -33,6 +33,7 @@ jobs:
         run: cmake .
 
       - name: Test
+        run: |
           cd tests
           # Use Pytest to run all the tests.
           pytest

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -29,11 +29,9 @@ jobs:
         run: |
           pip3 install -r requirements.txt
 
-      - name: Build
-        run: cmake .
-
-      - name: Test
+      - name: Build and Test
         run: |
+          cmake .
           cd tests
           # Use Pytest to run all the tests.
           pytest

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -30,11 +30,8 @@ jobs:
           pip3 install -r requirements.txt
 
       - name: Build
-        run: |
-          mkdir build && cd build
-          cmake ..
-          cd ..
-      
+        run: cmake .
+
       - name: Test
           cd tests
           # Use Pytest to run all the tests.

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -29,8 +29,14 @@ jobs:
         run: |
           pip3 install -r requirements.txt
 
-      - name: Build and Test
+      - name: Build
         run: |
+          mkdir build && cd build
+          cmake ..
+          cd ..
+      
+      - name: Test
           cd tests
           # Use Pytest to run all the tests.
           pytest
+

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__/
 
 # Files related to code coverage stats
 **/.coverage
+
+gtwrap/matlab_wrapper.tpl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,13 @@ else()
   set(SCRIPT_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib/cmake")
 endif()
 
+# Configure the include directory for matlab.h
+# This allows the #include to be either gtwrap/matlab.h, wrap/matlab.h or something custom.
+if(NOT DEFINED GTWRAP_INCLUDE_NAME)
+  set(GTWRAP_INCLUDE_NAME "gtwrap" CACHE INTERNAL "Directory name for Matlab includes")
+endif()
+configure_file(${PROJECT_SOURCE_DIR}/templates/matlab_wrapper.tpl.in ${PROJECT_SOURCE_DIR}/gtwrap/matlab_wrapper.tpl)
+
 # Install CMake scripts to the standard CMake script directory.
 install(FILES cmake/gtwrapConfig.cmake cmake/MatlabWrap.cmake
               cmake/PybindWrap.cmake cmake/GtwrapUtils.cmake

--- a/gtwrap/matlab_wrapper.py
+++ b/gtwrap/matlab_wrapper.py
@@ -76,7 +76,9 @@ class MatlabWrapper(object):
     # Files and their content
     content: List[str] = []
 
-    wrapper_file_template = "matlab_wrapper.tpl"
+    # Ensure the template file is always picked up from the correct directory.
+    dir_path = osp.dirname(osp.realpath(__file__))
+    wrapper_file_template = osp.join(dir_path, "matlab_wrapper.tpl")
 
     def __init__(self,
                  module,

--- a/gtwrap/matlab_wrapper.py
+++ b/gtwrap/matlab_wrapper.py
@@ -76,6 +76,8 @@ class MatlabWrapper(object):
     # Files and their content
     content: List[str] = []
 
+    wrapper_file_template = "matlab_wrapper.tpl"
+
     def __init__(self,
                  module,
                  module_name,
@@ -664,10 +666,8 @@ class MatlabWrapper(object):
         """Generate the C++ file for the wrapper."""
         file_name = self._wrapper_name() + '.cpp'
 
-        wrapper_file = textwrap.dedent('''\
-            # include <gtwrap/matlab.h>
-            # include <map>
-        ''')
+        with open(self.wrapper_file_template) as f:
+            wrapper_file = f.read()
 
         return file_name, wrapper_file
 

--- a/templates/matlab_wrapper.tpl.in
+++ b/templates/matlab_wrapper.tpl.in
@@ -1,0 +1,2 @@
+# include <${GTWRAP_INCLUDE_NAME}/matlab.h>
+# include <map>


### PR DESCRIPTION
Currently, `matlab_wrapper.py` assumes `matlab.h` is under `gtwrap/` (aka `#include <gtwrap/matlab.h>` which is fine when used as a standalone package.

But this doesn't hold for GTSAM which has the directory `wrap`, which explains the issues some folks have been having.

Thus this PR introduces a CMake variable to configure that directory from a parent level.
I'll add the corresponding CMake to GTSAM as well once this PR is merged.