### PR TITLE
Global variables

### DIFF
--- a/gtwrap/interface_parser/classes.py
+++ b/gtwrap/interface_parser/classes.py
@@ -19,6 +19,7 @@ from .template import Template
 from .tokens import (CLASS, COLON, CONST, IDENT, LBRACE, LPAREN, RBRACE,
                      RPAREN, SEMI_COLON, STATIC, VIRTUAL, OPERATOR)
 from .type import TemplatedType, Type, Typename
+from .variable import Variable
 
 
 class Method:
@@ -136,32 +137,6 @@ class Constructor:
         return "Constructor: {}".format(self.name)
 
 
-class Property:
-    """
-    Rule to parse the variable members of a class.
-
-    E.g.
-    ```
-    class Hello {
-        string name;  // This is a property.
-    };
-    ````
-    """
-    rule = (
-        (Type.rule ^ TemplatedType.rule)("ctype")  #
-        + IDENT("name")  #
-        + SEMI_COLON  #
-    ).setParseAction(lambda t: Property(t.ctype, t.name))
-
-    def __init__(self, ctype: Type, name: str, parent=''):
-        self.ctype = ctype[0]  # ParseResult is a list
-        self.name = name
-        self.parent = parent
-
-    def __repr__(self) -> str:
-        return '{} {}'.format(self.ctype.__repr__(), self.name)
-
-
 class Operator:
     """
     Rule for parsing operator overloads.
@@ -256,12 +231,12 @@ class Class:
         Rule for all the members within a class.
         """
         rule = ZeroOrMore(Constructor.rule ^ StaticMethod.rule ^ Method.rule
-                          ^ Property.rule ^ Operator.rule).setParseAction(
+                          ^ Variable.rule ^ Operator.rule).setParseAction(
                               lambda t: Class.Members(t.asList()))
 
         def __init__(self,
                      members: List[Union[Constructor, Method, StaticMethod,
-                                         Property, Operator]]):
+                                         Variable, Operator]]):
             self.ctors = []
             self.methods = []
             self.static_methods = []
@@ -274,7 +249,7 @@ class Class:
                     self.methods.append(m)
                 elif isinstance(m, StaticMethod):
                     self.static_methods.append(m)
-                elif isinstance(m, Property):
+                elif isinstance(m, Variable):
                     self.properties.append(m)
                 elif isinstance(m, Operator):
                     self.operators.append(m)
@@ -311,7 +286,7 @@ class Class:
         ctors: List[Constructor],
         methods: List[Method],
         static_methods: List[StaticMethod],
-        properties: List[Property],
+        properties: List[Variable],
         operators: List[Operator],
         parent: str = '',
     ):

--- a/gtwrap/interface_parser/function.py
+++ b/gtwrap/interface_parser/function.py
@@ -137,6 +137,31 @@ class ReturnType:
             return self.type1.to_cpp(use_boost)
 
 
