### PR TITLE
Python Operator Overloading

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -51,6 +51,17 @@ The python wrapper supports keyword arguments for functions/methods. Hence, the 
 
     - Class variables are read-write so they can be updated directly in Python.
 
+- Operator Overloading (Python only)
+    - You can overload operators just like in C++.
+
+    ```cpp
+    class Overload {
+        Overload operator*(const Overload& other) const;
+    };
+    ```
+    - Supported operators are the intersection of those supported in C++ and in Python.
+    - Operator overloading definitions have to be marked as `const` methods.
+
 - Pointer types
     - To declare a simple/raw pointer, simply add an `@` to the class name, e.g.`Pose3@`.
     - To declare a shared pointer (e.g. `gtsam::noiseModel::Base::shared_ptr`), use an asterisk (i.e. `*`). E.g. `gtsam::noiseModel::Base*` to define the wrapping for the `Base` noise model shared pointer.

--- a/gtwrap/interface_parser/classes.py
+++ b/gtwrap/interface_parser/classes.py
@@ -200,8 +200,17 @@ class Operator:
 
         self.parent = parent
 
+        # Check for valid unary operators
+        if self.is_unary and self.operator not in ('+', '-'):
+            raise ValueError("Invalid unary operator {} used for {}".format(
+                self.operator, self))
+
+        # Check that number of arguments are either 0 or 1
         assert 0 <= len(args) < 2, \
-            "Operator overload should be at most 1 argument, {} arguments provided".format(len(args))
+            "Operator overload should be at most 1 argument, " \
+                "{} arguments provided".format(len(args))
+
+        # Check to ensure arg and return type are the same.
         if len(args) == 1:
             assert args.args_list[0].ctype.typename.name == return_type.type1.typename.name, \
                 "Mixed type overloading not supported. Both arg and return type must be the same."

--- a/gtwrap/interface_parser/classes.py
+++ b/gtwrap/interface_parser/classes.py
@@ -12,7 +12,7 @@ Author: Duy Nguyen Ta, Fan Jiang, Matthew Sklar, Varun Agrawal, and Frank Dellae
 
 from typing import List, Union
 
-from pyparsing import Optional, ZeroOrMore
+from pyparsing import Optional, ZeroOrMore, Literal
 
 from .function import ArgumentList, ReturnType
 from .template import Template
@@ -174,7 +174,7 @@ class Operator:
     """
     rule = (
         ReturnType.rule("return_type")  #
-        + IDENT("name")  #
+        + Literal("operator")("name")  #
         + OPERATOR("operator")  #
         + LPAREN  #
         + ArgumentList.rule("args_list")  #
@@ -203,7 +203,7 @@ class Operator:
         assert 0 <= len(args) < 2, \
             "Operator overload should at most 1 argument, {} arguments provided".format(len(args))
         if len(args) == 1:
-            assert args.args_list[0].ctype.typename == return_type.type1.typename, \
+            assert args.args_list[0].ctype.typename.name == return_type.type1.typename.name, \
                 "Mixed type overloading not supported. Both arg and return type must be the same."
 
     def __repr__(self) -> str:
@@ -250,8 +250,9 @@ class Class:
                           ^ Property.rule ^ Operator.rule).setParseAction(
                               lambda t: Class.Members(t.asList()))
 
-        def __init__(self, members: List[Union[Constructor, Method, StaticMethod, Property,
-                                                     Operator]]):
+        def __init__(self,
+                     members: List[Union[Constructor, Method, StaticMethod,
+                                         Property, Operator]]):
             self.ctors = []
             self.methods = []
             self.static_methods = []

--- a/gtwrap/interface_parser/classes.py
+++ b/gtwrap/interface_parser/classes.py
@@ -201,7 +201,7 @@ class Operator:
         self.parent = parent
 
         assert 0 <= len(args) < 2, \
-            "Operator overload should at most 1 argument, {} arguments provided".format(len(args))
+            "Operator overload should be at most 1 argument, {} arguments provided".format(len(args))
         if len(args) == 1:
             assert args.args_list[0].ctype.typename.name == return_type.type1.typename.name, \
                 "Mixed type overloading not supported. Both arg and return type must be the same."

--- a/gtwrap/interface_parser/function.py
+++ b/gtwrap/interface_parser/function.py
@@ -38,7 +38,11 @@ class Argument:
         self.parent: Union[ArgumentList, None] = None
 
     def __repr__(self) -> str:
-        return '{} {}'.format(self.ctype.__repr__(), self.name)
+        return self.to_cpp()
+
+    def to_cpp(self) -> str:
+        """Return full C++ representation of argument."""
+        return '{} {}'.format(repr(self.ctype), self.name)
 
 
 class ArgumentList:

--- a/gtwrap/interface_parser/tokens.py
+++ b/gtwrap/interface_parser/tokens.py
@@ -10,7 +10,7 @@ All the token definitions.
 Author: Duy Nguyen Ta, Fan Jiang, Matthew Sklar, Varun Agrawal, and Frank Dellaert
 """
 
