### PR TITLE
Redirect stdout for print_

### DIFF
--- a/gtwrap/pybind_wrapper.py
+++ b/gtwrap/pybind_wrapper.py
@@ -126,6 +126,7 @@ class PybindWrapper:
 
         if method.name == 'print':
             type_list = method.args.to_cpp(self.use_boost)
+            ret = ret.replace('self->', 'py::scoped_ostream_redirect output; self->')
             if len(type_list) > 0 and type_list[0].strip() == 'string':
                 ret += '''{prefix}.def("__repr__",
                     [](const {cpp_class} &a) {{

--- a/gtwrap/pybind_wrapper.py
+++ b/gtwrap/pybind_wrapper.py
@@ -125,8 +125,12 @@ class PybindWrapper:
                ))
 
         if method.name == 'print':
-            type_list = method.args.to_cpp(self.use_boost)
+            # Redirect stdout - see pybind docs for why this is a good idea:
+            # https://pybind11.readthedocs.io/en/stable/advanced/pycpp/utilities.html#capturing-standard-output-from-ostream
             ret = ret.replace('self->', 'py::scoped_ostream_redirect output; self->')
+
+            # __repr__() uses print's implementation:
+            type_list = method.args.to_cpp(self.use_boost)
             if len(type_list) > 0 and type_list[0].strip() == 'string':
                 ret += '''{prefix}.def("__repr__",
                     [](const {cpp_class} &a) {{

--- a/tests/expected/python/class_pybind.cpp
+++ b/tests/expected/python/class_pybind.cpp
@@ -55,7 +55,7 @@ PYBIND11_MODULE(class_py, m_) {
         .def("create_ptrs",[](Test* self){return self->create_ptrs();})
         .def("create_MixedPtrs",[](Test* self){return self->create_MixedPtrs();})
         .def("return_ptrs",[](Test* self, std::shared_ptr<Test> p1, std::shared_ptr<Test> p2){return self->return_ptrs(p1, p2);}, py::arg("p1"), py::arg("p2"))
-        .def("print_",[](Test* self){ self->print();})
+        .def("print_",[](Test* self){ py::scoped_ostream_redirect output; self->print();})
         .def("__repr__",
                     [](const Test &a) {
                         gtsam::RedirectCout redirect;


### PR DESCRIPTION
Apparently python sys.stdout and c++ linked cout are not the same stream, so things play a little nicer in python if you use pybind's redirection of cout to sys.stdout.  See [pybind docs](https://pybind11.readthedocs.io/en/stable/reference.html#redirecting-c-streams)

One place this is useful is in capturing stdout to a string, as in for unit testing `print_`:
```python
from io import StringIO
from unittest.mock import patch
with patch('sys.stdout', new = StringIO()) as fake_out:
    factor.print_('factor: ', kf)
    self.assertTrue('factor: min torque factor' in fake_out.getvalue())
```

This will only work if `factor.print_` is outputting to python's sys.stdout.