### PR TITLE
Templated Base Class

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -98,6 +98,7 @@ The python wrapper supports keyword arguments for functions/methods. Hence, the 
 - Virtual inheritance
     - Specify fully-qualified base classes, i.e. `virtual class Derived : ns::Base {` where `ns` is the namespace.
     - Mark with `virtual` keyword, e.g. `virtual class Base {`, and also `virtual class Derived : ns::Base {`.
+    - Base classes can be templated, e.g. `virtual class Dog: ns::Animal<Pet> {};`. This is useful when you want to inherit from specialized classes.
     - Forward declarations must also be marked virtual, e.g. `virtual class ns::Base;` and
       also `virtual class ns::Derived;`.
     - Pure virtual (abstract) classes should list no constructors in the interface file.

--- a/gtwrap/interface_parser/classes.py
+++ b/gtwrap/interface_parser/classes.py
@@ -279,7 +279,7 @@ class Class:
                 elif isinstance(m, Operator):
                     self.operators.append(m)
 
-    _parent = COLON + Typename.rule("parent_class")
+    _parent = COLON + (TemplatedType.rule ^ Typename.rule)("parent_class")
     rule = (
         Optional(Template.rule("template"))  #
         + Optional(VIRTUAL("is_virtual"))  #
@@ -319,11 +319,16 @@ class Class:
         self.is_virtual = is_virtual
         self.name = name
         if parent_class:
+            # If it is in an iterable, extract the parent class.
             if isinstance(parent_class, Iterable):
-                self.parent_class = parent_class[0]
-            else:
-                self.parent_class = parent_class
+                parent_class = parent_class[0]
 
+            # If the base class is a TemplatedType,
+            # we want the instantiated Typename
+            if isinstance(parent_class, TemplatedType):
+                parent_class = parent_class.typename
+
+            self.parent_class = parent_class
         else:
             self.parent_class = ''
 

--- a/tests/expected/matlab/inheritance_wrapper.cpp
+++ b/tests/expected/matlab/inheritance_wrapper.cpp
@@ -50,6 +50,8 @@ typedef std::set<boost::shared_ptr<MyTemplatePoint2>*> Collector_MyTemplatePoint
 static Collector_MyTemplatePoint2 collector_MyTemplatePoint2;
 typedef std::set<boost::shared_ptr<MyTemplateMatrix>*> Collector_MyTemplateMatrix;
 static Collector_MyTemplateMatrix collector_MyTemplateMatrix;
+typedef std::set<boost::shared_ptr<ForwardKinematicsFactor>*> Collector_ForwardKinematicsFactor;
+static Collector_ForwardKinematicsFactor collector_ForwardKinematicsFactor;
 
 void _deleteAllObjects()
 {
@@ -141,6 +143,12 @@ void _deleteAllObjects()
     collector_MyTemplateMatrix.erase(iter++);
     anyDeleted = true;
   } }
+  { for(Collector_ForwardKinematicsFactor::iterator iter = collector_ForwardKinematicsFactor.begin();
+      iter != collector_ForwardKinematicsFactor.end(); ) {
+    delete *iter;
+    collector_ForwardKinematicsFactor.erase(iter++);
+    anyDeleted = true;
+  } }
   if(anyDeleted)
     cout <<
       "WARNING:  Wrap modules with variables in the workspace have been reloaded due to\n"