-from pyparsing import Keyword, Literal, Suppress, Word, alphanums, alphas, nums
+from pyparsing import Keyword, Literal, Suppress, Word, alphanums, alphas, nums, Or
 
 # rule for identifiers (e.g. variable names)
 IDENT = Word(alphas + '_', alphanums + '_') ^ Word(nums)
@@ -46,3 +46,48 @@ BASIS_TYPES = map(
         "float",
     ],
 )
+
+OPERATOR = Or(
+    map(
+        Literal,
+        [
+            '+',  # __add__, __pos__
+            '-',  # __sub__, __neg__
+            '*',  # __mul__
+            '/',  # __truediv__
+            '%',  # __mod__
+            '^',  # __xor__
+            '&',  # __and__
+            '|',  # __or__
+            # '~',  # __invert__
+            # '=',  # Not supported
+            '+=',  # __iadd__
+            '-=',  # __isub__
+            '*=',  # __imul__
+            '/=',  # __itruediv__
+            '%=',  # __imod__
+            '^=',  # __ixor__
+            '&=',  # __iand__
+            '|=',  # __ior__
+            '<<',  # __lshift__
+            '<<=',  # __ilshift__
+            '>>',  # __rshift__
+            '>>=',  # __irshift__
+            '==',  # __eq__
+            '!=',  # __ne__
+            '<',  # __lt__
+            '>',  # __gt__
+            '<=',  # __le__
+            '>=',  # __ge__
+            # '!',  # `not`
+            # '&&',  # `and`
+            # '||',  # `or`
+            '++',  # Not supported
+            '--',  # Not supported
+            ',',  # Not supported
+            '->*',  # Not supported
+            '->',  # Not supported
+            '()',  # Not supported
+            '[]',  # Not supported
+        ],
+    ))

--- a/gtwrap/interface_parser/tokens.py
+++ b/gtwrap/interface_parser/tokens.py
@@ -60,7 +60,6 @@ OPERATOR = Or(
             '&',  # __and__
             '|',  # __or__
             # '~',  # __invert__
-            # '=',  # Not supported
             '+=',  # __iadd__
             '-=',  # __isub__
             '*=',  # __imul__
@@ -79,15 +78,10 @@ OPERATOR = Or(
             '>',  # __gt__
             '<=',  # __le__
             '>=',  # __ge__
-            # '!',  # `not`
-            # '&&',  # `and`
-            # '||',  # `or`
-            '++',  # Not supported
-            '--',  # Not supported
-            ',',  # Not supported
-            '->*',  # Not supported
-            '->',  # Not supported
-            '()',  # Not supported
-            '[]',  # Not supported
+            # '!',  # Use `not` in python
+            # '&&',  # Use `and` in python
+            # '||',  # Use `or` in python
+            '()',  # __call__
+            '[]',  # __getitem__
         ],
     ))

--- a/gtwrap/interface_parser/type.py
+++ b/gtwrap/interface_parser/type.py
@@ -200,8 +200,8 @@ class Type:
             raise ValueError("Parse result is not a Type")
 
     def __repr__(self) -> str:
