### PR TITLE
Better cmake messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,12 +35,11 @@ configure_package_config_file(
             INSTALL_INCLUDE_DIR
   INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
 
-message(STATUS "Package config  : ${CMAKE_INSTALL_PREFIX}/${INSTALL_CMAKE_DIR}")
+message(STATUS "Package config : ${CMAKE_INSTALL_PREFIX}/${INSTALL_CMAKE_DIR}")
 
 # ##############################################################################
 # Install the package
 
-message(STATUS "CMake           : ${CMAKE_INSTALL_PREFIX}/${INSTALL_CMAKE_DIR}")
 # Install CMake scripts to the standard CMake script directory.
 install(
   FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/gtwrapConfig.cmake
@@ -60,7 +59,6 @@ configure_file(${PROJECT_SOURCE_DIR}/templates/matlab_wrapper.tpl.in
 
 # Install the gtwrap python package as a directory so it can be found  by CMake
 # for wrapping.
-message(STATUS "Lib path        : ${CMAKE_INSTALL_PREFIX}/${INSTALL_LIB_DIR}")
 install(DIRECTORY gtwrap
         DESTINATION "${CMAKE_INSTALL_PREFIX}/${INSTALL_LIB_DIR}")
 
@@ -72,12 +70,17 @@ install(DIRECTORY pybind11
 # Install wrapping scripts as binaries to `CMAKE_INSTALL_PREFIX/bin` so they can
 # be invoked for wrapping. We use DESTINATION (instead of TYPE) so we can
 # support older CMake versions.
-message(STATUS "Bin path        : ${CMAKE_INSTALL_PREFIX}/${INSTALL_BIN_DIR}")
 install(PROGRAMS scripts/pybind_wrap.py scripts/matlab_wrap.py
         DESTINATION "${CMAKE_INSTALL_PREFIX}/${INSTALL_BIN_DIR}")
 
 # Install the matlab.h file to `CMAKE_INSTALL_PREFIX/lib/gtwrap/matlab.h`.
-message(
-  STATUS "Header path     : ${CMAKE_INSTALL_PREFIX}/${INSTALL_INCLUDE_DIR}")
 install(FILES matlab.h
         DESTINATION "${CMAKE_INSTALL_PREFIX}/${INSTALL_INCLUDE_DIR}")
+
+string(ASCII 27 Esc)
+set(gtwrap "${Esc}[1;36mgtwrap${Esc}[m")
+message(STATUS "${gtwrap} version : ${PROJECT_VERSION}")
+message(STATUS "${gtwrap} CMake   : ${CMAKE_INSTALL_PREFIX}/${INSTALL_CMAKE_DIR}")
+message(STATUS "${gtwrap} library : ${CMAKE_INSTALL_PREFIX}/${INSTALL_LIB_DIR}")
+message(STATUS "${gtwrap} binary  : ${CMAKE_INSTALL_PREFIX}/${INSTALL_BIN_DIR}")
+message(STATUS "${gtwrap} header  : ${CMAKE_INSTALL_PREFIX}/${INSTALL_INCLUDE_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,16 +35,19 @@ configure_package_config_file(
             INSTALL_INCLUDE_DIR
   INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
 
-message(STATUS "Package config : ${CMAKE_INSTALL_PREFIX}/${INSTALL_CMAKE_DIR}")
+# Set all the install paths
+set(GTWRAP_CMAKE_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/${INSTALL_CMAKE_DIR})
+set(GTWRAP_LIB_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/${INSTALL_LIB_DIR})
+set(GTWRAP_BIN_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/${INSTALL_BIN_DIR})
+set(GTWRAP_INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/${INSTALL_INCLUDE_DIR})
 
 # ##############################################################################
 # Install the package
 
 # Install CMake scripts to the standard CMake script directory.
-install(
-  FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/gtwrapConfig.cmake
-        cmake/MatlabWrap.cmake cmake/PybindWrap.cmake cmake/GtwrapUtils.cmake
-  DESTINATION "${CMAKE_INSTALL_PREFIX}/${INSTALL_CMAKE_DIR}")
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/gtwrapConfig.cmake
+              cmake/MatlabWrap.cmake cmake/PybindWrap.cmake
+              cmake/GtwrapUtils.cmake DESTINATION "${GTWRAP_CMAKE_INSTALL_DIR}")
 
 # Configure the include directory for matlab.h This allows the #include to be
 # either gtwrap/matlab.h, wrap/matlab.h or something custom.
@@ -59,28 +62,26 @@ configure_file(${PROJECT_SOURCE_DIR}/templates/matlab_wrapper.tpl.in
 
 # Install the gtwrap python package as a directory so it can be found  by CMake
 # for wrapping.
-install(DIRECTORY gtwrap
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/${INSTALL_LIB_DIR}")
+install(DIRECTORY gtwrap DESTINATION "${GTWRAP_INSTALL_LIB_DIR}")
 
 # Install pybind11 directory to `CMAKE_INSTALL_PREFIX/lib/gtwrap/pybind11` This
 # will allow the gtwrapConfig.cmake file to load it later.
-install(DIRECTORY pybind11
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/${INSTALL_LIB_DIR}")
+install(DIRECTORY pybind11 DESTINATION "${GTWRAP_INSTALL_LIB_DIR}")
 
 # Install wrapping scripts as binaries to `CMAKE_INSTALL_PREFIX/bin` so they can
 # be invoked for wrapping. We use DESTINATION (instead of TYPE) so we can
 # support older CMake versions.
 install(PROGRAMS scripts/pybind_wrap.py scripts/matlab_wrap.py
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/${INSTALL_BIN_DIR}")
+        DESTINATION "${GTWRAP_BIN_INSTALL_DIR}")
 
 # Install the matlab.h file to `CMAKE_INSTALL_PREFIX/lib/gtwrap/matlab.h`.
-install(FILES matlab.h
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/${INSTALL_INCLUDE_DIR}")
+install(FILES matlab.h DESTINATION "${GTWRAP_INCLUDE_INSTALL_DIR}")
 
 string(ASCII 27 Esc)
 set(gtwrap "${Esc}[1;36mgtwrap${Esc}[m")
-message(STATUS "${gtwrap} version : ${PROJECT_VERSION}")
-message(STATUS "${gtwrap} CMake   : ${CMAKE_INSTALL_PREFIX}/${INSTALL_CMAKE_DIR}")
-message(STATUS "${gtwrap} library : ${CMAKE_INSTALL_PREFIX}/${INSTALL_LIB_DIR}")
-message(STATUS "${gtwrap} binary  : ${CMAKE_INSTALL_PREFIX}/${INSTALL_BIN_DIR}")
-message(STATUS "${gtwrap} header  : ${CMAKE_INSTALL_PREFIX}/${INSTALL_INCLUDE_DIR}")
+message(STATUS "${gtwrap} Package config : ${GTWRAP_CMAKE_INSTALL_DIR}")
+message(STATUS "${gtwrap} version        : ${PROJECT_VERSION}")
+message(STATUS "${gtwrap} CMake path     : ${GTWRAP_CMAKE_INSTALL_DIR}")
+message(STATUS "${gtwrap} library path   : ${GTWRAP_LIB_INSTALL_DIR}")
+message(STATUS "${gtwrap} binary path    : ${GTWRAP_BIN_INSTALL_DIR}")
+message(STATUS "${gtwrap} header path    : ${GTWRAP_INCLUDE_INSTALL_DIR}")


### PR DESCRIPTION
```
cmake ..
-- Package config : /usr/local/lib/cmake/gtwrap
-- gtwrap version : 1.0
-- gtwrap CMake   : /usr/local/lib/cmake/gtwrap
-- gtwrap library : /usr/local/lib/gtwrap
-- gtwrap binary  : /usr/local/bin/gtwrap
-- gtwrap header  : /usr/local/include/gtwrap
-- Configuring done
-- Generating done
-- Build files have been written to: /home/varun/borglab/wrap/build
```