### PR TITLE
Additional Operator Overloading

### DIFF
--- a/gtwrap/interface_parser/classes.py
+++ b/gtwrap/interface_parser/classes.py
@@ -211,7 +211,7 @@ class Operator:
                 "{} arguments provided".format(len(args))
 
         # Check to ensure arg and return type are the same.
-        if len(args) == 1:
+        if len(args) == 1 and self.operator not in ("()", "[]"):
             assert args.args_list[0].ctype.typename.name == return_type.type1.typename.name, \
                 "Mixed type overloading not supported. Both arg and return type must be the same."
 

--- a/tests/expected/python/operator_pybind.cpp
+++ b/tests/expected/python/operator_pybind.cpp
@@ -29,6 +29,10 @@ PYBIND11_MODULE(operator_py, m_) {
         .def(py::init<gtsam::Rot3, gtsam::Point3>(), py::arg("R"), py::arg("t"))
         .def(py::self * py::self);
 
+    py::class_<gtsam::Container<gtsam::Matrix>, std::shared_ptr<gtsam::Container<gtsam::Matrix>>>(m_gtsam, "ContainerMatrix")
+        .def("__call__", &gtsam::Container<gtsam::Matrix>::operator())
+        .def("__getitem__", &gtsam::Container<gtsam::Matrix>::operator[]);
+
 
 #include "python/specializations.h"
 

--- a/tests/fixtures/operator.i
+++ b/tests/fixtures/operator.i
@@ -7,4 +7,10 @@ class Pose3 {
 
   gtsam::Pose3 operator*(gtsam::Pose3 other) const;
 };
+
+template<T = {Matrix}>
+class Container {
+  gtsam::JacobianFactor operator()(const T& m) const;
+  T operator[](size_t idx) const;
+};
 }


### PR DESCRIPTION
Added support for `()` and `[]` operators.

We can have a C++ class

```cpp
class Greeting {
  std::vector<std::string> names_;

 public:
  std::string operator()(const std::string& name) const {
    return "Function invoked by " + name;
  }

  void insertName(const std::string& name) { names_.push_back(name); }

  std::string operator[](size_t idx) const { return this->names_[idx]; }
};
```

be wrapped

```cpp
class Greeting {
  Greeting();
  string operator()(const string& name) const;

  void insertName(const string& name);
  string operator[](size_t idx) const;
};
```

and then we can invoke it like this

```py
import numpy as np
import gtsam_example

g = gtsam_example.Greeting()
print(g("GTSAM"))

g.insertName("Varun")
g.insertName("Frank")
g.insertName("Fan")

print(g[1])
print(g[2])
```

to get the output as

```sh
Function invoked by GTSAM
Frank
Fan
```