-        return "{self.typename} " \
-            "{self.is_const}{self.is_shared_ptr}{self.is_ptr}{self.is_ref}".format(
+        return "{self.is_const} {self.typename} " \
+            "{self.is_shared_ptr}{self.is_ptr}{self.is_ref}".format(
             self=self)
 
     def to_cpp(self, use_boost: bool) -> str:

--- a/gtwrap/pybind_wrapper.py
+++ b/gtwrap/pybind_wrapper.py
@@ -193,6 +193,18 @@ class PybindWrapper:
                     ))
         return res
 
+    def wrap_operators(self, operators, prefix='\n' + ' ' * 8):
+        """Wrap all the overloaded operators in the `cpp_class`."""
+        res = ""
+        template = "{prefix}.def({{0}})".format(prefix=prefix)
+        for op in operators:
+            if op.operator in ('+', '-') and op.is_unary:
+                res += template.format("{0}py::self".format(op.operator))
+            else:
+                res += template.format("py::self {0} py::self".format(
+                    op.operator))
+        return res
+
     def wrap_instantiated_class(self, instantiated_class):
         """Wrap the class."""
         module_var = self._gen_module_var(instantiated_class.namespaces())
@@ -205,7 +217,8 @@ class PybindWrapper:
             '{wrapped_ctors}'
             '{wrapped_methods}'
             '{wrapped_static_methods}'
-            '{wrapped_properties};\n'.format(
+            '{wrapped_properties}'
+            '{wrapped_operators};\n'.format(
                 shared_ptr_type=('boost' if self.use_boost else 'std'),
                 cpp_class=cpp_class,
                 class_name=instantiated_class.name,
@@ -219,6 +232,7 @@ class PybindWrapper:
                     instantiated_class.static_methods, cpp_class),
                 wrapped_properties=self.wrap_properties(
                     instantiated_class.properties, cpp_class),
+                wrapped_operators=self.wrap_operators(instantiated_class.operators)
             ))
 
     def wrap_stl_class(self, stl_class):

--- a/gtwrap/pybind_wrapper.py
+++ b/gtwrap/pybind_wrapper.py
@@ -198,7 +198,7 @@ class PybindWrapper:
         res = ""
         template = "{prefix}.def({{0}})".format(prefix=prefix)
         for op in operators:
-            if op.operator in ('+', '-') and op.is_unary:
+            if op.is_unary:
                 res += template.format("{0}py::self".format(op.operator))
             else:
                 res += template.format("py::self {0} py::self".format(

--- a/gtwrap/template_instantiator.py
+++ b/gtwrap/template_instantiator.py
@@ -206,7 +206,7 @@ class InstantiatedMethod(parser.Method):
     """
     We can only instantiate template methods with a single template parameter.
     """
-    def __init__(self, original, instantiations: List[parser.Typename]=''):
+    def __init__(self, original, instantiations: List[parser.Typename] = ''):
         self.original = original
         self.instantiations = instantiations
         self.template = ''
@@ -292,11 +292,15 @@ class InstantiatedClass(parser.Class):
         # This will allow the `This` keyword to be used in both templated and non-templated classes.
         typenames = self.original.template.typenames if self.original.template else []
 
-        # Instantiate the constructors, static methods, properties
-        # and instance methods, respectively.
+        # Instantiate the constructors, static methods, properties, respectively.
         self.ctors = self.instantiate_ctors(typenames)
         self.static_methods = self.instantiate_static_methods(typenames)
         self.properties = self.instantiate_properties(typenames)
+
+        # Instantiate all operator overloads
+        self.operators = self.instantiate_operators(typenames)
+
+        # Instantiate all instance methods
         instantiated_methods = \
             self.instantiate_class_templates_in_methods(typenames)
 
@@ -323,6 +327,7 @@ class InstantiatedClass(parser.Class):
             self.methods,
             self.static_methods,
             self.properties,
+            self.operators,
             parent=self.parent,
         )
 
@@ -333,10 +338,11 @@ class InstantiatedClass(parser.Class):
                name=self.name,
                cpp_class=self.cpp_class(),
                parent_class=self.parent,
-               ctors="\n".join([ctor.__repr__() for ctor in self.ctors]),
-               methods="\n".join([m.__repr__() for m in self.methods]),
-               static_methods="\n".join([m.__repr__()
+               ctors="\n".join([repr(ctor) for ctor in self.ctors]),
+               methods="\n".join([repr(m) for m in self.methods]),
+               static_methods="\n".join([repr(m)
                                          for m in self.static_methods]),
+               operators="\n".join([repr(op) for op in self.operators])
             )
 
     def instantiate_ctors(self, typenames):
@@ -434,6 +440,39 @@ class InstantiatedClass(parser.Class):
                     parent=self,
                 ))
         return class_instantiated_methods
