### PR TITLE
Allow default args of 0

### DIFF
--- a/gtwrap/interface_parser/tokens.py
+++ b/gtwrap/interface_parser/tokens.py
@@ -25,7 +25,8 @@ LOPBRACK, ROPBRACK, COMMA, EQUAL = map(Suppress, "<>,=")
 # Encapsulating type for numbers, and single and double quoted strings.
 # The pyparsing_common utilities ensure correct coversion to the corresponding type.
 # E.g. pyparsing_common.number will convert 3.1415 to a float type.
-NUMBER_OR_STRING = (pyparsing_common.number ^ QuotedString('"') ^ QuotedString("'"))
+NUMBER_OR_STRING = (pyparsing_common.number ^ QuotedString('"', unquoteResults=False) ^
+                    QuotedString("'", unquoteResults=False))
 
 # A python tuple, e.g. (1, 9, "random", 3.1415)
 TUPLE = (LPAREN + delimitedList(NUMBER_OR_STRING) + RPAREN)

--- a/gtwrap/pybind_wrapper.py
+++ b/gtwrap/pybind_wrapper.py
@@ -50,7 +50,7 @@ class PybindWrapper:
                 if isinstance(arg.default, str) and arg.default is not None:
                     # string default arg
                     arg.default = ' = "{arg.default}"'.format(arg=arg)
-                elif arg.default:  # Other types
+                elif arg.default is not None:  # Other types
                     arg.default = ' = {arg.default}'.format(arg=arg)
                 else:
                     arg.default = ''

--- a/gtwrap/pybind_wrapper.py
+++ b/gtwrap/pybind_wrapper.py
@@ -47,10 +47,7 @@ class PybindWrapper:
         if names:
             py_args = []
             for arg in args_list.args_list:
-                if isinstance(arg.default, str) and arg.default is not None:
-                    # string default arg
-                    arg.default = ' = "{arg.default}"'.format(arg=arg)
-                elif arg.default is not None:  # Other types
+                if arg.default is not None:
                     arg.default = ' = {arg.default}'.format(arg=arg)
                 else:
                     arg.default = ''

--- a/tests/expected/matlab/TemplatedFunctionRot3.m
+++ b/tests/expected/matlab/TemplatedFunctionRot3.m
@@ -1,6 +1,6 @@
 function varargout = TemplatedFunctionRot3(varargin)
       if length(varargin) == 1 && isa(varargin{1},'gtsam.Rot3')
-        functions_wrapper(11, varargin{:});
+        functions_wrapper(12, varargin{:});
       else
         error('Arguments do not match any overload of function TemplatedFunctionRot3');
       end

