### PR TITLE
Allow templates as paramters to templates

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -89,7 +89,7 @@ The python wrapper supports keyword arguments for functions/methods. Hence, the 
     - Can have multiple functions of the same name in different namespaces.
     - Functions can be templated and have multiple template arguments, e.g.
         ```cpp
-        template<T, >
+        template<T, R, S>
         ```
 
 - Using classes defined in other modules
@@ -110,7 +110,7 @@ The python wrapper supports keyword arguments for functions/methods. Hence, the 
         virtual boost::shared_ptr<CLASS_NAME> clone() const;
         ```
 
-- Class Templates
+- Templates
     - Basic templates are supported either with an explicit list of types to instantiate,
       e.g.
 
@@ -124,17 +124,30 @@ The python wrapper supports keyword arguments for functions/methods. Hence, the 
       template<T, U> class Class2 { ... };
       typedef Class2<Type1, Type2> MyInstantiatedClass;
       ```
-
+    - Templates can also be defined for methods, properties and static methods.
     - In the class definition, appearances of the template argument(s) will be replaced with their
       instantiated types, e.g. `void setValue(const T& value);`.
     - To refer to the instantiation of the template class itself, use `This`, i.e. `static This Create();`.
     - To create new instantiations in other modules, you must copy-and-paste the whole class definition
       into the new module, but use only your new instantiation types.
-    - When forward-declaring template instantiations, use the generated/typedefed name, e.g.
+    - When forward-declaring template instantiations, use the generated/typedef'd name, e.g.
 
       ```cpp
       class gtsam::Class1Pose2;
       class gtsam::MyInstantiatedClass;
+      ```
+    - Template arguments can be templates themselves, e.g.
+
+      ```cpp
+      // Typedef'd PinholeCamera
+      template<CALIBRATION>
+      class PinholeCamera { ... };
+      typedef gtsam::PinholeCamera<gtsam::Cal3_S2> PinholeCameraCal3_S2;
+
+      template<CAMERA>
+      class SfmFactor { ... };
+      // This is valid.
+      typedef gtsam::SfmFactor<gtsam::PinholeCamera<gtsam::Cal3_S2>> BasicSfmFactor;
       ```
 
 - `Boost.serialization` within the wrapper:

--- a/gtwrap/interface_parser/classes.py
+++ b/gtwrap/interface_parser/classes.py
@@ -18,7 +18,7 @@ from .function import ArgumentList, ReturnType
 from .template import Template
 from .tokens import (CLASS, COLON, CONST, IDENT, LBRACE, LPAREN, RBRACE,
                      RPAREN, SEMI_COLON, STATIC, VIRTUAL, OPERATOR)
-from .type import Type, Typename
+from .type import TemplatedType, Type, Typename
 
 
 class Method:
@@ -148,13 +148,13 @@ class Property:
     ````
     """
     rule = (
-        Type.rule("ctype")  #
+        (Type.rule ^ TemplatedType.rule)("ctype")  #
         + IDENT("name")  #
         + SEMI_COLON  #
     ).setParseAction(lambda t: Property(t.ctype, t.name))
 
     def __init__(self, ctype: Type, name: str, parent=''):
-        self.ctype = ctype
+        self.ctype = ctype[0]  # ParseResult is a list
         self.name = name
         self.parent = parent
 

--- a/gtwrap/interface_parser/function.py
+++ b/gtwrap/interface_parser/function.py
@@ -100,12 +100,13 @@ class ReturnType:
         + Type.rule("type2")  #
         + ROPBRACK  #
     )
-    rule = (_pair ^ Type.rule("type1")
-            ^ TemplatedType.rule("type1")).setParseAction(  # BR
+    rule = (_pair ^
+            (Type.rule ^ TemplatedType.rule)("type1")).setParseAction(  # BR
                 lambda t: ReturnType(t.type1, t.type2))
 
-    def __init__(self, type1: Type, type2: Type):
-        self.type1 = type1
+    def __init__(self, type1: Union[Type, TemplatedType], type2: Type):
+        # If a TemplatedType, the return is a ParseResults, so we extract out the type.
+        self.type1 = type1[0] if isinstance(type1, ParseResults) else type1
         self.type2 = type2
         # The parent object which contains the return type
         # E.g. Method, StaticMethod, Template, Constructor, GlobalFunction

--- a/gtwrap/interface_parser/template.py
+++ b/gtwrap/interface_parser/template.py
@@ -10,7 +10,6 @@ Classes and rules for parsing C++ templates and typedefs for template instantiat
 Author: Duy Nguyen Ta, Fan Jiang, Matthew Sklar, Varun Agrawal, and Frank Dellaert
 """
 