+
+    def instantiate_operators(self, typenames):
+        """
+        Instantiate the class-level template in the operator overload.
+
+        Args:
+            typenames: List of template types to instantiate.
+
+        Return: List of methods instantiated with provided template args on the class.
+        """
+        instantiated_operators = []
+        for operator in self.original.operators:
+            instantiated_args = instantiate_args_list(
+                operator.args.args_list,
+                typenames,
+                self.instantiations,
+                self.cpp_typename(),
+            )
+            instantiated_operators.append(
+                parser.Operator(
+                    name=operator.name,
+                    operator=operator.operator,
+                    return_type=instantiate_return_type(
+                        operator.return_type,
+                        typenames,
+                        self.instantiations,
+                        self.cpp_typename(),
+                    ),
+                    args=parser.ArgumentList(instantiated_args),
+                    is_const=operator.is_const,
+                    parent=self,
+                ))
+        return instantiated_operators
 
     def instantiate_properties(self, typenames):
         """

--- a/templates/pybind_wrapper.tpl.example
+++ b/templates/pybind_wrapper.tpl.example
@@ -3,6 +3,7 @@
 #include <pybind11/eigen.h>
 #include <pybind11/stl_bind.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
 #include "gtsam/base/serialization.h"
 #include "gtsam/nonlinear/utilities.h"  // for RedirectCout.
 

--- a/tests/expected/python/class_pybind.cpp
+++ b/tests/expected/python/class_pybind.cpp
@@ -3,6 +3,7 @@
 #include <pybind11/eigen.h>
 #include <pybind11/stl_bind.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
 #include "gtsam/nonlinear/utilities.h"  // for RedirectCout.
 
 #include "folder/path/to/Test.h"

--- a/tests/expected/python/functions_pybind.cpp
+++ b/tests/expected/python/functions_pybind.cpp
@@ -3,6 +3,7 @@
 #include <pybind11/eigen.h>
 #include <pybind11/stl_bind.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
 #include "gtsam/nonlinear/utilities.h"  // for RedirectCout.
 
 

--- a/tests/expected/python/geometry_pybind.cpp
+++ b/tests/expected/python/geometry_pybind.cpp
@@ -3,6 +3,7 @@
 #include <pybind11/eigen.h>
 #include <pybind11/stl_bind.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
 #include "gtsam/nonlinear/utilities.h"  // for RedirectCout.
 
 #include "gtsam/geometry/Point2.h"

--- a/tests/expected/python/inheritance_pybind.cpp
+++ b/tests/expected/python/inheritance_pybind.cpp
@@ -3,6 +3,7 @@
 #include <pybind11/eigen.h>
 #include <pybind11/stl_bind.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
 #include "gtsam/nonlinear/utilities.h"  // for RedirectCout.
 
 

--- a/tests/expected/python/namespaces_pybind.cpp
+++ b/tests/expected/python/namespaces_pybind.cpp
@@ -3,6 +3,7 @@
 #include <pybind11/eigen.h>
 #include <pybind11/stl_bind.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
 #include "gtsam/nonlinear/utilities.h"  // for RedirectCout.
 
 #include "path/to/ns1.h"

--- a/tests/expected/python/operator_pybind.cpp
+++ b/tests/expected/python/operator_pybind.cpp
@@ -6,6 +6,7 @@
 #include <pybind11/operators.h>
 #include "gtsam/nonlinear/utilities.h"  // for RedirectCout.
 
+#include "gtsam/geometry/Pose3.h"
 
 #include "wrap/serialization.h"
 #include <boost/serialization/export.hpp>
@@ -21,9 +22,11 @@ namespace py = pybind11;
 PYBIND11_MODULE(operator_py, m_) {
     m_.doc() = "pybind11 wrapper of operator_py";
 
+    pybind11::module m_gtsam = m_.def_submodule("gtsam", "gtsam submodule");
 
-    py::class_<Pose3, std::shared_ptr<Pose3>>(m_, "Pose3")
+    py::class_<gtsam::Pose3, std::shared_ptr<gtsam::Pose3>>(m_gtsam, "Pose3")
         .def(py::init<>())
+        .def(py::init<gtsam::Rot3, gtsam::Point3>(), py::arg("R"), py::arg("t"))
         .def(py::self * py::self);
 
 

--- a/tests/expected/python/operator_pybind.cpp
+++ b/tests/expected/python/operator_pybind.cpp
@@ -1,0 +1,33 @@
+
+
+#include <pybind11/eigen.h>
+#include <pybind11/stl_bind.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include "gtsam/nonlinear/utilities.h"  // for RedirectCout.
+
+
+#include "wrap/serialization.h"
+#include <boost/serialization/export.hpp>
+
+
+
+
+
+using namespace std;
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(operator_py, m_) {
+    m_.doc() = "pybind11 wrapper of operator_py";
+
+
+    py::class_<Pose3, std::shared_ptr<Pose3>>(m_, "Pose3")
+        .def(py::init<>())
+        .def(py::self * py::self);
+
+
+#include "python/specializations.h"
+
+}
+

--- a/tests/expected/python/special_cases_pybind.cpp
+++ b/tests/expected/python/special_cases_pybind.cpp
@@ -3,6 +3,7 @@
 #include <pybind11/eigen.h>
 #include <pybind11/stl_bind.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
 #include "gtsam/nonlinear/utilities.h"  // for RedirectCout.
 
 #include "gtsam/geometry/Cal3Bundler.h"

--- a/tests/fixtures/operator.i
+++ b/tests/fixtures/operator.i
@@ -1,4 +1,10 @@
+namespace gtsam {
+
+#include <gtsam/geometry/Pose3.h>
 class Pose3 {
-    Pose3();
-    Pose3 operator*(const Pose3& v) const;
+  Pose3();
+  Pose3(gtsam::Rot3 R, gtsam::Point3 t);
+
+  gtsam::Pose3 operator*(gtsam::Pose3 other) const;
 };
+}

--- a/tests/fixtures/operator.i
+++ b/tests/fixtures/operator.i
@@ -1,0 +1,4 @@
+class Pose3 {
+    Pose3();
+    Pose3 operator*(const Pose3& v) const;
+};

--- a/tests/pybind_wrapper.tpl
+++ b/tests/pybind_wrapper.tpl
@@ -3,6 +3,7 @@
 #include <pybind11/eigen.h>
 #include <pybind11/stl_bind.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
 #include "gtsam/nonlinear/utilities.h"  // for RedirectCout.
 
 {includes}

--- a/tests/test_interface_parser.py
+++ b/tests/test_interface_parser.py
@@ -21,7 +21,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from gtwrap.interface_parser import (ArgumentList, Class, Constructor,
                                      ForwardDeclaration, GlobalFunction,
                                      Include, Method, Module, Namespace,
-                                     ReturnType, StaticMethod, Type,
+                                     Operator, ReturnType, StaticMethod, Type,
                                      TypedefTemplateInstantiation, Typename)
 
 
@@ -156,6 +156,30 @@ class TestInterfaceParser(unittest.TestCase):
             "f(const int x, const Class& c, Class* t);")[0]
         self.assertEqual("f", ret.name)
         self.assertEqual(3, len(ret.args))
+
+    def test_operator_overload(self):
+        """Test for operator overloading."""
+        # Unary operator
+        wrap_string = "gtsam::Vector2 operator-() const;"
+        ret = Operator.rule.parseString(wrap_string)[0]
+        self.assertEqual("operator", ret.name)
+        self.assertEqual("-", ret.operator)
+        self.assertEqual("Vector2", ret.return_type.typename.name)
+        self.assertEqual("gtsam::Vector2", ret.return_type.typename.to_cpp())
+        self.assertTrue(len(ret.args) == 0)
+        self.assertTrue(ret.is_unary)
+
+        # Binary operator
+        wrap_string = "gtsam::Vector2 operator*(const gtsam::Vector2 &v) const;"
+        ret = Operator.rule.parseString(wrap_string)[0]
+        self.assertEqual("operator", ret.name)
+        self.assertEqual("*", ret.operator)
+        self.assertEqual("Vector2", ret.return_type.typename.name)
+        self.assertEqual("gtsam::Vector2", ret.return_type.typename.to_cpp())
+        self.assertTrue(len(ret.args) == 1)
+        self.assertEqual("const gtsam::Vector2 &",
+                         repr(ret.args.args_list[0].ctype))
+        self.assertTrue(not ret.is_unary)
 
     def test_typedef_template_instantiation(self):
         """Test for typedef'd instantiation of a template."""

