### PR TITLE
Multiple templates in methods

### DIFF
--- a/gtwrap/matlab_wrapper.py
+++ b/gtwrap/matlab_wrapper.py
@@ -347,7 +347,7 @@ class MatlabWrapper(object):
 
             method += instance_method.parent.name + separator
             method += instance_method.original.name
-            method += "<" + instance_method.instantiation.to_cpp() + ">"
+            method += "<" + instance_method.instantiations.to_cpp() + ">"
 
         return method[2 * len(separator):]
 
@@ -1337,9 +1337,9 @@ class MatlabWrapper(object):
             method_name = method.to_cpp()
             obj_start = 'obj->'
 
-            if method.instantiation:
+            if method.instantiations:
                 # method_name += '<{}>'.format(
-                #     self._format_type_name(method.instantiation))
+                #     self._format_type_name(method.instantiations))
                 # method_name = self._format_instance_method(method, '::')
                 method = method.to_cpp()
 

--- a/gtwrap/template_instantiator.py
+++ b/gtwrap/template_instantiator.py
@@ -246,9 +246,13 @@ class InstantiatedMethod(parser.Method):
     def to_cpp(self):
         """Generate the C++ code for wrapping."""
         if self.original.template:
-            ret = "{}<{}>".format(
-                self.original.name,
-                ",".join([x.name for x in self.instantiations]))
+            instantiation_list = [
+                # Get the fully qualified name
+                "::".join(x.namespaces + [x.name])
+                for x in self.instantiations
+            ]
+            ret = "{}<{}>".format(self.original.name,
+                                  ",".join(instantiation_list))
         else:
             ret = self.original.name
         return ret

--- a/tests/expected/matlab/FunDouble.m
+++ b/tests/expected/matlab/FunDouble.m
@@ -3,6 +3,7 @@
 %
 %-------Methods-------
 %dhamaalString(double d, string t) : returns Fun<double>
+%pretStringSize_t(double d, string t, size_t u) : returns Fun<double>
 %
 %-------Static Methods-------
 %divertido() : returns Fun<double>
@@ -44,6 +45,16 @@ classdef FunDouble < handle
       error('Arguments do not match any overload of function FunDouble.dhamaalString');
     end
 
+    function varargout = pretStringSize_t(this, varargin)
+      % PRETSTRINGSIZE_T usage: pretStringSize_t(double d, string t, size_t u) : returns Fun<double>
+      % Doxygen can be found at https://gtsam.org/doxygen/
+      if length(varargin) == 3 && isa(varargin{1},'double') && isa(varargin{2},'char') && isa(varargin{3},'numeric')
+        varargout{1} = class_wrapper(8, this, varargin{:});
+        return
+      end
+      error('Arguments do not match any overload of function FunDouble.pretStringSize_t');
+    end
+
   end
 
   methods(Static = true)
@@ -51,7 +62,7 @@ classdef FunDouble < handle
       % DIVERTIDO usage: divertido() : returns Fundouble
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 0
-        varargout{1} = class_wrapper(8, varargin{:});
+        varargout{1} = class_wrapper(9, varargin{:});
         return
       end
 

--- a/tests/expected/matlab/FunDouble.m
+++ b/tests/expected/matlab/FunDouble.m
@@ -2,11 +2,11 @@
 %at https://gtsam.org/doxygen/
 %
 %-------Methods-------
-%dhamaalString(double d, string t) : returns Fun<double>
-%pretStringSize_t(double d, string t, size_t u) : returns Fun<double>
+%multiTemplatedMethodStringSize_t(double d, string t, size_t u) : returns Fun<double>
+%templatedMethodString(double d, string t) : returns Fun<double>
 %
 %-------Static Methods-------
-%divertido() : returns Fun<double>
+%staticMethodWithThis() : returns Fun<double>
 %
 %-------Serialization Interface-------
 %string_serialize() : returns string
@@ -35,38 +35,38 @@ classdef FunDouble < handle
     %DISPLAY Calls print on the object
     function disp(obj), obj.display; end
     %DISP Calls print on the object
-    function varargout = dhamaalString(this, varargin)
-      % DHAMAALSTRING usage: dhamaalString(double d, string t) : returns Fun<double>
+    function varargout = multiTemplatedMethodStringSize_t(this, varargin)
+      % MULTITEMPLATEDMETHODSTRINGSIZE_T usage: multiTemplatedMethodStringSize_t(double d, string t, size_t u) : returns Fun<double>
       % Doxygen can be found at https://gtsam.org/doxygen/
-      if length(varargin) == 2 && isa(varargin{1},'double') && isa(varargin{2},'char')
+      if length(varargin) == 3 && isa(varargin{1},'double') && isa(varargin{2},'char') && isa(varargin{3},'numeric')
         varargout{1} = class_wrapper(7, this, varargin{:});
         return
       end
-      error('Arguments do not match any overload of function FunDouble.dhamaalString');
+      error('Arguments do not match any overload of function FunDouble.multiTemplatedMethodStringSize_t');
     end
 
-    function varargout = pretStringSize_t(this, varargin)
-      % PRETSTRINGSIZE_T usage: pretStringSize_t(double d, string t, size_t u) : returns Fun<double>
+    function varargout = templatedMethodString(this, varargin)
+      % TEMPLATEDMETHODSTRING usage: templatedMethodString(double d, string t) : returns Fun<double>
       % Doxygen can be found at https://gtsam.org/doxygen/
-      if length(varargin) == 3 && isa(varargin{1},'double') && isa(varargin{2},'char') && isa(varargin{3},'numeric')
+      if length(varargin) == 2 && isa(varargin{1},'double') && isa(varargin{2},'char')
         varargout{1} = class_wrapper(8, this, varargin{:});
         return
       end
-      error('Arguments do not match any overload of function FunDouble.pretStringSize_t');
+      error('Arguments do not match any overload of function FunDouble.templatedMethodString');
     end
 
   end
 
   methods(Static = true)
