### PR TITLE
Include `pybind11/iostream` in example tpl

### DIFF
--- a/templates/pybind_wrapper.tpl.example
+++ b/templates/pybind_wrapper.tpl.example
@@ -4,6 +4,7 @@
 #include <pybind11/stl_bind.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/operators.h>
+#include <pybind11/iostream.h>
 #include "gtsam/base/serialization.h"
 #include "gtsam/nonlinear/utilities.h"  // for RedirectCout.
 


### PR DESCRIPTION
In the generated cpp file, `pybind11/ostream` is used for `py::scoped_ostream_redirect` as part of #84.  I add this include to the "example" project tpl file.