--- a/tests/test_interface_parser.py
+++ b/tests/test_interface_parser.py
@@ -164,8 +164,9 @@ class TestInterfaceParser(unittest.TestCase):
         ret = Operator.rule.parseString(wrap_string)[0]
         self.assertEqual("operator", ret.name)
         self.assertEqual("-", ret.operator)
-        self.assertEqual("Vector2", ret.return_type.typename.name)
-        self.assertEqual("gtsam::Vector2", ret.return_type.typename.to_cpp())
+        self.assertEqual("Vector2", ret.return_type.type1.typename.name)
+        self.assertEqual("gtsam::Vector2",
+                         ret.return_type.type1.typename.to_cpp())
         self.assertTrue(len(ret.args) == 0)
         self.assertTrue(ret.is_unary)
 
@@ -174,8 +175,9 @@ class TestInterfaceParser(unittest.TestCase):
         ret = Operator.rule.parseString(wrap_string)[0]
         self.assertEqual("operator", ret.name)
         self.assertEqual("*", ret.operator)
-        self.assertEqual("Vector2", ret.return_type.typename.name)
-        self.assertEqual("gtsam::Vector2", ret.return_type.typename.to_cpp())
+        self.assertEqual("Vector2", ret.return_type.type1.typename.name)
+        self.assertEqual("gtsam::Vector2",
+                         ret.return_type.type1.typename.to_cpp())
         self.assertTrue(len(ret.args) == 1)
         self.assertEqual("const gtsam::Vector2 &",
                          repr(ret.args.args_list[0].ctype))