+class GlobalVariable:
+    """
+    Rule to parse the variable members of a class.
+
+    E.g.
+    ```
+    class Hello {
+        string name;  // This is a property.
+    };
+    ````
+    """
+    rule = (
+        (Type.rule ^ TemplatedType.rule)("ctype")  #
+        + IDENT("name")  #
+        + SEMI_COLON  #
+    ).setParseAction(lambda t: Property(t.ctype, t.name))
+
+    def __init__(self, ctype: Type, name: str, parent=''):
+        self.ctype = ctype[0]  # ParseResult is a list
+        self.name = name
+        self.parent = parent
+
+    def __repr__(self) -> str:
+        return '{} {}'.format(self.ctype.__repr__(), self.name)
+
 class GlobalFunction:
     """
     Rule to parse functions defined in the global scope.

--- a/gtwrap/interface_parser/function.py
+++ b/gtwrap/interface_parser/function.py
@@ -137,31 +137,6 @@ class ReturnType:
             return self.type1.to_cpp(use_boost)
 
 
-class GlobalVariable:
-    """
-    Rule to parse the variable members of a class.
-
-    E.g.
-    ```
-    class Hello {
-        string name;  // This is a property.
-    };
-    ````
-    """
-    rule = (
-        (Type.rule ^ TemplatedType.rule)("ctype")  #
-        + IDENT("name")  #
-        + SEMI_COLON  #
-    ).setParseAction(lambda t: Property(t.ctype, t.name))
-
-    def __init__(self, ctype: Type, name: str, parent=''):
-        self.ctype = ctype[0]  # ParseResult is a list
-        self.name = name
-        self.parent = parent
-
-    def __repr__(self) -> str:
-        return '{} {}'.format(self.ctype.__repr__(), self.name)
-
 class GlobalFunction:
     """
     Rule to parse functions defined in the global scope.

--- a/gtwrap/interface_parser/module.py
+++ b/gtwrap/interface_parser/module.py
@@ -23,6 +23,7 @@ from .declaration import ForwardDeclaration, Include
 from .function import GlobalFunction
 from .namespace import Namespace
 from .template import TypedefTemplateInstantiation
+from .variable import Variable
 
 
 class Module:
@@ -43,6 +44,7 @@ class Module:
                    ^ Class.rule  #
                    ^ TypedefTemplateInstantiation.rule  #
                    ^ GlobalFunction.rule  #
+                   ^ Variable.rule #
                    ^ Namespace.rule  #
                    ).setParseAction(lambda t: Namespace('', t.asList())) +
         stringEnd)

--- a/gtwrap/interface_parser/namespace.py
+++ b/gtwrap/interface_parser/namespace.py
@@ -22,6 +22,7 @@ from .function import GlobalFunction
 from .template import TypedefTemplateInstantiation
 from .tokens import IDENT, LBRACE, NAMESPACE, RBRACE
 from .type import Typename
+from .variable import Variable
 
 
 def find_sub_namespace(namespace: "Namespace",
@@ -67,6 +68,7 @@ class Namespace:
             ^ Class.rule  #
             ^ TypedefTemplateInstantiation.rule  #
             ^ GlobalFunction.rule  #
+            ^ Variable.rule #
             ^ rule  #
         )("content")  # BR
         + RBRACE  #

--- a/gtwrap/interface_parser/variable.py
+++ b/gtwrap/interface_parser/variable.py
@@ -1,0 +1,39 @@
+"""
+GTSAM Copyright 2010-2020, Georgia Tech Research Corporation,
+Atlanta, Georgia 30332-0415
+All Rights Reserved
+
+See LICENSE for the license information
+
+Parser classes and rules for parsing C++ variables.
+
+Author: Duy Nguyen Ta, Fan Jiang, Matthew Sklar, Varun Agrawal, and Frank Dellaert
+"""
+
+from .tokens import IDENT, SEMI_COLON
+from .type import TemplatedType, Type
+
+class Variable:
+    """
+    Rule to parse the variable members of a class.
+
+    E.g.
+    ```
+    class Hello {
+        string name;  // This is a property.
+    };
+    ````
+    """
+    rule = (
+        (Type.rule ^ TemplatedType.rule)("ctype")  #
+        + IDENT("name")  #
+        + SEMI_COLON  #
+    ).setParseAction(lambda t: Variable(t.ctype, t.name))
+
+    def __init__(self, ctype: Type, name: str, parent=''):
+        self.ctype = ctype[0]  # ParseResult is a list
+        self.name = name
+        self.parent = parent
+
+    def __repr__(self) -> str:
+        return '{} {}'.format(self.ctype.__repr__(), self.name)

--- a/gtwrap/interface_parser/variable.py
+++ b/gtwrap/interface_parser/variable.py
@@ -7,7 +7,7 @@ See LICENSE for the license information
 
 Parser classes and rules for parsing C++ variables.
 
-Author: Duy Nguyen Ta, Fan Jiang, Matthew Sklar, Varun Agrawal, and Frank Dellaert
+Author: Varun Agrawal, Gerry Chen
 """
 
 from .tokens import IDENT, SEMI_COLON