-    function varargout = Divertido(varargin)
-      % DIVERTIDO usage: divertido() : returns Fundouble
+    function varargout = StaticMethodWithThis(varargin)
+      % STATICMETHODWITHTHIS usage: staticMethodWithThis() : returns Fundouble
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 0
         varargout{1} = class_wrapper(9, varargin{:});
         return
       end
 
-      error('Arguments do not match any overload of function FunDouble.divertido');
+      error('Arguments do not match any overload of function FunDouble.staticMethodWithThis');
     end
 
   end

--- a/tests/expected/matlab/MultipleTemplatesIntDouble.m
+++ b/tests/expected/matlab/MultipleTemplatesIntDouble.m
@@ -9,7 +9,7 @@ classdef MultipleTemplatesIntDouble < handle
     function obj = MultipleTemplatesIntDouble(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(43, my_ptr);
+        class_wrapper(44, my_ptr);
       else
         error('Arguments do not match any overload of MultipleTemplatesIntDouble constructor');
       end
@@ -17,7 +17,7 @@ classdef MultipleTemplatesIntDouble < handle
     end
 
     function delete(obj)
-      class_wrapper(44, obj.ptr_MultipleTemplatesIntDouble);
+      class_wrapper(45, obj.ptr_MultipleTemplatesIntDouble);
     end
 
     function display(obj), obj.print(''); end

--- a/tests/expected/matlab/MultipleTemplatesIntFloat.m
+++ b/tests/expected/matlab/MultipleTemplatesIntFloat.m
@@ -9,7 +9,7 @@ classdef MultipleTemplatesIntFloat < handle
     function obj = MultipleTemplatesIntFloat(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(45, my_ptr);
+        class_wrapper(46, my_ptr);
       else
         error('Arguments do not match any overload of MultipleTemplatesIntFloat constructor');
       end
@@ -17,7 +17,7 @@ classdef MultipleTemplatesIntFloat < handle
     end
 
     function delete(obj)
-      class_wrapper(46, obj.ptr_MultipleTemplatesIntFloat);
+      class_wrapper(47, obj.ptr_MultipleTemplatesIntFloat);
     end
 
     function display(obj), obj.print(''); end

--- a/tests/expected/matlab/MyFactorPosePoint2.m
+++ b/tests/expected/matlab/MyFactorPosePoint2.m
@@ -12,9 +12,9 @@ classdef MyFactorPosePoint2 < handle
     function obj = MyFactorPosePoint2(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(47, my_ptr);
+        class_wrapper(48, my_ptr);
       elseif nargin == 4 && isa(varargin{1},'numeric') && isa(varargin{2},'numeric') && isa(varargin{3},'double') && isa(varargin{4},'gtsam.noiseModel.Base')
-        my_ptr = class_wrapper(48, varargin{1}, varargin{2}, varargin{3}, varargin{4});
+        my_ptr = class_wrapper(49, varargin{1}, varargin{2}, varargin{3}, varargin{4});
       else
         error('Arguments do not match any overload of MyFactorPosePoint2 constructor');
       end
@@ -22,7 +22,7 @@ classdef MyFactorPosePoint2 < handle
     end
 
     function delete(obj)
-      class_wrapper(49, obj.ptr_MyFactorPosePoint2);
+      class_wrapper(50, obj.ptr_MyFactorPosePoint2);
     end
 
     function display(obj), obj.print(''); end

--- a/tests/expected/matlab/MyVector12.m
+++ b/tests/expected/matlab/MyVector12.m
@@ -12,9 +12,9 @@ classdef MyVector12 < handle
     function obj = MyVector12(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(40, my_ptr);
+        class_wrapper(41, my_ptr);
       elseif nargin == 0
-        my_ptr = class_wrapper(41);
+        my_ptr = class_wrapper(42);
       else
         error('Arguments do not match any overload of MyVector12 constructor');
       end
@@ -22,7 +22,7 @@ classdef MyVector12 < handle
     end
 
     function delete(obj)
-      class_wrapper(42, obj.ptr_MyVector12);
+      class_wrapper(43, obj.ptr_MyVector12);
     end
 
     function display(obj), obj.print(''); end

--- a/tests/expected/matlab/MyVector3.m
+++ b/tests/expected/matlab/MyVector3.m
@@ -12,9 +12,9 @@ classdef MyVector3 < handle
     function obj = MyVector3(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(37, my_ptr);
+        class_wrapper(38, my_ptr);
       elseif nargin == 0
-        my_ptr = class_wrapper(38);
+        my_ptr = class_wrapper(39);
       else
         error('Arguments do not match any overload of MyVector3 constructor');
       end
@@ -22,7 +22,7 @@ classdef MyVector3 < handle
     end
 
     function delete(obj)
-      class_wrapper(39, obj.ptr_MyVector3);
+      class_wrapper(40, obj.ptr_MyVector3);
     end
 
     function display(obj), obj.print(''); end

--- a/tests/expected/matlab/PrimitiveRefDouble.m
+++ b/tests/expected/matlab/PrimitiveRefDouble.m
@@ -19,9 +19,9 @@ classdef PrimitiveRefDouble < handle
     function obj = PrimitiveRefDouble(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(33, my_ptr);
+        class_wrapper(34, my_ptr);
       elseif nargin == 0
-        my_ptr = class_wrapper(34);
+        my_ptr = class_wrapper(35);
       else
         error('Arguments do not match any overload of PrimitiveRefDouble constructor');
       end
@@ -29,7 +29,7 @@ classdef PrimitiveRefDouble < handle
     end
 
     function delete(obj)
-      class_wrapper(35, obj.ptr_PrimitiveRefDouble);
+      class_wrapper(36, obj.ptr_PrimitiveRefDouble);
     end
 
     function display(obj), obj.print(''); end
@@ -43,7 +43,7 @@ classdef PrimitiveRefDouble < handle
       % BRUTAL usage: Brutal(double t) : returns PrimitiveRefdouble
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'double')
-        varargout{1} = class_wrapper(36, varargin{:});
+        varargout{1} = class_wrapper(37, varargin{:});
         return
       end
 

--- a/tests/expected/matlab/Test.m
+++ b/tests/expected/matlab/Test.m
@@ -35,11 +35,11 @@ classdef Test < handle
     function obj = Test(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(9, my_ptr);
+        class_wrapper(10, my_ptr);
       elseif nargin == 0
-        my_ptr = class_wrapper(10);
+        my_ptr = class_wrapper(11);
       elseif nargin == 2 && isa(varargin{1},'double') && isa(varargin{2},'double')
-        my_ptr = class_wrapper(11, varargin{1}, varargin{2});
+        my_ptr = class_wrapper(12, varargin{1}, varargin{2});
       else
         error('Arguments do not match any overload of Test constructor');
       end
@@ -47,7 +47,7 @@ classdef Test < handle
     end
 
     function delete(obj)
-      class_wrapper(12, obj.ptr_Test);
+      class_wrapper(13, obj.ptr_Test);
     end
 
     function display(obj), obj.print(''); end
@@ -58,7 +58,7 @@ classdef Test < handle
       % ARG_EIGENCONSTREF usage: arg_EigenConstRef(Matrix value) : returns void
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'double')
-        class_wrapper(13, this, varargin{:});
+        class_wrapper(14, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.arg_EigenConstRef');
@@ -68,7 +68,7 @@ classdef Test < handle
       % CREATE_MIXEDPTRS usage: create_MixedPtrs() : returns pair< Test, Test >
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 0
-        [ varargout{1} varargout{2} ] = class_wrapper(14, this, varargin{:});
+        [ varargout{1} varargout{2} ] = class_wrapper(15, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.create_MixedPtrs');
@@ -78,7 +78,7 @@ classdef Test < handle
       % CREATE_PTRS usage: create_ptrs() : returns pair< Test, Test >
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 0
-        [ varargout{1} varargout{2} ] = class_wrapper(15, this, varargin{:});
+        [ varargout{1} varargout{2} ] = class_wrapper(16, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.create_ptrs');
@@ -88,7 +88,7 @@ classdef Test < handle
       % PRINT usage: print() : returns void
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 0
-        class_wrapper(16, this, varargin{:});
+        class_wrapper(17, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.print');
@@ -98,7 +98,7 @@ classdef Test < handle
       % RETURN_POINT2PTR usage: return_Point2Ptr(bool value) : returns Point2
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'logical')
-        varargout{1} = class_wrapper(17, this, varargin{:});
+        varargout{1} = class_wrapper(18, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_Point2Ptr');
@@ -108,7 +108,7 @@ classdef Test < handle
       % RETURN_TEST usage: return_Test(Test value) : returns Test
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'Test')
-        varargout{1} = class_wrapper(18, this, varargin{:});
+        varargout{1} = class_wrapper(19, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_Test');
@@ -118,7 +118,7 @@ classdef Test < handle
       % RETURN_TESTPTR usage: return_TestPtr(Test value) : returns Test
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'Test')
-        varargout{1} = class_wrapper(19, this, varargin{:});
+        varargout{1} = class_wrapper(20, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_TestPtr');
@@ -128,7 +128,7 @@ classdef Test < handle
       % RETURN_BOOL usage: return_bool(bool value) : returns bool
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'logical')
-        varargout{1} = class_wrapper(20, this, varargin{:});
+        varargout{1} = class_wrapper(21, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_bool');
@@ -138,7 +138,7 @@ classdef Test < handle
       % RETURN_DOUBLE usage: return_double(double value) : returns double
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'double')
-        varargout{1} = class_wrapper(21, this, varargin{:});
+        varargout{1} = class_wrapper(22, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_double');
@@ -148,7 +148,7 @@ classdef Test < handle
       % RETURN_FIELD usage: return_field(Test t) : returns bool
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'Test')
-        varargout{1} = class_wrapper(22, this, varargin{:});
+        varargout{1} = class_wrapper(23, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_field');
@@ -158,7 +158,7 @@ classdef Test < handle
       % RETURN_INT usage: return_int(int value) : returns int
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'numeric')
-        varargout{1} = class_wrapper(23, this, varargin{:});
+        varargout{1} = class_wrapper(24, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_int');
@@ -168,7 +168,7 @@ classdef Test < handle
       % RETURN_MATRIX1 usage: return_matrix1(Matrix value) : returns Matrix
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'double')
-        varargout{1} = class_wrapper(24, this, varargin{:});
+        varargout{1} = class_wrapper(25, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_matrix1');
@@ -178,7 +178,7 @@ classdef Test < handle
       % RETURN_MATRIX2 usage: return_matrix2(Matrix value) : returns Matrix
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'double')
-        varargout{1} = class_wrapper(25, this, varargin{:});
+        varargout{1} = class_wrapper(26, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_matrix2');
@@ -188,13 +188,13 @@ classdef Test < handle
       % RETURN_PAIR usage: return_pair(Vector v, Matrix A) : returns pair< Vector, Matrix >
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 2 && isa(varargin{1},'double') && size(varargin{1},2)==1 && isa(varargin{2},'double')
-        [ varargout{1} varargout{2} ] = class_wrapper(26, this, varargin{:});
+        [ varargout{1} varargout{2} ] = class_wrapper(27, this, varargin{:});
         return
       end
       % RETURN_PAIR usage: return_pair(Vector v) : returns pair< Vector, Matrix >
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'double') && size(varargin{1},2)==1
-        [ varargout{1} varargout{2} ] = class_wrapper(27, this, varargin{:});
+        [ varargout{1} varargout{2} ] = class_wrapper(28, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_pair');
@@ -204,7 +204,7 @@ classdef Test < handle
       % RETURN_PTRS usage: return_ptrs(Test p1, Test p2) : returns pair< Test, Test >
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 2 && isa(varargin{1},'Test') && isa(varargin{2},'Test')
-        [ varargout{1} varargout{2} ] = class_wrapper(28, this, varargin{:});
+        [ varargout{1} varargout{2} ] = class_wrapper(29, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_ptrs');
@@ -214,7 +214,7 @@ classdef Test < handle
       % RETURN_SIZE_T usage: return_size_t(size_t value) : returns size_t
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'numeric')
-        varargout{1} = class_wrapper(29, this, varargin{:});
+        varargout{1} = class_wrapper(30, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_size_t');
@@ -224,7 +224,7 @@ classdef Test < handle
       % RETURN_STRING usage: return_string(string value) : returns string
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'char')
-        varargout{1} = class_wrapper(30, this, varargin{:});
+        varargout{1} = class_wrapper(31, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_string');
@@ -234,7 +234,7 @@ classdef Test < handle
       % RETURN_VECTOR1 usage: return_vector1(Vector value) : returns Vector
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'double') && size(varargin{1},2)==1
-        varargout{1} = class_wrapper(31, this, varargin{:});
+        varargout{1} = class_wrapper(32, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_vector1');
@@ -244,7 +244,7 @@ classdef Test < handle
       % RETURN_VECTOR2 usage: return_vector2(Vector value) : returns Vector
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'double') && size(varargin{1},2)==1
-        varargout{1} = class_wrapper(32, this, varargin{:});
+        varargout{1} = class_wrapper(33, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_vector2');

--- a/tests/expected/matlab/class_wrapper.cpp
+++ b/tests/expected/matlab/class_wrapper.cpp
@@ -200,29 +200,29 @@ void FunDouble_deconstructor_6(int nargout, mxArray *out[], int nargin, const mx
   }
 }
 
-void FunDouble_dhamaal_7(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void FunDouble_multiTemplatedMethod_7(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  checkArguments("dhamaalString",nargout,nargin-1,2);
-  auto obj = unwrap_shared_ptr<Fun<double>>(in[0], "ptr_FunDouble");
-  double d = unwrap< double >(in[1]);
-  string t = unwrap< string >(in[2]);
-  out[0] = wrap_shared_ptr(boost::make_shared<Fun<double>>(obj->dhamaal<string>(d,t)),"Fun<double>", false);
-}
-
-void FunDouble_pret_8(int nargout, mxArray *out[], int nargin, const mxArray *in[])
-{
-  checkArguments("pretStringSize_t",nargout,nargin-1,3);
+  checkArguments("multiTemplatedMethodStringSize_t",nargout,nargin-1,3);
   auto obj = unwrap_shared_ptr<Fun<double>>(in[0], "ptr_FunDouble");
   double d = unwrap< double >(in[1]);
   string t = unwrap< string >(in[2]);
   size_t u = unwrap< size_t >(in[3]);
-  out[0] = wrap_shared_ptr(boost::make_shared<Fun<double>>(obj->pret<string,size_t>(d,t,u)),"Fun<double>", false);
+  out[0] = wrap_shared_ptr(boost::make_shared<Fun<double>>(obj->multiTemplatedMethod<string,size_t>(d,t,u)),"Fun<double>", false);
 }
 
-void FunDouble_divertido_9(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void FunDouble_templatedMethod_8(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  checkArguments("FunDouble.divertido",nargout,nargin,0);
-  out[0] = wrap_shared_ptr(boost::make_shared<Fun<double>>(Fun<double>::divertido()),"Fundouble", false);
+  checkArguments("templatedMethodString",nargout,nargin-1,2);
+  auto obj = unwrap_shared_ptr<Fun<double>>(in[0], "ptr_FunDouble");
+  double d = unwrap< double >(in[1]);
+  string t = unwrap< string >(in[2]);
+  out[0] = wrap_shared_ptr(boost::make_shared<Fun<double>>(obj->templatedMethod<string>(d,t)),"Fun<double>", false);
+}
+
+void FunDouble_staticMethodWithThis_9(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("FunDouble.staticMethodWithThis",nargout,nargin,0);
+  out[0] = wrap_shared_ptr(boost::make_shared<Fun<double>>(Fun<double>::staticMethodWithThis()),"Fundouble", false);
 }
 
 void Test_collectorInsertAndMakeBase_10(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -664,13 +664,13 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       FunDouble_deconstructor_6(nargout, out, nargin-1, in+1);
       break;
     case 7:
-      FunDouble_dhamaal_7(nargout, out, nargin-1, in+1);
+      FunDouble_multiTemplatedMethod_7(nargout, out, nargin-1, in+1);
       break;
     case 8:
-      FunDouble_pret_8(nargout, out, nargin-1, in+1);
+      FunDouble_templatedMethod_8(nargout, out, nargin-1, in+1);
       break;
     case 9:
-      FunDouble_divertido_9(nargout, out, nargin-1, in+1);
+      FunDouble_staticMethodWithThis_9(nargout, out, nargin-1, in+1);
       break;
     case 10:
       Test_collectorInsertAndMakeBase_10(nargout, out, nargin-1, in+1);

--- a/tests/expected/matlab/class_wrapper.cpp
+++ b/tests/expected/matlab/class_wrapper.cpp
@@ -209,13 +209,23 @@ void FunDouble_dhamaal_7(int nargout, mxArray *out[], int nargin, const mxArray 
   out[0] = wrap_shared_ptr(boost::make_shared<Fun<double>>(obj->dhamaal<string>(d,t)),"Fun<double>", false);
 }
 
-void FunDouble_divertido_8(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void FunDouble_pret_8(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("pretStringSize_t",nargout,nargin-1,3);
+  auto obj = unwrap_shared_ptr<Fun<double>>(in[0], "ptr_FunDouble");
+  double d = unwrap< double >(in[1]);
+  string t = unwrap< string >(in[2]);
+  size_t u = unwrap< size_t >(in[3]);
+  out[0] = wrap_shared_ptr(boost::make_shared<Fun<double>>(obj->pret<string,size_t>(d,t,u)),"Fun<double>", false);
+}
+
+void FunDouble_divertido_9(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("FunDouble.divertido",nargout,nargin,0);
   out[0] = wrap_shared_ptr(boost::make_shared<Fun<double>>(Fun<double>::divertido()),"Fundouble", false);
 }
 
-void Test_collectorInsertAndMakeBase_9(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_collectorInsertAndMakeBase_10(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<Test> Shared;
@@ -224,7 +234,7 @@ void Test_collectorInsertAndMakeBase_9(int nargout, mxArray *out[], int nargin, 
   collector_Test.insert(self);
 }
 
-void Test_constructor_10(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_constructor_11(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<Test> Shared;
@@ -235,7 +245,7 @@ void Test_constructor_10(int nargout, mxArray *out[], int nargin, const mxArray 
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void Test_constructor_11(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_constructor_12(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<Test> Shared;
@@ -248,7 +258,7 @@ void Test_constructor_11(int nargout, mxArray *out[], int nargin, const mxArray 
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void Test_deconstructor_12(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_deconstructor_13(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<Test> Shared;
   checkArguments("delete_Test",nargout,nargin,1);
@@ -261,7 +271,7 @@ void Test_deconstructor_12(int nargout, mxArray *out[], int nargin, const mxArra
   }
 }
 
-void Test_arg_EigenConstRef_13(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_arg_EigenConstRef_14(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("arg_EigenConstRef",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -269,7 +279,7 @@ void Test_arg_EigenConstRef_13(int nargout, mxArray *out[], int nargin, const mx
   obj->arg_EigenConstRef(value);
 }
 
-void Test_create_MixedPtrs_14(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_create_MixedPtrs_15(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("create_MixedPtrs",nargout,nargin-1,0);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -278,7 +288,7 @@ void Test_create_MixedPtrs_14(int nargout, mxArray *out[], int nargin, const mxA
   out[1] = wrap_shared_ptr(pairResult.second,"Test", false);
 }
 
-void Test_create_ptrs_15(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_create_ptrs_16(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("create_ptrs",nargout,nargin-1,0);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -287,14 +297,14 @@ void Test_create_ptrs_15(int nargout, mxArray *out[], int nargin, const mxArray 
   out[1] = wrap_shared_ptr(pairResult.second,"Test", false);
 }
 
-void Test_print_16(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_print_17(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("print",nargout,nargin-1,0);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
   obj->print();
 }
 
-void Test_return_Point2Ptr_17(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_Point2Ptr_18(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_Point2Ptr",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -305,7 +315,7 @@ void Test_return_Point2Ptr_17(int nargout, mxArray *out[], int nargin, const mxA
   }
 }
 
-void Test_return_Test_18(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_Test_19(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_Test",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -313,7 +323,7 @@ void Test_return_Test_18(int nargout, mxArray *out[], int nargin, const mxArray 
   out[0] = wrap_shared_ptr(boost::make_shared<Test>(obj->return_Test(value)),"Test", false);
 }
 
-void Test_return_TestPtr_19(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_TestPtr_20(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_TestPtr",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -321,7 +331,7 @@ void Test_return_TestPtr_19(int nargout, mxArray *out[], int nargin, const mxArr
   out[0] = wrap_shared_ptr(obj->return_TestPtr(value),"Test", false);
 }
 
-void Test_return_bool_20(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_bool_21(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_bool",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -329,7 +339,7 @@ void Test_return_bool_20(int nargout, mxArray *out[], int nargin, const mxArray 
   out[0] = wrap< bool >(obj->return_bool(value));
 }
 
-void Test_return_double_21(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_double_22(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_double",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -337,7 +347,7 @@ void Test_return_double_21(int nargout, mxArray *out[], int nargin, const mxArra
   out[0] = wrap< double >(obj->return_double(value));
 }
 
-void Test_return_field_22(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_field_23(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_field",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -345,7 +355,7 @@ void Test_return_field_22(int nargout, mxArray *out[], int nargin, const mxArray
   out[0] = wrap< bool >(obj->return_field(t));
 }
 
-void Test_return_int_23(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_int_24(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_int",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -353,7 +363,7 @@ void Test_return_int_23(int nargout, mxArray *out[], int nargin, const mxArray *
   out[0] = wrap< int >(obj->return_int(value));
 }
 
-void Test_return_matrix1_24(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_matrix1_25(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_matrix1",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -361,7 +371,7 @@ void Test_return_matrix1_24(int nargout, mxArray *out[], int nargin, const mxArr
   out[0] = wrap< Matrix >(obj->return_matrix1(value));
 }
 
-void Test_return_matrix2_25(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_matrix2_26(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_matrix2",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -369,7 +379,7 @@ void Test_return_matrix2_25(int nargout, mxArray *out[], int nargin, const mxArr
   out[0] = wrap< Matrix >(obj->return_matrix2(value));
 }
 
-void Test_return_pair_26(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_pair_27(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_pair",nargout,nargin-1,2);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -380,7 +390,7 @@ void Test_return_pair_26(int nargout, mxArray *out[], int nargin, const mxArray 
   out[1] = wrap< Matrix >(pairResult.second);
 }
 
-void Test_return_pair_27(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_pair_28(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_pair",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -390,7 +400,7 @@ void Test_return_pair_27(int nargout, mxArray *out[], int nargin, const mxArray 
   out[1] = wrap< Matrix >(pairResult.second);
 }
 
-void Test_return_ptrs_28(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_ptrs_29(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_ptrs",nargout,nargin-1,2);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -401,7 +411,7 @@ void Test_return_ptrs_28(int nargout, mxArray *out[], int nargin, const mxArray 
   out[1] = wrap_shared_ptr(pairResult.second,"Test", false);
 }
 
-void Test_return_size_t_29(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_size_t_30(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_size_t",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -409,7 +419,7 @@ void Test_return_size_t_29(int nargout, mxArray *out[], int nargin, const mxArra
   out[0] = wrap< size_t >(obj->return_size_t(value));
 }
 
-void Test_return_string_30(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_string_31(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_string",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -417,7 +427,7 @@ void Test_return_string_30(int nargout, mxArray *out[], int nargin, const mxArra
   out[0] = wrap< string >(obj->return_string(value));
 }
 
-void Test_return_vector1_31(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_vector1_32(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_vector1",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -425,7 +435,7 @@ void Test_return_vector1_31(int nargout, mxArray *out[], int nargin, const mxArr
   out[0] = wrap< Vector >(obj->return_vector1(value));
 }
 
-void Test_return_vector2_32(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_vector2_33(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_vector2",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -433,7 +443,7 @@ void Test_return_vector2_32(int nargout, mxArray *out[], int nargin, const mxArr
   out[0] = wrap< Vector >(obj->return_vector2(value));
 }
 
-void PrimitiveRefDouble_collectorInsertAndMakeBase_33(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void PrimitiveRefDouble_collectorInsertAndMakeBase_34(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<PrimitiveRef<double>> Shared;
@@ -442,7 +452,7 @@ void PrimitiveRefDouble_collectorInsertAndMakeBase_33(int nargout, mxArray *out[
   collector_PrimitiveRefDouble.insert(self);
 }
 
-void PrimitiveRefDouble_constructor_34(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void PrimitiveRefDouble_constructor_35(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<PrimitiveRef<double>> Shared;
@@ -453,7 +463,7 @@ void PrimitiveRefDouble_constructor_34(int nargout, mxArray *out[], int nargin, 
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void PrimitiveRefDouble_deconstructor_35(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void PrimitiveRefDouble_deconstructor_36(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<PrimitiveRef<double>> Shared;
   checkArguments("delete_PrimitiveRefDouble",nargout,nargin,1);
@@ -466,14 +476,14 @@ void PrimitiveRefDouble_deconstructor_35(int nargout, mxArray *out[], int nargin
   }
 }
 
-void PrimitiveRefDouble_Brutal_36(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void PrimitiveRefDouble_Brutal_37(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("PrimitiveRefDouble.Brutal",nargout,nargin,1);
   double t = unwrap< double >(in[0]);
   out[0] = wrap_shared_ptr(boost::make_shared<PrimitiveRef<double>>(PrimitiveRef<double>::Brutal(t)),"PrimitiveRefdouble", false);
 }
 
-void MyVector3_collectorInsertAndMakeBase_37(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyVector3_collectorInsertAndMakeBase_38(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MyVector<3>> Shared;
@@ -482,7 +492,7 @@ void MyVector3_collectorInsertAndMakeBase_37(int nargout, mxArray *out[], int na
   collector_MyVector3.insert(self);
 }
 
-void MyVector3_constructor_38(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyVector3_constructor_39(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MyVector<3>> Shared;
@@ -493,7 +503,7 @@ void MyVector3_constructor_38(int nargout, mxArray *out[], int nargin, const mxA
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void MyVector3_deconstructor_39(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyVector3_deconstructor_40(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<MyVector<3>> Shared;
   checkArguments("delete_MyVector3",nargout,nargin,1);
@@ -506,7 +516,7 @@ void MyVector3_deconstructor_39(int nargout, mxArray *out[], int nargin, const m
   }
 }
 
-void MyVector12_collectorInsertAndMakeBase_40(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyVector12_collectorInsertAndMakeBase_41(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MyVector<12>> Shared;
@@ -515,7 +525,7 @@ void MyVector12_collectorInsertAndMakeBase_40(int nargout, mxArray *out[], int n
   collector_MyVector12.insert(self);
 }
 
-void MyVector12_constructor_41(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyVector12_constructor_42(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MyVector<12>> Shared;
@@ -526,7 +536,7 @@ void MyVector12_constructor_41(int nargout, mxArray *out[], int nargin, const mx
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void MyVector12_deconstructor_42(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyVector12_deconstructor_43(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<MyVector<12>> Shared;
   checkArguments("delete_MyVector12",nargout,nargin,1);
@@ -539,7 +549,7 @@ void MyVector12_deconstructor_42(int nargout, mxArray *out[], int nargin, const 
   }
 }
 
-void MultipleTemplatesIntDouble_collectorInsertAndMakeBase_43(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MultipleTemplatesIntDouble_collectorInsertAndMakeBase_44(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MultipleTemplates<int, double>> Shared;
@@ -548,7 +558,7 @@ void MultipleTemplatesIntDouble_collectorInsertAndMakeBase_43(int nargout, mxArr
   collector_MultipleTemplatesIntDouble.insert(self);
 }
 
-void MultipleTemplatesIntDouble_deconstructor_44(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MultipleTemplatesIntDouble_deconstructor_45(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<MultipleTemplates<int, double>> Shared;
   checkArguments("delete_MultipleTemplatesIntDouble",nargout,nargin,1);
@@ -561,7 +571,7 @@ void MultipleTemplatesIntDouble_deconstructor_44(int nargout, mxArray *out[], in
   }
 }
 
-void MultipleTemplatesIntFloat_collectorInsertAndMakeBase_45(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MultipleTemplatesIntFloat_collectorInsertAndMakeBase_46(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MultipleTemplates<int, float>> Shared;
@@ -570,7 +580,7 @@ void MultipleTemplatesIntFloat_collectorInsertAndMakeBase_45(int nargout, mxArra
   collector_MultipleTemplatesIntFloat.insert(self);
 }
 
-void MultipleTemplatesIntFloat_deconstructor_46(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MultipleTemplatesIntFloat_deconstructor_47(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<MultipleTemplates<int, float>> Shared;
   checkArguments("delete_MultipleTemplatesIntFloat",nargout,nargin,1);
@@ -583,7 +593,7 @@ void MultipleTemplatesIntFloat_deconstructor_46(int nargout, mxArray *out[], int
   }
 }
 
-void MyFactorPosePoint2_collectorInsertAndMakeBase_47(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyFactorPosePoint2_collectorInsertAndMakeBase_48(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>> Shared;
@@ -592,7 +602,7 @@ void MyFactorPosePoint2_collectorInsertAndMakeBase_47(int nargout, mxArray *out[
   collector_MyFactorPosePoint2.insert(self);
 }
 
-void MyFactorPosePoint2_constructor_48(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyFactorPosePoint2_constructor_49(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>> Shared;
@@ -607,7 +617,7 @@ void MyFactorPosePoint2_constructor_48(int nargout, mxArray *out[], int nargin, 
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void MyFactorPosePoint2_deconstructor_49(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyFactorPosePoint2_deconstructor_50(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>> Shared;
   checkArguments("delete_MyFactorPosePoint2",nargout,nargin,1);
@@ -657,130 +667,133 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       FunDouble_dhamaal_7(nargout, out, nargin-1, in+1);
       break;
     case 8:
-      FunDouble_divertido_8(nargout, out, nargin-1, in+1);
+      FunDouble_pret_8(nargout, out, nargin-1, in+1);
       break;
     case 9:
-      Test_collectorInsertAndMakeBase_9(nargout, out, nargin-1, in+1);
+      FunDouble_divertido_9(nargout, out, nargin-1, in+1);
       break;
     case 10:
-      Test_constructor_10(nargout, out, nargin-1, in+1);
+      Test_collectorInsertAndMakeBase_10(nargout, out, nargin-1, in+1);
       break;
     case 11:
       Test_constructor_11(nargout, out, nargin-1, in+1);
       break;
     case 12:
-      Test_deconstructor_12(nargout, out, nargin-1, in+1);
+      Test_constructor_12(nargout, out, nargin-1, in+1);
       break;
     case 13:
-      Test_arg_EigenConstRef_13(nargout, out, nargin-1, in+1);
+      Test_deconstructor_13(nargout, out, nargin-1, in+1);
       break;
     case 14:
-      Test_create_MixedPtrs_14(nargout, out, nargin-1, in+1);
+      Test_arg_EigenConstRef_14(nargout, out, nargin-1, in+1);
       break;
     case 15:
-      Test_create_ptrs_15(nargout, out, nargin-1, in+1);
+      Test_create_MixedPtrs_15(nargout, out, nargin-1, in+1);
       break;
     case 16:
-      Test_print_16(nargout, out, nargin-1, in+1);
+      Test_create_ptrs_16(nargout, out, nargin-1, in+1);
       break;
     case 17:
-      Test_return_Point2Ptr_17(nargout, out, nargin-1, in+1);
+      Test_print_17(nargout, out, nargin-1, in+1);
       break;
     case 18:
-      Test_return_Test_18(nargout, out, nargin-1, in+1);
+      Test_return_Point2Ptr_18(nargout, out, nargin-1, in+1);
       break;
     case 19:
-      Test_return_TestPtr_19(nargout, out, nargin-1, in+1);
+      Test_return_Test_19(nargout, out, nargin-1, in+1);
       break;
     case 20:
-      Test_return_bool_20(nargout, out, nargin-1, in+1);
+      Test_return_TestPtr_20(nargout, out, nargin-1, in+1);
       break;
     case 21:
-      Test_return_double_21(nargout, out, nargin-1, in+1);
+      Test_return_bool_21(nargout, out, nargin-1, in+1);
       break;
     case 22:
-      Test_return_field_22(nargout, out, nargin-1, in+1);
+      Test_return_double_22(nargout, out, nargin-1, in+1);
       break;
     case 23:
-      Test_return_int_23(nargout, out, nargin-1, in+1);
+      Test_return_field_23(nargout, out, nargin-1, in+1);
       break;
     case 24:
-      Test_return_matrix1_24(nargout, out, nargin-1, in+1);
+      Test_return_int_24(nargout, out, nargin-1, in+1);
       break;
     case 25:
-      Test_return_matrix2_25(nargout, out, nargin-1, in+1);
+      Test_return_matrix1_25(nargout, out, nargin-1, in+1);
       break;
     case 26:
-      Test_return_pair_26(nargout, out, nargin-1, in+1);
+      Test_return_matrix2_26(nargout, out, nargin-1, in+1);
       break;
     case 27:
       Test_return_pair_27(nargout, out, nargin-1, in+1);
       break;
     case 28:
-      Test_return_ptrs_28(nargout, out, nargin-1, in+1);
+      Test_return_pair_28(nargout, out, nargin-1, in+1);
       break;
     case 29:
-      Test_return_size_t_29(nargout, out, nargin-1, in+1);
+      Test_return_ptrs_29(nargout, out, nargin-1, in+1);
       break;
     case 30:
-      Test_return_string_30(nargout, out, nargin-1, in+1);
+      Test_return_size_t_30(nargout, out, nargin-1, in+1);
       break;
     case 31:
-      Test_return_vector1_31(nargout, out, nargin-1, in+1);
+      Test_return_string_31(nargout, out, nargin-1, in+1);
       break;
     case 32:
-      Test_return_vector2_32(nargout, out, nargin-1, in+1);
+      Test_return_vector1_32(nargout, out, nargin-1, in+1);
       break;
     case 33:
-      PrimitiveRefDouble_collectorInsertAndMakeBase_33(nargout, out, nargin-1, in+1);
+      Test_return_vector2_33(nargout, out, nargin-1, in+1);
       break;
     case 34:
-      PrimitiveRefDouble_constructor_34(nargout, out, nargin-1, in+1);
+      PrimitiveRefDouble_collectorInsertAndMakeBase_34(nargout, out, nargin-1, in+1);
       break;
     case 35:
-      PrimitiveRefDouble_deconstructor_35(nargout, out, nargin-1, in+1);
+      PrimitiveRefDouble_constructor_35(nargout, out, nargin-1, in+1);
       break;
     case 36:
-      PrimitiveRefDouble_Brutal_36(nargout, out, nargin-1, in+1);
+      PrimitiveRefDouble_deconstructor_36(nargout, out, nargin-1, in+1);
       break;
     case 37:
-      MyVector3_collectorInsertAndMakeBase_37(nargout, out, nargin-1, in+1);
+      PrimitiveRefDouble_Brutal_37(nargout, out, nargin-1, in+1);
       break;
     case 38:
-      MyVector3_constructor_38(nargout, out, nargin-1, in+1);
+      MyVector3_collectorInsertAndMakeBase_38(nargout, out, nargin-1, in+1);
       break;
     case 39:
-      MyVector3_deconstructor_39(nargout, out, nargin-1, in+1);
+      MyVector3_constructor_39(nargout, out, nargin-1, in+1);
       break;
     case 40:
-      MyVector12_collectorInsertAndMakeBase_40(nargout, out, nargin-1, in+1);
+      MyVector3_deconstructor_40(nargout, out, nargin-1, in+1);
       break;
     case 41:
-      MyVector12_constructor_41(nargout, out, nargin-1, in+1);
+      MyVector12_collectorInsertAndMakeBase_41(nargout, out, nargin-1, in+1);
       break;
     case 42:
-      MyVector12_deconstructor_42(nargout, out, nargin-1, in+1);
+      MyVector12_constructor_42(nargout, out, nargin-1, in+1);
       break;
     case 43:
-      MultipleTemplatesIntDouble_collectorInsertAndMakeBase_43(nargout, out, nargin-1, in+1);
+      MyVector12_deconstructor_43(nargout, out, nargin-1, in+1);
       break;
     case 44:
-      MultipleTemplatesIntDouble_deconstructor_44(nargout, out, nargin-1, in+1);
+      MultipleTemplatesIntDouble_collectorInsertAndMakeBase_44(nargout, out, nargin-1, in+1);
       break;
     case 45:
-      MultipleTemplatesIntFloat_collectorInsertAndMakeBase_45(nargout, out, nargin-1, in+1);
+      MultipleTemplatesIntDouble_deconstructor_45(nargout, out, nargin-1, in+1);
       break;
     case 46:
-      MultipleTemplatesIntFloat_deconstructor_46(nargout, out, nargin-1, in+1);
+      MultipleTemplatesIntFloat_collectorInsertAndMakeBase_46(nargout, out, nargin-1, in+1);
       break;
     case 47:
-      MyFactorPosePoint2_collectorInsertAndMakeBase_47(nargout, out, nargin-1, in+1);
+      MultipleTemplatesIntFloat_deconstructor_47(nargout, out, nargin-1, in+1);
       break;
     case 48:
-      MyFactorPosePoint2_constructor_48(nargout, out, nargin-1, in+1);
+      MyFactorPosePoint2_collectorInsertAndMakeBase_48(nargout, out, nargin-1, in+1);
       break;
     case 49:
-      MyFactorPosePoint2_deconstructor_49(nargout, out, nargin-1, in+1);
+      MyFactorPosePoint2_constructor_49(nargout, out, nargin-1, in+1);
+      break;
+    case 50:
+      MyFactorPosePoint2_deconstructor_50(nargout, out, nargin-1, in+1);
       break;
     }
   } catch(const std::exception& e) {

--- a/tests/expected/python/class_pybind.cpp
+++ b/tests/expected/python/class_pybind.cpp
@@ -28,9 +28,9 @@ PYBIND11_MODULE(class_py, m_) {
         .def_static("create",[](){return FunRange::create();});
 
     py::class_<Fun<double>, std::shared_ptr<Fun<double>>>(m_, "FunDouble")
-        .def("dhamaalString",[](Fun<double>* self, double d, string t){return self->dhamaal<string>(d, t);}, py::arg("d"), py::arg("t"))
-        .def("pretStringSize_t",[](Fun<double>* self, double d, string t, size_t u){return self->pret<string,size_t>(d, t, u);}, py::arg("d"), py::arg("t"), py::arg("u"))
-        .def_static("divertido",[](){return Fun<double>::divertido();});
+        .def("templatedMethodString",[](Fun<double>* self, double d, string t){return self->templatedMethod<string>(d, t);}, py::arg("d"), py::arg("t"))
+        .def("multiTemplatedMethodStringSize_t",[](Fun<double>* self, double d, string t, size_t u){return self->multiTemplatedMethod<string,size_t>(d, t, u);}, py::arg("d"), py::arg("t"), py::arg("u"))
+        .def_static("staticMethodWithThis",[](){return Fun<double>::staticMethodWithThis();});
 
     py::class_<Test, std::shared_ptr<Test>>(m_, "Test")
         .def(py::init<>())

--- a/tests/expected/python/class_pybind.cpp
+++ b/tests/expected/python/class_pybind.cpp
@@ -29,6 +29,7 @@ PYBIND11_MODULE(class_py, m_) {
 
     py::class_<Fun<double>, std::shared_ptr<Fun<double>>>(m_, "FunDouble")
         .def("dhamaalString",[](Fun<double>* self, double d, string t){return self->dhamaal<string>(d, t);}, py::arg("d"), py::arg("t"))
+        .def("pretStringSize_t",[](Fun<double>* self, double d, string t, size_t u){return self->pret<string,size_t>(d, t, u);}, py::arg("d"), py::arg("t"), py::arg("u"))
         .def_static("divertido",[](){return Fun<double>::divertido();});
 
     py::class_<Test, std::shared_ptr<Test>>(m_, "Test")

--- a/tests/fixtures/class.i
+++ b/tests/fixtures/class.i
@@ -12,8 +12,8 @@ class Fun {
   template<T={string}>
   This dhamaal(double d, T t);
 
-  // template<T={string}, U={size_t}>
-  // This pret(double d, T t, U u);
+  template<T={string}, U={size_t}>
+  This pret(double d, T t, U u);
 };
 
 

--- a/tests/fixtures/class.i
+++ b/tests/fixtures/class.i
@@ -7,13 +7,13 @@ class FunRange {
 
 template<M={double}>
 class Fun {
-  static This divertido();
+  static This staticMethodWithThis();
 
   template<T={string}>
-  This dhamaal(double d, T t);
+  This templatedMethod(double d, T t);
 
   template<T={string}, U={size_t}>
-  This pret(double d, T t, U u);
+  This multiTemplatedMethod(double d, T t, U u);
 };
 
 


### PR DESCRIPTION
Finished up a major TODO with multiple template support extended to class methods as well.

Now we can do this in the wrapper:

```cpp
class Test {
  template<T={SO3, SO4}, D={double, float}>
  void coolLieFunc(const T& g, const D& d);
}
```