@@ -156,6 +164,7 @@ void _inheritance_RTTIRegister() {
     types.insert(std::make_pair(typeid(MyBase).name(), "MyBase"));
     types.insert(std::make_pair(typeid(MyTemplatePoint2).name(), "MyTemplatePoint2"));
     types.insert(std::make_pair(typeid(MyTemplateMatrix).name(), "MyTemplateMatrix"));
+    types.insert(std::make_pair(typeid(ForwardKinematicsFactor).name(), "ForwardKinematicsFactor"));
 
     mxArray *registry = mexGetVariable("global", "gtsamwrap_rttiRegistry");
     if(!registry)
@@ -555,6 +564,40 @@ void MyTemplateMatrix_Level_34(int nargout, mxArray *out[], int nargin, const mx
   out[0] = wrap_shared_ptr(boost::make_shared<MyTemplate<Matrix>>(MyTemplate<gtsam::Matrix>::Level(K)),"MyTemplateMatrix", false);
 }
 
+void Test_set_container_35(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("set_container",nargout,nargin-1,1);
+  auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
+  boost::shared_ptr<std::vector<testing::Test>> container = unwrap_shared_ptr< std::vector<testing::Test> >(in[1], "ptr_stdvectorTest");
+  obj->set_container(*container);
+}
+
+void ForwardKinematicsFactor_collectorInsertAndMakeBase_35(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  mexAtExit(&_deleteAllObjects);
+  typedef boost::shared_ptr<ForwardKinematicsFactor> Shared;
+
+  Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
+  collector_ForwardKinematicsFactor.insert(self);
+
+  typedef boost::shared_ptr<gtsam::BetweenFactor<gtsam::Pose3>> SharedBase;
+  out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
+  *reinterpret_cast<SharedBase**>(mxGetData(out[0])) = new SharedBase(*self);
+}
+
+void ForwardKinematicsFactor_deconstructor_37(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  typedef boost::shared_ptr<ForwardKinematicsFactor> Shared;
+  checkArguments("delete_ForwardKinematicsFactor",nargout,nargin,1);
+  Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
+  Collector_ForwardKinematicsFactor::iterator item;
+  item = collector_ForwardKinematicsFactor.find(self);
+  if(item != collector_ForwardKinematicsFactor.end()) {
+    delete self;
+    collector_ForwardKinematicsFactor.erase(item);
+  }
+}
+
 
 void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
@@ -671,6 +714,15 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       break;
     case 34:
       MyTemplateMatrix_Level_34(nargout, out, nargin-1, in+1);
+      break;
+    case 35:
+      Test_set_container_35(nargout, out, nargin-1, in+1);
+      break;
+    case 36:
+      ForwardKinematicsFactor_collectorInsertAndMakeBase_35(nargout, out, nargin-1, in+1);
+      break;
+    case 37:
+      ForwardKinematicsFactor_deconstructor_37(nargout, out, nargin-1, in+1);
       break;
     }
   } catch(const std::exception& e) {

--- a/tests/expected/matlab/namespaces_wrapper.cpp
+++ b/tests/expected/matlab/namespaces_wrapper.cpp
@@ -55,6 +55,8 @@ typedef std::set<boost::shared_ptr<MyTemplatePoint2>*> Collector_MyTemplatePoint
 static Collector_MyTemplatePoint2 collector_MyTemplatePoint2;
 typedef std::set<boost::shared_ptr<MyTemplateMatrix>*> Collector_MyTemplateMatrix;
 static Collector_MyTemplateMatrix collector_MyTemplateMatrix;
+typedef std::set<boost::shared_ptr<ForwardKinematicsFactor>*> Collector_ForwardKinematicsFactor;
+static Collector_ForwardKinematicsFactor collector_ForwardKinematicsFactor;
 typedef std::set<boost::shared_ptr<ns1::ClassA>*> Collector_ns1ClassA;
 static Collector_ns1ClassA collector_ns1ClassA;
 typedef std::set<boost::shared_ptr<ns1::ClassB>*> Collector_ns1ClassB;
@@ -158,6 +160,12 @@ void _deleteAllObjects()
     collector_MyTemplateMatrix.erase(iter++);
     anyDeleted = true;
   } }
