### PR TITLE
Optional arguments for __repr__()

### DIFF
--- a/tests/expected/python/class_pybind.cpp
+++ b/tests/expected/python/class_pybind.cpp
@@ -55,13 +55,13 @@ PYBIND11_MODULE(class_py, m_) {
         .def("create_ptrs",[](Test* self){return self->create_ptrs();})
         .def("create_MixedPtrs",[](Test* self){return self->create_MixedPtrs();})
         .def("return_ptrs",[](Test* self, std::shared_ptr<Test> p1, std::shared_ptr<Test> p2){return self->return_ptrs(p1, p2);}, py::arg("p1"), py::arg("p2"))
-        .def("print_",[](Test* self){ self->print();})
+        .def("print_",[](Test* self, const string& s, const gtsam::KeyFormatter& keyFormatter){ self->print(s, keyFormatter);}, py::arg("s"), py::arg("keyFormatter"))
         .def("__repr__",
-                    [](const Test &a) {
+                    [](const Test &a, const string& s, const gtsam::KeyFormatter& keyFormatter) {
                         gtsam::RedirectCout redirect;
-                        a.print();
+                        a.print(s, keyFormatter);
                         return redirect.str();
-                    })
+                    }, py::arg("s") = "", py::arg("keyFormatter") = gtsam::DefaultKeyFormatter)
         .def("set_container",[](Test* self, std::vector<testing::Test> container){ self->set_container(container);}, py::arg("container"))
         .def("set_container",[](Test* self, std::vector<std::shared_ptr<testing::Test>> container){ self->set_container(container);}, py::arg("container"))
         .def("set_container",[](Test* self, std::vector<testing::Test&> container){ self->set_container(container);}, py::arg("container"))

--- a/tests/expected/python/class_pybind.cpp
+++ b/tests/expected/python/class_pybind.cpp
@@ -57,7 +57,7 @@ PYBIND11_MODULE(class_py, m_) {
         .def("return_ptrs",[](Test* self, std::shared_ptr<Test> p1, std::shared_ptr<Test> p2){return self->return_ptrs(p1, p2);}, py::arg("p1"), py::arg("p2"))
         .def("print_",[](Test* self, const string& s, const gtsam::KeyFormatter& keyFormatter){ self->print(s, keyFormatter);}, py::arg("s"), py::arg("keyFormatter"))
         .def("__repr__",
-                    [](const Test &a, const string& s, const gtsam::KeyFormatter& keyFormatter) {
+                    [](const Test& a, const string& s, const gtsam::KeyFormatter& keyFormatter) {
                         gtsam::RedirectCout redirect;
                         a.print(s, keyFormatter);
                         return redirect.str();

--- a/tests/fixtures/class.i
+++ b/tests/fixtures/class.i
@@ -61,7 +61,7 @@ class Test {
   pair<Test ,Test*> create_MixedPtrs () const;
   pair<Test*,Test*> return_ptrs (Test* p1, Test* p2) const;
 
-  void print(const string& s, gtsam::KeyFormatter keyFormatter) const;
+  void print(const string& s, const gtsam::KeyFormatter& keyFormatter) const;
 
   void set_container(std::vector<testing::Test> container);
   void set_container(std::vector<testing::Test*> container);

--- a/tests/fixtures/class.i
+++ b/tests/fixtures/class.i
@@ -61,7 +61,7 @@ class Test {
   pair<Test ,Test*> create_MixedPtrs () const;
   pair<Test*,Test*> return_ptrs (Test* p1, Test* p2) const;
 
-  void print() const;
+  void print(const string& s, gtsam::KeyFormatter keyFormatter) const;
 
   void set_container(std::vector<testing::Test> container);
   void set_container(std::vector<testing::Test*> container);


### PR DESCRIPTION
This PR adds optional arguments of `string s, KeyFormatter keyFormatter` to __repr__.  This should help in 2 ways:

1) convenient way for users to "print" to a string, i.e. rather than catpure stdout and use `factor.print_(s, keyFormatter)`, instead `mystring = factor.__repr__(s, keyFormatter)` can be used.
2) the default keyFormatter can be altered in third-party projects to use other keyFormatters by default.  Ideally this could eventually go as a #define or cmake flag or something, but I figured best to separate out PRs.

Hopefully this will eventually be superceded by real default arguments, but in the meantime this would be convenient for gtdynamics GTDKeyFormatter right now.

Note: since we use default arguments instead of normal arguments, then calling `factor.__repr__()` still works, and thus default printing/string conversion/debugging is still fine.