@@ -15,13 +15,16 @@ from .type import TemplatedType, Type
 
 class Variable:
     """
-    Rule to parse the variable members of a class.
+    Rule to parse variables.
+    Variables are a combination of Type/TemplatedType and the variable identifier.
 
     E.g.
     ```
     class Hello {
-        string name;  // This is a property.
+        string name;  // This is a property variable.
     };
+
+    Vector3 kGravity;  // This is a global variable.
     ````
     """
     rule = (

--- a/gtwrap/pybind_wrapper.py
+++ b/gtwrap/pybind_wrapper.py
@@ -180,6 +180,15 @@ class PybindWrapper:
 
         return res
 
+    def wrap_variable(self, module, variable, prefix='\n' + ' ' * 8):
+        """Wrap a variable that's not part of a class (i.e. global)
+        """
+        return '{prefix}{module}.attr("{variable_name}") = {variable_name};'.format(
+            prefix=prefix,
+            module=module,
+            variable_name=variable.name
+        )
+
     def wrap_properties(self, properties, cpp_class, prefix='\n' + ' ' * 8):
         """Wrap all the properties in the `cpp_class`."""
         res = ""
@@ -335,6 +344,12 @@ class PybindWrapper:
                     includes += includes_namespace
                 elif isinstance(element, instantiator.InstantiatedClass):
                     wrapped += self.wrap_instantiated_class(element)
+                elif isinstance(element, parser.Variable):
+                    wrapped += self.wrap_variable(
+                        module=module_var,
+                        variable=element,
+                        prefix='\n' + ' ' * 4
+                    )
 
             # Global functions.
             all_funcs = [

--- a/gtwrap/pybind_wrapper.py
+++ b/gtwrap/pybind_wrapper.py
@@ -180,12 +180,13 @@ class PybindWrapper:
 
         return res
 
-    def wrap_variable(self, module, variable, prefix='\n' + ' ' * 8):
+    def wrap_variable(self, module, module_var, variable, prefix='\n' + ' ' * 8):
         """Wrap a variable that's not part of a class (i.e. global)
         """
-        return '{prefix}{module}.attr("{variable_name}") = {variable_name};'.format(
+        return '{prefix}{module_var}.attr("{variable_name}") = {module}{variable_name};'.format(
             prefix=prefix,
             module=module,
+            module_var=module_var,
             variable_name=variable.name
         )
 
@@ -346,7 +347,8 @@ class PybindWrapper:
                     wrapped += self.wrap_instantiated_class(element)
                 elif isinstance(element, parser.Variable):
                     wrapped += self.wrap_variable(
-                        module=module_var,
+                        module=self._add_namespaces('', namespaces),
+                        module_var=module_var,
                         variable=element,
                         prefix='\n' + ' ' * 4
                     )

--- a/tests/expected/python/namespaces_pybind.cpp
+++ b/tests/expected/python/namespaces_pybind.cpp
@@ -53,9 +53,12 @@ PYBIND11_MODULE(namespaces_py, m_) {
     m_ns2.def("aGlobalFunction",[](){return ns2::aGlobalFunction();});
     m_ns2.def("overloadedGlobalFunction",[](const ns1::ClassA& a){return ns2::overloadedGlobalFunction(a);}, py::arg("a"));
     m_ns2.def("overloadedGlobalFunction",[](const ns1::ClassA& a, double b){return ns2::overloadedGlobalFunction(a, b);}, py::arg("a"), py::arg("b"));
+    m_ns2.attr("aNs2Var") = aNs2Var;
+
     py::class_<ClassD, std::shared_ptr<ClassD>>(m_, "ClassD")
         .def(py::init<>());
 
+    m_.attr("aGlobalVar") = aGlobalVar;
 
 #include "python/specializations.h"
 

--- a/tests/expected/python/namespaces_pybind.cpp
+++ b/tests/expected/python/namespaces_pybind.cpp
@@ -50,11 +50,10 @@ PYBIND11_MODULE(namespaces_py, m_) {
     py::class_<ns2::ClassC, std::shared_ptr<ns2::ClassC>>(m_ns2, "ClassC")
         .def(py::init<>());
 
+    m_ns2.attr("aNs2Var") = aNs2Var;
     m_ns2.def("aGlobalFunction",[](){return ns2::aGlobalFunction();});
     m_ns2.def("overloadedGlobalFunction",[](const ns1::ClassA& a){return ns2::overloadedGlobalFunction(a);}, py::arg("a"));
     m_ns2.def("overloadedGlobalFunction",[](const ns1::ClassA& a, double b){return ns2::overloadedGlobalFunction(a, b);}, py::arg("a"), py::arg("b"));
-    m_ns2.attr("aNs2Var") = aNs2Var;
-
     py::class_<ClassD, std::shared_ptr<ClassD>>(m_, "ClassD")
         .def(py::init<>());
 

--- a/tests/expected/python/namespaces_pybind.cpp
+++ b/tests/expected/python/namespaces_pybind.cpp
@@ -50,7 +50,7 @@ PYBIND11_MODULE(namespaces_py, m_) {
     py::class_<ns2::ClassC, std::shared_ptr<ns2::ClassC>>(m_ns2, "ClassC")
         .def(py::init<>());
 
-    m_ns2.attr("aNs2Var") = aNs2Var;
+    m_ns2.attr("aNs2Var") = ns2::aNs2Var;
     m_ns2.def("aGlobalFunction",[](){return ns2::aGlobalFunction();});
     m_ns2.def("overloadedGlobalFunction",[](const ns1::ClassA& a){return ns2::overloadedGlobalFunction(a);}, py::arg("a"));
     m_ns2.def("overloadedGlobalFunction",[](const ns1::ClassA& a, double b){return ns2::overloadedGlobalFunction(a, b);}, py::arg("a"), py::arg("b"));

--- a/tests/fixtures/namespaces.i
+++ b/tests/fixtures/namespaces.i
@@ -17,7 +17,7 @@ class ClassB {
 // check namespace handling
 Vector aGlobalFunction();
 
-}
+}  // namespace ns1
 
 #include <path/to/ns2.h>
 namespace ns2 {
@@ -38,7 +38,7 @@ class ClassB {
   ClassB();
 };
 
-}
+}  // namespace ns3
 
 class ClassC {
   ClassC();
@@ -51,10 +51,12 @@ Vector aGlobalFunction();
 ns1::ClassA overloadedGlobalFunction(const ns1::ClassA& a);
 ns1::ClassA overloadedGlobalFunction(const ns1::ClassA& a, double b);
 
-} //\namespace ns2
+int aNs2Var;
+
+}  // namespace ns2
 
 class ClassD {
   ClassD();
 };
 
-
+int aGlobalVar;

--- a/tests/test_interface_parser.py
+++ b/tests/test_interface_parser.py
@@ -469,16 +469,18 @@ class TestInterfaceParser(unittest.TestCase):
 
                 };
             }
+            int oneVar;
         }
 
         class Global{
         };
+        int globalVar;
         """)
 
         # print("module: ", module)
         # print(dir(module.content[0].name))
-        self.assertEqual(["one", "Global"], [x.name for x in module.content])
-        self.assertEqual(["two", "two_dummy", "two"],
+        self.assertEqual(["one", "Global", "globalVar"], [x.name for x in module.content])
+        self.assertEqual(["two", "two_dummy", "two", "oneVar"],
                          [x.name for x in module.content[0].content])
 
 


### PR DESCRIPTION
Coordinated with Varun:
This adds the ability to make global variables accessible to python.  One primary use case is KeyFormatters, which are variables of type std::functional aka callables in python.  So for example, we can now do in `gtsam.i`:

```c++
gtsam::KeyFormatter DefaultKeyFormatter
```
and this will be available in python:
```python
print(gtsam.DefaultKeyFormatter(12345))
graph.print('factor graph: ', gtsam.DefaultKeyFormatter)
```
(assuming that the gtsam wrapper is updated to include the additional argument for key formatter).

The tokenizer for "Property" is renamed to "Variable" and used in class, namespace, and module now.  Variables that exist in namespace or module use the `attr` syntax in [pybind](https://pybind11.readthedocs.io/en/stable/basics.html#exporting-variables)