--- a/tests/expected/matlab/functions_wrapper.cpp
+++ b/tests/expected/matlab/functions_wrapper.cpp
@@ -198,9 +198,10 @@ void MultiTemplatedFunctionDoubleSize_tDouble_7(int nargout, mxArray *out[], int
 }
 void DefaultFuncInt_8(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  checkArguments("DefaultFuncInt",nargout,nargin,1);
+  checkArguments("DefaultFuncInt",nargout,nargin,2);
   int a = unwrap< int >(in[0]);
-  DefaultFuncInt(a);
+  int b = unwrap< int >(in[1]);
+  DefaultFuncInt(a,b);
 }
 void DefaultFuncString_9(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {

--- a/tests/expected/matlab/functions_wrapper.cpp
+++ b/tests/expected/matlab/functions_wrapper.cpp
@@ -216,7 +216,17 @@ void DefaultFuncObj_10(int nargout, mxArray *out[], int nargin, const mxArray *i
   gtsam::KeyFormatter& keyFormatter = *unwrap_shared_ptr< gtsam::KeyFormatter >(in[0], "ptr_gtsamKeyFormatter");
   DefaultFuncObj(keyFormatter);
 }
-void TemplatedFunctionRot3_11(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void DefaultFuncZero_11(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("DefaultFuncZero",nargout,nargin,5);
+  int a = unwrap< int >(in[0]);
+  int b = unwrap< int >(in[1]);
+  double c = unwrap< double >(in[2]);
+  bool d = unwrap< bool >(in[3]);
+  bool e = unwrap< bool >(in[4]);
+  DefaultFuncZero(a,b,c,d,e);
+}
+void TemplatedFunctionRot3_12(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("TemplatedFunctionRot3",nargout,nargin,1);
   gtsam::Rot3& t = *unwrap_shared_ptr< gtsam::Rot3 >(in[0], "ptr_gtsamRot3");
@@ -268,7 +278,10 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       DefaultFuncObj_10(nargout, out, nargin-1, in+1);
       break;
     case 11:
-      TemplatedFunctionRot3_11(nargout, out, nargin-1, in+1);
+      DefaultFuncZero_11(nargout, out, nargin-1, in+1);
+      break;
+    case 12:
+      TemplatedFunctionRot3_12(nargout, out, nargin-1, in+1);
       break;
     }
   } catch(const std::exception& e) {

--- a/tests/expected/python/functions_pybind.cpp
+++ b/tests/expected/python/functions_pybind.cpp
@@ -33,8 +33,8 @@ PYBIND11_MODULE(functions_py, m_) {
     m_.def("DefaultFuncInt",[](int a, int b){ ::DefaultFuncInt(a, b);}, py::arg("a") = 123, py::arg("b") = 0);
     m_.def("DefaultFuncString",[](const string& s, const string& name){ ::DefaultFuncString(s, name);}, py::arg("s") = "hello", py::arg("name") = "");
     m_.def("DefaultFuncObj",[](const gtsam::KeyFormatter& keyFormatter){ ::DefaultFuncObj(keyFormatter);}, py::arg("keyFormatter") = gtsam::DefaultKeyFormatter);
-    m_.def("TemplatedFunctionRot3",[](const gtsam::Rot3& t){ ::TemplatedFunction<Rot3>(t);}, py::arg("t"));
     m_.def("DefaultFuncZero",[](int a, int b, double c, bool d, bool e){ ::DefaultFuncZero(a, b, c, d, e);}, py::arg("a") = 0, py::arg("b"), py::arg("c") = 0.0, py::arg("d") = false, py::arg("e"));
+    m_.def("TemplatedFunctionRot3",[](const gtsam::Rot3& t){ ::TemplatedFunction<Rot3>(t);}, py::arg("t"));
 
 #include "python/specializations.h"
 

--- a/tests/expected/python/functions_pybind.cpp
+++ b/tests/expected/python/functions_pybind.cpp
@@ -34,6 +34,7 @@ PYBIND11_MODULE(functions_py, m_) {
     m_.def("DefaultFuncString",[](const string& s, const string& name){ ::DefaultFuncString(s, name);}, py::arg("s") = "hello", py::arg("name") = "");
     m_.def("DefaultFuncObj",[](const gtsam::KeyFormatter& keyFormatter){ ::DefaultFuncObj(keyFormatter);}, py::arg("keyFormatter") = gtsam::DefaultKeyFormatter);
     m_.def("TemplatedFunctionRot3",[](const gtsam::Rot3& t){ ::TemplatedFunction<Rot3>(t);}, py::arg("t"));
+    m_.def("DefaultFuncZero",[](int a, int b, double c, bool d, bool e){ ::DefaultFuncZero(a, b, c, d, e);}, py::arg("a") = 0, py::arg("b"), py::arg("c") = 0.0, py::arg("d") = false, py::arg("e"));
 
 #include "python/specializations.h"
 

--- a/tests/expected/python/functions_pybind.cpp
+++ b/tests/expected/python/functions_pybind.cpp
@@ -30,7 +30,7 @@ PYBIND11_MODULE(functions_py, m_) {
     m_.def("overloadedGlobalFunction",[](int a, double b){return ::overloadedGlobalFunction(a, b);}, py::arg("a"), py::arg("b"));
     m_.def("MultiTemplatedFunctionStringSize_tDouble",[](const T& x, size_t y){return ::MultiTemplatedFunction<string,size_t,double>(x, y);}, py::arg("x"), py::arg("y"));
     m_.def("MultiTemplatedFunctionDoubleSize_tDouble",[](const T& x, size_t y){return ::MultiTemplatedFunction<double,size_t,double>(x, y);}, py::arg("x"), py::arg("y"));
-    m_.def("DefaultFuncInt",[](int a){ ::DefaultFuncInt(a);}, py::arg("a") = 123);
+    m_.def("DefaultFuncInt",[](int a, int b){ ::DefaultFuncInt(a, b);}, py::arg("a") = 123, py::arg("b") = 0);
     m_.def("DefaultFuncString",[](const string& s, const string& name){ ::DefaultFuncString(s, name);}, py::arg("s") = "hello", py::arg("name") = "");
     m_.def("DefaultFuncObj",[](const gtsam::KeyFormatter& keyFormatter){ ::DefaultFuncObj(keyFormatter);}, py::arg("keyFormatter") = gtsam::DefaultKeyFormatter);
     m_.def("TemplatedFunctionRot3",[](const gtsam::Rot3& t){ ::TemplatedFunction<Rot3>(t);}, py::arg("t"));

--- a/tests/fixtures/functions.i
+++ b/tests/fixtures/functions.i
@@ -31,3 +31,4 @@ typedef TemplatedFunction<gtsam::Rot3> TemplatedFunctionRot3;
 void DefaultFuncInt(int a = 123, int b = 0);
 void DefaultFuncString(const string& s = "hello", const string& name = "");
 void DefaultFuncObj(const gtsam::KeyFormatter& keyFormatter = gtsam::DefaultKeyFormatter);
+void DefaultFuncZero(int a = 0, int b, double c = 0.0, bool d = false, bool e);

--- a/tests/fixtures/functions.i
+++ b/tests/fixtures/functions.i
@@ -28,6 +28,6 @@ void TemplatedFunction(const T& t);
 typedef TemplatedFunction<gtsam::Rot3> TemplatedFunctionRot3;
 
 // Check default arguments
-void DefaultFuncInt(int a = 123);
+void DefaultFuncInt(int a = 123, int b = 0);
 void DefaultFuncString(const string& s = "hello", const string& name = "");
 void DefaultFuncObj(const gtsam::KeyFormatter& keyFormatter = gtsam::DefaultKeyFormatter);

--- a/tests/test_interface_parser.py
+++ b/tests/test_interface_parser.py
@@ -181,7 +181,8 @@ class TestInterfaceParser(unittest.TestCase):
     def test_default_arguments(self):
         """Tests any expression that is a valid default argument"""
         args = ArgumentList.rule.parseString(
-            "string c = \"\", string s=\"hello\", int a=3, "
+            "string c = \"\", int z = 0, double z2 = 0.0, bool f = false, "
+            "string s=\"hello\", int a=3, "
             "int b, double pi = 3.1415, "
             "gtsam::KeyFormatter kf = gtsam::DefaultKeyFormatter, "
             "std::vector<size_t> p = std::vector<size_t>(), "
@@ -190,20 +191,23 @@ class TestInterfaceParser(unittest.TestCase):
 
         # Test for basic types
         self.assertEqual(args[0].default, "")
-        self.assertEqual(args[1].default, "hello")
-        self.assertEqual(args[2].default, 3)
+        self.assertEqual(args[1].default, 0)
+        self.assertEqual(args[2].default, 0)
+        self.assertEqual(args[3].default, "false")
+        self.assertEqual(args[4].default, "hello")
+        self.assertEqual(args[5].default, 3)
         # No default argument should set `default` to None
-        self.assertIsNone(args[3].default)
+        self.assertIsNone(args[6].default)
 
-        self.assertEqual(args[4].default, 3.1415)
+        self.assertEqual(args[7].default, 3.1415)
 
         # Test non-basic type
-        self.assertEqual(repr(args[5].default.typename),
+        self.assertEqual(repr(args[8].default.typename),
                          'gtsam::DefaultKeyFormatter')
         # Test templated type
-        self.assertEqual(repr(args[6].default.typename), 'std::vector<size_t>')
+        self.assertEqual(repr(args[9].default.typename), 'std::vector<size_t>')
         # Test for allowing list as default argument
-        self.assertEqual(args[7].default, (1, 2, 'name', "random", 3.1415))
+        self.assertEqual(args[10].default, (1, 2, 'name', "random", 3.1415))
 
     def test_return_type(self):
         """Test ReturnType"""

--- a/tests/test_interface_parser.py
+++ b/tests/test_interface_parser.py
@@ -181,33 +181,34 @@ class TestInterfaceParser(unittest.TestCase):
     def test_default_arguments(self):
         """Tests any expression that is a valid default argument"""
         args = ArgumentList.rule.parseString(
-            "string c = \"\", int z = 0, double z2 = 0.0, bool f = false, "
-            "string s=\"hello\", int a=3, "
-            "int b, double pi = 3.1415, "
-            "gtsam::KeyFormatter kf = gtsam::DefaultKeyFormatter, "
-            "std::vector<size_t> p = std::vector<size_t>(), "
-            "std::vector<size_t> l = (1, 2, 'name', \"random\", 3.1415)"
+            """string c = "", int z = 0, double z2 = 0.0, bool f = false, """
+            """string s="hello", char c='a', int a=3, """
+            """int b, double pi = 3.1415, """
+            """gtsam::KeyFormatter kf = gtsam::DefaultKeyFormatter, """
+            """std::vector<size_t> p = std::vector<size_t>(), """
+            """std::vector<size_t> l = (1, 2, "name", "random", 3.1415)"""
         )[0].args_list
 
         # Test for basic types
-        self.assertEqual(args[0].default, "")
+        self.assertEqual(args[0].default, '""')
         self.assertEqual(args[1].default, 0)
         self.assertEqual(args[2].default, 0)
         self.assertEqual(args[3].default, "false")
-        self.assertEqual(args[4].default, "hello")
-        self.assertEqual(args[5].default, 3)
+        self.assertEqual(args[4].default, '"hello"')
+        self.assertEqual(args[5].default, "'a'")
+        self.assertEqual(args[6].default, 3)
         # No default argument should set `default` to None
-        self.assertIsNone(args[6].default)
+        self.assertIsNone(args[7].default)
 
-        self.assertEqual(args[7].default, 3.1415)
+        self.assertEqual(args[8].default, 3.1415)
 
         # Test non-basic type
-        self.assertEqual(repr(args[8].default.typename),
+        self.assertEqual(repr(args[9].default.typename),
                          'gtsam::DefaultKeyFormatter')
         # Test templated type
-        self.assertEqual(repr(args[9].default.typename), 'std::vector<size_t>')
+        self.assertEqual(repr(args[10].default.typename), 'std::vector<size_t>')
         # Test for allowing list as default argument
-        self.assertEqual(args[10].default, (1, 2, 'name', "random", 3.1415))
+        self.assertEqual(args[11].default, (1, 2, '"name"', '"random"', 3.1415))
 
     def test_return_type(self):
         """Test ReturnType"""

--- a/tests/test_interface_parser.py
+++ b/tests/test_interface_parser.py
@@ -180,13 +180,13 @@ class TestInterfaceParser(unittest.TestCase):
 
     def test_default_arguments(self):
         """Tests any expression that is a valid default argument"""
-        args = ArgumentList.rule.parseString(
-            """string c = "", int z = 0, double z2 = 0.0, bool f = false, """
-            """string s="hello", char c='a', int a=3, """
-            """int b, double pi = 3.1415, """
-            """gtsam::KeyFormatter kf = gtsam::DefaultKeyFormatter, """
-            """std::vector<size_t> p = std::vector<size_t>(), """
-            """std::vector<size_t> l = (1, 2, "name", "random", 3.1415)"""
+        args = ArgumentList.rule.parseString("""\
+            string c = "", int z = 0, double z2 = 0.0, bool f = false, 
+            string s="hello", char c='a', int a=3, 
+            int b, double pi = 3.1415, 
+            gtsam::KeyFormatter kf = gtsam::DefaultKeyFormatter, 
+            std::vector<size_t> p = std::vector<size_t>(), 
+            std::vector<size_t> l = (1, 2, 'a', "name", "random", 3.1415)"""
         )[0].args_list
 
         # Test for basic types
@@ -208,7 +208,7 @@ class TestInterfaceParser(unittest.TestCase):
         # Test templated type
         self.assertEqual(repr(args[10].default.typename), 'std::vector<size_t>')
         # Test for allowing list as default argument
-        self.assertEqual(args[11].default, (1, 2, '"name"', '"random"', 3.1415))
+        self.assertEqual(args[11].default, (1, 2, "'a'", '"name"', '"random"', 3.1415))
 
     def test_return_type(self):
         """Test ReturnType"""


### PR DESCRIPTION
Currently the check in `pybind_wrapper.py` for whether there is a default arg or not is just
```python
  if ...:
    # deal with string manually
   ...
  elif arg.default:
    # yes default arg
    ...
  else:
    # no default arg
    ...
```

But since things like `0` and `""` are False-y, then this check misses those cases.  Should be `elif arg.default is not None:`.