+  { for(Collector_ForwardKinematicsFactor::iterator iter = collector_ForwardKinematicsFactor.begin();
+      iter != collector_ForwardKinematicsFactor.end(); ) {
+    delete *iter;
+    collector_ForwardKinematicsFactor.erase(iter++);
+    anyDeleted = true;
+  } }
   { for(Collector_ns1ClassA::iterator iter = collector_ns1ClassA.begin();
       iter != collector_ns1ClassA.end(); ) {
     delete *iter;
@@ -209,6 +217,7 @@ void _namespaces_RTTIRegister() {
     types.insert(std::make_pair(typeid(MyBase).name(), "MyBase"));
     types.insert(std::make_pair(typeid(MyTemplatePoint2).name(), "MyTemplatePoint2"));
     types.insert(std::make_pair(typeid(MyTemplateMatrix).name(), "MyTemplateMatrix"));
+    types.insert(std::make_pair(typeid(ForwardKinematicsFactor).name(), "ForwardKinematicsFactor"));
 
     mxArray *registry = mexGetVariable("global", "gtsamwrap_rttiRegistry");
     if(!registry)

--- a/tests/expected/matlab/special_cases_wrapper.cpp
+++ b/tests/expected/matlab/special_cases_wrapper.cpp
@@ -58,6 +58,8 @@ typedef std::set<boost::shared_ptr<MyTemplatePoint2>*> Collector_MyTemplatePoint
 static Collector_MyTemplatePoint2 collector_MyTemplatePoint2;
 typedef std::set<boost::shared_ptr<MyTemplateMatrix>*> Collector_MyTemplateMatrix;
 static Collector_MyTemplateMatrix collector_MyTemplateMatrix;
+typedef std::set<boost::shared_ptr<ForwardKinematicsFactor>*> Collector_ForwardKinematicsFactor;
+static Collector_ForwardKinematicsFactor collector_ForwardKinematicsFactor;
 typedef std::set<boost::shared_ptr<ns1::ClassA>*> Collector_ns1ClassA;
 static Collector_ns1ClassA collector_ns1ClassA;
 typedef std::set<boost::shared_ptr<ns1::ClassB>*> Collector_ns1ClassB;
@@ -169,6 +171,12 @@ void _deleteAllObjects()
     collector_MyTemplateMatrix.erase(iter++);
     anyDeleted = true;
   } }
+  { for(Collector_ForwardKinematicsFactor::iterator iter = collector_ForwardKinematicsFactor.begin();
+      iter != collector_ForwardKinematicsFactor.end(); ) {
+    delete *iter;
+    collector_ForwardKinematicsFactor.erase(iter++);
+    anyDeleted = true;
+  } }
   { for(Collector_ns1ClassA::iterator iter = collector_ns1ClassA.begin();
       iter != collector_ns1ClassA.end(); ) {
     delete *iter;
@@ -244,6 +252,7 @@ void _special_cases_RTTIRegister() {
     types.insert(std::make_pair(typeid(MyBase).name(), "MyBase"));
     types.insert(std::make_pair(typeid(MyTemplatePoint2).name(), "MyTemplatePoint2"));
     types.insert(std::make_pair(typeid(MyTemplateMatrix).name(), "MyTemplateMatrix"));
+    types.insert(std::make_pair(typeid(ForwardKinematicsFactor).name(), "ForwardKinematicsFactor"));
 
     mxArray *registry = mexGetVariable("global", "gtsamwrap_rttiRegistry");
     if(!registry)

--- a/tests/expected/python/inheritance_pybind.cpp
+++ b/tests/expected/python/inheritance_pybind.cpp
@@ -54,6 +54,8 @@ PYBIND11_MODULE(inheritance_py, m_) {
         .def("return_ptrs",[](MyTemplate<gtsam::Matrix>* self, const std::shared_ptr<gtsam::Matrix> p1, const std::shared_ptr<gtsam::Matrix> p2){return self->return_ptrs(p1, p2);}, py::arg("p1"), py::arg("p2"))
         .def_static("Level",[](const gtsam::Matrix& K){return MyTemplate<gtsam::Matrix>::Level(K);}, py::arg("K"));
 
+    py::class_<ForwardKinematicsFactor, gtsam::BetweenFactor<gtsam::Pose3>, std::shared_ptr<ForwardKinematicsFactor>>(m_, "ForwardKinematicsFactor");
+
 
 #include "python/specializations.h"
 

--- a/tests/fixtures/inheritance.i
+++ b/tests/fixtures/inheritance.i
@@ -22,3 +22,6 @@ virtual class MyTemplate : MyBase {
 
   static This Level(const T& K);
 };
+
+
+virtual class ForwardKinematicsFactor : gtsam::BetweenFactor<gtsam::Pose3> {};

--- a/tests/test_interface_parser.py
+++ b/tests/test_interface_parser.py
@@ -388,6 +388,15 @@ class TestInterfaceParser(unittest.TestCase):
                          ret.parent_class.namespaces)
         self.assertTrue(ret.is_virtual)
 
+        ret = Class.rule.parseString(
+            "class ForwardKinematicsFactor : gtsam::BetweenFactor<gtsam::Pose3> {};"
+        )[0]
+        self.assertEqual("ForwardKinematicsFactor", ret.name)
+        self.assertEqual("BetweenFactor", ret.parent_class.name)
+        self.assertEqual(["gtsam"], ret.parent_class.namespaces)
+        self.assertEqual("Pose3", ret.parent_class.instantiations[0].name)
+        self.assertEqual(["gtsam"], ret.parent_class.instantiations[0].namespaces)
+
     def test_include(self):
         """Test for include statements."""
         include = Include.rule.parseString(


### PR DESCRIPTION
Added support for templated base classes.

We can now do 
```cpp
class ForwardKinematicsFactor : gtsam::BetweenFactor<gtsam::Pose3> {};
```