-from re import template
 from typing import List
 
 from pyparsing import Optional, ParseResults, delimitedList
@@ -39,7 +38,8 @@ class Template:
             + Optional(  #
                 EQUAL  #
                 + LBRACE  #
-                + ((delimitedList(TemplatedType.rule ^ Typename.rule)("instantiations")))  #
+                + ((delimitedList(TemplatedType.rule ^ Typename.rule)
+                    ("instantiations")))  #
                 + RBRACE  #
             )).setParseAction(lambda t: Template.TypenameAndInstantiations(
                 t.typename, t.instantiations))
@@ -50,9 +50,9 @@ class Template:
             self.instantiations = []
             if instantiations:
                 for inst in instantiations:
-                    x = inst.typename if isinstance(inst, TemplatedType) else inst
+                    x = inst.typename if isinstance(inst,
+                                                    TemplatedType) else inst
                     self.instantiations.append(x)
-                        
 
     rule = (  # BR
         TEMPLATE  #
@@ -83,11 +83,19 @@ class TypedefTemplateInstantiation:
     typedef SuperComplexName<Arg1, Arg2, Arg3> EasierName;
     ```
     """
-    rule = (TYPEDEF + TemplatedType.rule("templated_type") + IDENT("new_name") +
+    rule = (TYPEDEF + TemplatedType.rule("templated_type") +
+            IDENT("new_name") +
             SEMI_COLON).setParseAction(lambda t: TypedefTemplateInstantiation(
-                t.templated_type, t.new_name))
+                t.templated_type[0], t.new_name))
 
-    def __init__(self, templated_type: TemplatedType, new_name: str, parent: str = ''):
+    def __init__(self,
+                 templated_type: TemplatedType,
+                 new_name: str,
+                 parent: str = ''):
         self.typename = templated_type.typename
         self.new_name = new_name
         self.parent = parent
+
+    def __repr__(self):
+        return "Typedef: {new_name} = {typename}".format(
+            new_name=self.new_name, typename=self.typename)

--- a/tests/expected/matlab/+gtsam/PinholeCameraCal3Bundler.m
+++ b/tests/expected/matlab/+gtsam/PinholeCameraCal3Bundler.m
@@ -9,7 +9,7 @@ classdef PinholeCameraCal3Bundler < handle
     function obj = PinholeCameraCal3Bundler(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        special_cases_wrapper(3, my_ptr);
+        special_cases_wrapper(5, my_ptr);
       else
         error('Arguments do not match any overload of gtsam.PinholeCameraCal3Bundler constructor');
       end
@@ -17,7 +17,7 @@ classdef PinholeCameraCal3Bundler < handle
     end
 
     function delete(obj)
-      special_cases_wrapper(4, obj.ptr_gtsamPinholeCameraCal3Bundler);
+      special_cases_wrapper(6, obj.ptr_gtsamPinholeCameraCal3Bundler);
     end
 
     function display(obj), obj.print(''); end

--- a/tests/expected/matlab/special_cases_wrapper.cpp
+++ b/tests/expected/matlab/special_cases_wrapper.cpp
@@ -25,6 +25,7 @@ typedef MyFactor<gtsam::Pose2, gtsam::Matrix> MyFactorPosePoint2;
 typedef MyTemplate<gtsam::Point2> MyTemplatePoint2;
 typedef MyTemplate<gtsam::Matrix> MyTemplateMatrix;
 typedef gtsam::PinholeCamera<gtsam::Cal3Bundler> PinholeCameraCal3Bundler;
+typedef gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3> GeneralSFMFactorCal3Bundler;
 
 BOOST_CLASS_EXPORT_GUID(gtsam::Point2, "gtsamPoint2");
 BOOST_CLASS_EXPORT_GUID(gtsam::Point3, "gtsamPoint3");
@@ -71,8 +72,12 @@ typedef std::set<boost::shared_ptr<ClassD>*> Collector_ClassD;
 static Collector_ClassD collector_ClassD;
 typedef std::set<boost::shared_ptr<gtsam::NonlinearFactorGraph>*> Collector_gtsamNonlinearFactorGraph;
 static Collector_gtsamNonlinearFactorGraph collector_gtsamNonlinearFactorGraph;
+typedef std::set<boost::shared_ptr<gtsam::SfmTrack>*> Collector_gtsamSfmTrack;
+static Collector_gtsamSfmTrack collector_gtsamSfmTrack;
 typedef std::set<boost::shared_ptr<PinholeCameraCal3Bundler>*> Collector_gtsamPinholeCameraCal3Bundler;
 static Collector_gtsamPinholeCameraCal3Bundler collector_gtsamPinholeCameraCal3Bundler;
+typedef std::set<boost::shared_ptr<GeneralSFMFactorCal3Bundler>*> Collector_gtsamGeneralSFMFactorCal3Bundler;
+static Collector_gtsamGeneralSFMFactorCal3Bundler collector_gtsamGeneralSFMFactorCal3Bundler;
 
 void _deleteAllObjects()
 {
@@ -206,10 +211,22 @@ void _deleteAllObjects()
     collector_gtsamNonlinearFactorGraph.erase(iter++);
     anyDeleted = true;
   } }
+  { for(Collector_gtsamSfmTrack::iterator iter = collector_gtsamSfmTrack.begin();
+      iter != collector_gtsamSfmTrack.end(); ) {
+    delete *iter;
+    collector_gtsamSfmTrack.erase(iter++);
+    anyDeleted = true;
+  } }
   { for(Collector_gtsamPinholeCameraCal3Bundler::iterator iter = collector_gtsamPinholeCameraCal3Bundler.begin();
       iter != collector_gtsamPinholeCameraCal3Bundler.end(); ) {
     delete *iter;
     collector_gtsamPinholeCameraCal3Bundler.erase(iter++);
+    anyDeleted = true;
+  } }
+  { for(Collector_gtsamGeneralSFMFactorCal3Bundler::iterator iter = collector_gtsamGeneralSFMFactorCal3Bundler.begin();
+      iter != collector_gtsamGeneralSFMFactorCal3Bundler.end(); ) {
+    delete *iter;
+    collector_gtsamGeneralSFMFactorCal3Bundler.erase(iter++);
     anyDeleted = true;
   } }
   if(anyDeleted)
@@ -282,7 +299,29 @@ void gtsamNonlinearFactorGraph_addPrior_2(int nargout, mxArray *out[], int nargi
   obj->addPrior<gtsam::PinholeCamera<gtsam::Cal3Bundler>>(key,prior,noiseModel);
 }
 
-void gtsamPinholeCameraCal3Bundler_collectorInsertAndMakeBase_3(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void gtsamSfmTrack_collectorInsertAndMakeBase_3(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  mexAtExit(&_deleteAllObjects);
+  typedef boost::shared_ptr<gtsam::SfmTrack> Shared;
+
+  Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
+  collector_gtsamSfmTrack.insert(self);
+}
+
+void gtsamSfmTrack_deconstructor_4(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  typedef boost::shared_ptr<gtsam::SfmTrack> Shared;
+  checkArguments("delete_gtsamSfmTrack",nargout,nargin,1);
+  Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
+  Collector_gtsamSfmTrack::iterator item;
+  item = collector_gtsamSfmTrack.find(self);
+  if(item != collector_gtsamSfmTrack.end()) {
+    delete self;
+    collector_gtsamSfmTrack.erase(item);
+  }
+}
+
+void gtsamPinholeCameraCal3Bundler_collectorInsertAndMakeBase_5(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<gtsam::PinholeCamera<gtsam::Cal3Bundler>> Shared;
@@ -291,7 +330,7 @@ void gtsamPinholeCameraCal3Bundler_collectorInsertAndMakeBase_3(int nargout, mxA
   collector_gtsamPinholeCameraCal3Bundler.insert(self);
 }
 
-void gtsamPinholeCameraCal3Bundler_deconstructor_4(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void gtsamPinholeCameraCal3Bundler_deconstructor_6(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<gtsam::PinholeCamera<gtsam::Cal3Bundler>> Shared;
   checkArguments("delete_gtsamPinholeCameraCal3Bundler",nargout,nargin,1);
@@ -301,6 +340,28 @@ void gtsamPinholeCameraCal3Bundler_deconstructor_4(int nargout, mxArray *out[], 
   if(item != collector_gtsamPinholeCameraCal3Bundler.end()) {
     delete self;
     collector_gtsamPinholeCameraCal3Bundler.erase(item);
+  }
+}
+
+void gtsamGeneralSFMFactorCal3Bundler_collectorInsertAndMakeBase_7(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  mexAtExit(&_deleteAllObjects);
+  typedef boost::shared_ptr<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>> Shared;
+
+  Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
+  collector_gtsamGeneralSFMFactorCal3Bundler.insert(self);
+}
+
+void gtsamGeneralSFMFactorCal3Bundler_deconstructor_8(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  typedef boost::shared_ptr<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>> Shared;
+  checkArguments("delete_gtsamGeneralSFMFactorCal3Bundler",nargout,nargin,1);
+  Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
+  Collector_gtsamGeneralSFMFactorCal3Bundler::iterator item;
+  item = collector_gtsamGeneralSFMFactorCal3Bundler.find(self);
+  if(item != collector_gtsamGeneralSFMFactorCal3Bundler.end()) {
+    delete self;
+    collector_gtsamGeneralSFMFactorCal3Bundler.erase(item);
   }
 }
 
@@ -326,10 +387,22 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       gtsamNonlinearFactorGraph_addPrior_2(nargout, out, nargin-1, in+1);
       break;
     case 3:
-      gtsamPinholeCameraCal3Bundler_collectorInsertAndMakeBase_3(nargout, out, nargin-1, in+1);
+      gtsamSfmTrack_collectorInsertAndMakeBase_3(nargout, out, nargin-1, in+1);
       break;
     case 4:
-      gtsamPinholeCameraCal3Bundler_deconstructor_4(nargout, out, nargin-1, in+1);
+      gtsamSfmTrack_deconstructor_4(nargout, out, nargin-1, in+1);
+      break;
+    case 5:
+      gtsamPinholeCameraCal3Bundler_collectorInsertAndMakeBase_5(nargout, out, nargin-1, in+1);
+      break;
+    case 6:
+      gtsamPinholeCameraCal3Bundler_deconstructor_6(nargout, out, nargin-1, in+1);
+      break;
+    case 7:
+      gtsamGeneralSFMFactorCal3Bundler_collectorInsertAndMakeBase_7(nargout, out, nargin-1, in+1);
+      break;
+    case 8:
+      gtsamGeneralSFMFactorCal3Bundler_deconstructor_8(nargout, out, nargin-1, in+1);
       break;
     }
   } catch(const std::exception& e) {

--- a/tests/expected/python/special_cases_pybind.cpp
+++ b/tests/expected/python/special_cases_pybind.cpp
@@ -27,7 +27,12 @@ PYBIND11_MODULE(special_cases_py, m_) {
     py::class_<gtsam::NonlinearFactorGraph, std::shared_ptr<gtsam::NonlinearFactorGraph>>(m_gtsam, "NonlinearFactorGraph")
         .def("addPriorPinholeCameraCal3Bundler",[](gtsam::NonlinearFactorGraph* self, size_t key, const gtsam::PinholeCamera<gtsam::Cal3Bundler>& prior, const std::shared_ptr<gtsam::noiseModel::Base> noiseModel){ self->addPrior<gtsam::PinholeCamera<gtsam::Cal3Bundler>>(key, prior, noiseModel);}, py::arg("key"), py::arg("prior"), py::arg("noiseModel"));
 
+    py::class_<gtsam::SfmTrack, std::shared_ptr<gtsam::SfmTrack>>(m_gtsam, "SfmTrack")
+        .def_readwrite("measurements", &gtsam::SfmTrack::measurements);
+
     py::class_<gtsam::PinholeCamera<gtsam::Cal3Bundler>, std::shared_ptr<gtsam::PinholeCamera<gtsam::Cal3Bundler>>>(m_gtsam, "PinholeCameraCal3Bundler");
+
+    py::class_<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>, std::shared_ptr<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>>>(m_gtsam, "GeneralSFMFactorCal3Bundler");
 
 
 #include "python/specializations.h"

--- a/tests/fixtures/special_cases.i
+++ b/tests/fixtures/special_cases.i
@@ -10,8 +10,19 @@ class PinholeCamera {};
 typedef gtsam::PinholeCamera<gtsam::Cal3Bundler> PinholeCameraCal3Bundler;
 
 class NonlinearFactorGraph {
-  template<T = {gtsam::PinholeCamera<gtsam::Cal3Bundler>}>
-  void addPrior(size_t key, const T& prior, const gtsam::noiseModel::Base* noiseModel);
+  template <T = {gtsam::PinholeCamera<gtsam::Cal3Bundler>}>
+  void addPrior(size_t key, const T& prior,
+                const gtsam::noiseModel::Base* noiseModel);
 };
 
-}
+// Typedef with template as template arg.
+template<CALIBRATION, POINT>
+class GeneralSFMFactor {};
+typedef gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3> GeneralSFMFactorCal3Bundler;
+
+// Template as template arg for class property.
+class SfmTrack {
+  std::vector<std::pair<size_t, gtsam::Point2>> measurements;
+};
+
+}  // namespace gtsam


### PR DESCRIPTION
With this PR we should be able to now do

```cpp
typedef gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3> GeneralSFMFactorCal3Bundler;
```

i.e. pass a template as a template parameter.