--- a/tests/test_pybind_wrapper.py
+++ b/tests/test_pybind_wrapper.py
@@ -134,6 +134,18 @@ class TestWrap(unittest.TestCase):
 
         self.compare_and_diff('namespaces_pybind.cpp', output)
 
+    def test_operator_overload(self):
+        """
+        Tests for operator overloading.
+        """
+        with open(osp.join(self.INTERFACE_DIR, 'operator.i'), 'r') as f:
+            content = f.read()
+
+        output = self.wrap_content(content, 'operator_py',
+                                   self.PYTHON_ACTUAL_DIR)
+
+        self.compare_and_diff('operator_pybind.cpp', output)
+
     def test_special_cases(self):
         """
         Tests for some unique, non-trivial features.


### PR DESCRIPTION
With this PR, the wrapper will support operator overloading for a myriad of operations in Python.

`+` and `-` are the only supported unary operators for now though we can add more quite easily.


I updated the https://github.com/borglab/wrap-project-python example with the `+` operator such that it returns a new instance with the `name` fields concatenated.

```cpp
Greeting operator+(const Greeting& other) const {
  return Greeting(this->name + " " + other.name);
}
```

Using the below script:

```py
import wrap_example

firstname = wrap_example.Greeting("Varun")
lastname = wrap_example.Greeting("Agrawal")

fullname = firstname + lastname
fullname.sayHello()

reverse_fullname = lastname + firstname
reverse_fullname.sayHello()
```

I get the amazing output:

```sh
Hello from C++! Varun Agrawal
Hello from C++! Agrawal Varun
```