### PR TITLE
Better python printing

### DIFF
--- a/gtwrap/pybind_wrapper.py
+++ b/gtwrap/pybind_wrapper.py
@@ -126,9 +126,12 @@ class PybindWrapper:
 
         if method.name == 'print':
             type_list = method.args.to_cpp(self.use_boost)
+            # print_, with KeyFormatter
             if len(type_list) == 2 \
                     and 'string' in type_list[0] \
                     and 'gtsam::KeyFormatter' in type_list[1]:
+                # gtsam::KeyFormatter is a boost::function, so we need to wrap pybind's preferred
+                # std::function argument to pass into print(string, gtsam::KeyFormatter)
                 ret = '''{prefix}.def("print_",
                     []({cpp_class}* self, {stype} {sname}, {kftype} {kfname}) {{
                         py::scoped_ostream_redirect stream;
@@ -143,6 +146,7 @@ class PybindWrapper:
                     py_args_names=py_args_names,
                     suffix=suffix
                 )
+            # __repr__ does print() with default args
             ret += ('''{prefix}.def("__repr__",
                     [](const {cpp_class} &a) {{
                         gtsam::RedirectCout redirect;

--- a/gtwrap/pybind_wrapper.py
+++ b/gtwrap/pybind_wrapper.py
@@ -143,28 +143,17 @@ class PybindWrapper:
                     py_args_names=py_args_names,
                     suffix=suffix
                 )
-            if len(type_list) > 0 and type_list[0].strip() == 'string':
-                ret += '''{prefix}.def("__repr__",
+            ret += ('''{prefix}.def("__repr__",
                     [](const {cpp_class} &a) {{
                         gtsam::RedirectCout redirect;
-                        a.print("");
+                        a.print({print_args});
                         return redirect.str();
-                    }}){suffix}'''.format(
-                    prefix=prefix,
-                    cpp_class=cpp_class,
-                    suffix=suffix,
-                )
-            else:
-                ret += '''{prefix}.def("__repr__",
-                    [](const {cpp_class} &a) {{
-                        gtsam::RedirectCout redirect;
-                        a.print();
-                        return redirect.str();
-                    }}){suffix}'''.format(
-                    prefix=prefix,
-                    cpp_class=cpp_class,
-                    suffix=suffix,
-                )
+                    }}){suffix}''').format(
+                prefix=prefix,
+                cpp_class=cpp_class,
+                print_args='""' if len(type_list) > 0 and type_list[0].strip() == 'string' else '',
+                suffix=suffix,
+            )
         return ret
 
     def wrap_methods(self, methods, cpp_class, prefix='\n' + ' ' * 8, suffix=''):


### PR DESCRIPTION
Since `gtsam::KeyFormatter` is a `boost::function` and pybind11 does not do `boost::functions`, some modification is needed in order to be able to use the `print_(string s, KeyFormatter)` function.  Specifically, the `print_` function is altered so that the python interface accepts a `std::function` and then calls the gtsam `print` with the boost version.  So for example:

```c++
class ClassWithPrint {
  void print(const string &s,
             const gtsam::KeyFormatter &keyFormatter);
};
```
```c++
...
        .def("print_",
                    [](gtsam::ClassWithPrint* self, const string& s, const std::function<std::string(gtsam::Key)>& keyFormatter) {
                        py::scoped_ostream_redirect stream;
                        self->print(s, [&keyFormatter](gtsam::Key key){return keyFormatter(key);});
                    }, py::arg("s"), py::arg("keyFormatter"))
```

Note: `py::scoped_ostream_redirect stream;` is so that printing occurs to python sys.stdout which just generally plays nicer with python.  See [pybind docs](https://pybind11.readthedocs.io/en/stable/advanced/pycpp/utilities.html#capturing-standard-output-from-ostream)


Also, this allows functionals for the keyformatter:
```python
def myKeyFormatter(key):
    return 'this is my key formatter {}'.format(key)
factor.print_('factor: ', myKeyFormatter)
```
outputs:
```
factor: min torque factor
  keys = { this is my key formatter 23924273508777984 }
  noise model: unit (1) 
```