### PR TITLE
Support object types as default arguments

### DIFF
--- a/gtwrap/interface_parser/tokens.py
+++ b/gtwrap/interface_parser/tokens.py
@@ -10,9 +10,9 @@ All the token definitions.
 Author: Duy Nguyen Ta, Fan Jiang, Matthew Sklar, Varun Agrawal, and Frank Dellaert
 """
 
-from pyparsing import (Keyword, Literal, Or, QuotedString, Suppress, Word,
-                       ZeroOrMore, OneOrMore, alphanums, alphas, nestedExpr, nums,
-                       originalTextFor, printables, pyparsing_common)
+from pyparsing import (Keyword, Literal, OneOrMore, Or, QuotedString, Suppress,
+                       Word, alphanums, alphas, nestedExpr, nums,
+                       originalTextFor, printables)
 
 # rule for identifiers (e.g. variable names)
 IDENT = Word(alphas + '_', alphanums + '_') ^ Word(nums)
@@ -22,18 +22,19 @@ RAW_POINTER, SHARED_POINTER, REF = map(Literal, "@*&")
 LPAREN, RPAREN, LBRACE, RBRACE, COLON, SEMI_COLON = map(Suppress, "(){}:;")
 LOPBRACK, ROPBRACK, COMMA, EQUAL = map(Suppress, "<>,=")
 
-# Default argument passed to functions/methods.  Allow anything up to ',' or ';'
-# except when they appear inside matched expressions such as
-# (a, b) {c, b} "hello, how are you?"
+# Default argument passed to functions/methods.
+# Allow anything up to ',' or ';' except when they
+# appear inside matched expressions such as
+# (a, b) {c, b} "hello, world", templates, initializer lists, etc.
 DEFAULT_ARG = originalTextFor(
     OneOrMore(
-        Word(printables, excludeChars="(){}[]<>,;") ^ # stop at , or ; unless they:
-        QuotedString('"') ^                   # appear in "quoted strings"
-        QuotedString("'") ^                   # appear in 'quoted strings'
-        nestedExpr(opener='(', closer=')') ^  # appear in matched (...) expressions
-        nestedExpr(opener='[', closer=']') ^  # appear in matched [...] expressions
-        nestedExpr(opener='{', closer='}') ^  # appear in matched {...} expressions
-        nestedExpr(opener='<', closer='>')    # appear in matched <...> expressions
+        QuotedString('"') ^  # parse double quoted strings
+        QuotedString("'") ^  # parse single quoted strings
+        Word(printables, excludeChars="(){}[]<>,;") ^  # parse arbitrary words
+        nestedExpr(opener='(', closer=')') ^  # parse expression in parentheses
+        nestedExpr(opener='[', closer=']') ^  # parse expression in brackets
+        nestedExpr(opener='{', closer='}') ^  # parse expression in braces
+        nestedExpr(opener='<', closer='>')  # parse template expressions
     ))
 
 CONST, VIRTUAL, CLASS, STATIC, PAIR, TEMPLATE, TYPEDEF, INCLUDE = map(

--- a/gtwrap/interface_parser/tokens.py
+++ b/gtwrap/interface_parser/tokens.py
@@ -32,7 +32,7 @@ NUMBER_OR_STRING = (pyparsing_common.number ^ QuotedString('"', unquoteResults=F
 TUPLE = (LPAREN + delimitedList(NUMBER_OR_STRING) + RPAREN)
 
 # Default argument passed to functions/methods.
-DEFAULT_ARG = (NUMBER_OR_STRING ^ pyparsing_common.identifier ^ TUPLE)
+BASIC_DEFAULT_ARG = (NUMBER_OR_STRING ^ pyparsing_common.identifier ^ TUPLE)
 
 CONST, VIRTUAL, CLASS, STATIC, PAIR, TEMPLATE, TYPEDEF, INCLUDE = map(
     Keyword,

--- a/gtwrap/interface_parser/tokens.py
+++ b/gtwrap/interface_parser/tokens.py
@@ -11,7 +11,7 @@ Author: Duy Nguyen Ta, Fan Jiang, Matthew Sklar, Varun Agrawal, and Frank Dellae
 """
 
 from pyparsing import (Keyword, Literal, Or, QuotedString, Suppress, Word,
-                       ZeroOrMore, alphanums, alphas, nestedExpr, nums,
+                       ZeroOrMore, OneOrMore, alphanums, alphas, nestedExpr, nums,
                        originalTextFor, printables, pyparsing_common)
 
 # rule for identifiers (e.g. variable names)
@@ -37,8 +37,15 @@ TEMPLATED_ARG = originalTextFor(
     ZeroOrMore(Word(printables, excludeChars='>')) + Literal('>') +
     nestedExpr())
 # Default argument passed to functions/methods.
-DEFAULT_ARG = (NUMBER_OR_STRING | TEMPLATED_ARG | PARAMETERIZED_ARG
-               | BASIC_ARG)
+DEFAULT_ARG = originalTextFor(
+    OneOrMore(
+        QuotedString('"') ^  #
+        QuotedString("'") ^  #
+        nestedExpr(opener='(', closer=')') ^  #
+        nestedExpr(opener='[', closer=']') ^  #
+        nestedExpr(opener='{', closer='}') ^  #
+        nestedExpr(opener='<', closer='>') ^  #
+        Word(printables, excludeChars="(){}[]<>,;")))
 
 CONST, VIRTUAL, CLASS, STATIC, PAIR, TEMPLATE, TYPEDEF, INCLUDE = map(
     Keyword,

--- a/gtwrap/interface_parser/type.py
+++ b/gtwrap/interface_parser/type.py
@@ -16,8 +16,8 @@ from typing import Iterable, List, Union
 
 from pyparsing import Forward, Optional, Or, ParseResults, delimitedList
 
-from .tokens import (BASIS_TYPES, CONST, IDENT, LOPBRACK, RAW_POINTER, REF,
-                     ROPBRACK, SHARED_POINTER)
+from .tokens import (BASIS_TYPES, CONST, IDENT, LOPBRACK, LPAREN, RAW_POINTER,
+                     REF, ROPBRACK, RPAREN, SHARED_POINTER)
 
 
 class Typename:
@@ -316,3 +316,8 @@ class TemplatedType:
             (self.is_const
              or self.typename.name in ["Matrix", "Vector"]) else "",
             typename=typename))
+
+
+# Helper rule for object based default args.
+CUSTOM_DEFAULT_ARG = ((Type.rule ^ TemplatedType.rule) +
+                      Optional(LPAREN + RPAREN)("default_has_parens"))

--- a/gtwrap/interface_parser/type.py
+++ b/gtwrap/interface_parser/type.py
@@ -16,8 +16,8 @@ from typing import Iterable, List, Union
 
 from pyparsing import Forward, Optional, Or, ParseResults, delimitedList
 
-from .tokens import (BASIS_TYPES, CONST, IDENT, LOPBRACK, LPAREN, RAW_POINTER,
-                     REF, ROPBRACK, RPAREN, SHARED_POINTER)
+from .tokens import (BASIS_TYPES, CONST, IDENT, LOPBRACK, RAW_POINTER, REF,
+                     ROPBRACK, SHARED_POINTER)
 
 
 class Typename:
@@ -316,8 +316,3 @@ class TemplatedType:
             (self.is_const
              or self.typename.name in ["Matrix", "Vector"]) else "",
             typename=typename))
-
-
-# Helper rule for object based default args.
-CUSTOM_DEFAULT_ARG = ((Type.rule ^ TemplatedType.rule) +
-                      Optional(LPAREN + RPAREN)("default_has_parens"))

--- a/gtwrap/interface_parser/variable.py
+++ b/gtwrap/interface_parser/variable.py
@@ -12,8 +12,8 @@ Author: Varun Agrawal, Gerry Chen
 
 from pyparsing import Optional, ParseResults
 
-from .tokens import BASIC_DEFAULT_ARG, EQUAL, IDENT, SEMI_COLON
-from .type import CUSTOM_DEFAULT_ARG, TemplatedType, Type
+from .tokens import DEFAULT_ARG, EQUAL, IDENT, SEMI_COLON
+from .type import TemplatedType, Type
 
 
 class Variable:
@@ -32,28 +32,21 @@ class Variable:
     """
     rule = ((Type.rule ^ TemplatedType.rule)("ctype")  #
             + IDENT("name")  #
-            + Optional(EQUAL +
-                       (BASIC_DEFAULT_ARG ^ CUSTOM_DEFAULT_ARG))("default")  #
+            + Optional(EQUAL + DEFAULT_ARG)("default")  #
             + SEMI_COLON  #
-            ).setParseAction(lambda t: Variable(t.ctype, t.name, t.default, t.
-                                                default_has_parens != ''))
+            ).setParseAction(lambda t: Variable(
+                t.ctype,  #
+                t.name,  #
+                t.default[0] if isinstance(t.default, ParseResults) else None))
 
     def __init__(self,
                  ctype: Type,
                  name: str,
                  default: ParseResults = None,
-                 default_has_parens: bool = None,
                  parent=''):
         self.ctype = ctype[0]  # ParseResult is a list
         self.name = name
-        if default:
-            self.default = default[0]
-        else:
-            self.default = None
-
-        # If parsed type is not empty str, then parentheses exist
-        self.default_has_parens = default_has_parens
-
+        self.default = default
         self.parent = parent
 
     def __repr__(self) -> str:

--- a/gtwrap/interface_parser/variable.py
+++ b/gtwrap/interface_parser/variable.py
@@ -12,8 +12,8 @@ Author: Varun Agrawal, Gerry Chen
 
 from pyparsing import Optional, ParseResults
 
-from .tokens import DEFAULT_ARG, EQUAL, IDENT, SEMI_COLON, STATIC
-from .type import TemplatedType, Type
+from .tokens import BASIC_DEFAULT_ARG, EQUAL, IDENT, SEMI_COLON
+from .type import CUSTOM_DEFAULT_ARG, TemplatedType, Type
 
 
 class Variable:
@@ -32,15 +32,17 @@ class Variable:
     """
     rule = ((Type.rule ^ TemplatedType.rule)("ctype")  #
             + IDENT("name")  #
-            #TODO(Varun) Add support for non-basic types
-            + Optional(EQUAL + (DEFAULT_ARG))("default")  #
+            + Optional(EQUAL +
+                       (BASIC_DEFAULT_ARG ^ CUSTOM_DEFAULT_ARG))("default")  #
             + SEMI_COLON  #
-            ).setParseAction(lambda t: Variable(t.ctype, t.name, t.default))
+            ).setParseAction(lambda t: Variable(t.ctype, t.name, t.default, t.
+                                                default_has_parens != ''))
 
     def __init__(self,
                  ctype: Type,
                  name: str,
                  default: ParseResults = None,
+                 default_has_parens: bool = None,
                  parent=''):
         self.ctype = ctype[0]  # ParseResult is a list
         self.name = name
@@ -48,6 +50,9 @@ class Variable:
             self.default = default[0]
         else:
             self.default = None
+
+        # If parsed type is not empty str, then parentheses exist
+        self.default_has_parens = default_has_parens
 
         self.parent = parent
 

--- a/gtwrap/pybind_wrapper.py
+++ b/gtwrap/pybind_wrapper.py
@@ -48,7 +48,8 @@ class PybindWrapper:
             py_args = []
             for arg in args_list.args_list:
                 if arg.default is not None:
-                    arg.default = ' = {arg.default}'.format(arg=arg)
+                    arg.default = ' = {arg.default}{parens}'.format(
+                        arg=arg, parens="()" if arg.default_has_parens else '')
                 else:
                     arg.default = ''
                 argument = 'py::arg("{name}"){default}'.format(
@@ -291,10 +292,7 @@ class PybindWrapper:
 
         for enum in enums:
             res += "\n" + self.wrap_enum(
-                enum,
-                class_name=cpp_class,
-                module=module_var,
-                prefix=prefix)
+                enum, class_name=cpp_class, module=module_var, prefix=prefix)
         return res
 
     def wrap_instantiated_class(

--- a/gtwrap/pybind_wrapper.py
+++ b/gtwrap/pybind_wrapper.py
@@ -48,8 +48,7 @@ class PybindWrapper:
             py_args = []
             for arg in args_list.args_list:
                 if arg.default is not None:
-                    arg.default = ' = {arg.default}{parens}'.format(
-                        arg=arg, parens="()" if arg.default_has_parens else '')
+                    arg.default = ' = {arg.default}'.format(arg=arg)
                 else:
                     arg.default = ''
                 argument = 'py::arg("{name}"){default}'.format(

--- a/gtwrap/template_instantiator.py
+++ b/gtwrap/template_instantiator.py
@@ -95,12 +95,9 @@ def instantiate_args_list(args_list, template_typenames, instantiations,
     for arg in args_list:
         new_type = instantiate_type(arg.ctype, template_typenames,
                                     instantiations, cpp_typename)
-        default = [arg.default] if isinstance(arg, parser.Argument) else ''
         instantiated_args.append(
-            parser.Argument(name=arg.name,
-                            ctype=new_type,
-                            default=default,
-                            default_has_parens=arg.default_has_parens))
+            parser.Argument(name=arg.name, ctype=new_type,
+                            default=arg.default))
     return instantiated_args
 
 

--- a/gtwrap/template_instantiator.py
+++ b/gtwrap/template_instantiator.py
@@ -96,9 +96,11 @@ def instantiate_args_list(args_list, template_typenames, instantiations,
         new_type = instantiate_type(arg.ctype, template_typenames,
                                     instantiations, cpp_typename)
         default = [arg.default] if isinstance(arg, parser.Argument) else ''
-        instantiated_args.append(parser.Argument(name=arg.name,
-                                                 ctype=new_type,
-                                                 default=default))
+        instantiated_args.append(
+            parser.Argument(name=arg.name,
+                            ctype=new_type,
+                            default=default,
+                            default_has_parens=arg.default_has_parens))
     return instantiated_args
 
 

--- a/tests/expected/matlab/MyFactorPosePoint2.m
+++ b/tests/expected/matlab/MyFactorPosePoint2.m
@@ -15,9 +15,9 @@ classdef MyFactorPosePoint2 < handle
     function obj = MyFactorPosePoint2(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(52, my_ptr);
+        class_wrapper(55, my_ptr);
       elseif nargin == 4 && isa(varargin{1},'numeric') && isa(varargin{2},'numeric') && isa(varargin{3},'double') && isa(varargin{4},'gtsam.noiseModel.Base')
-        my_ptr = class_wrapper(53, varargin{1}, varargin{2}, varargin{3}, varargin{4});
+        my_ptr = class_wrapper(56, varargin{1}, varargin{2}, varargin{3}, varargin{4});
       else
         error('Arguments do not match any overload of MyFactorPosePoint2 constructor');
       end
@@ -25,7 +25,7 @@ classdef MyFactorPosePoint2 < handle
     end
 
     function delete(obj)
-      class_wrapper(54, obj.ptr_MyFactorPosePoint2);
+      class_wrapper(57, obj.ptr_MyFactorPosePoint2);
     end
 
     function display(obj), obj.print(''); end
@@ -36,7 +36,7 @@ classdef MyFactorPosePoint2 < handle
       % PRINT usage: print(string s, KeyFormatter keyFormatter) : returns void
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 2 && isa(varargin{1},'char') && isa(varargin{2},'gtsam.KeyFormatter')
-        class_wrapper(55, this, varargin{:});
+        class_wrapper(58, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function MyFactorPosePoint2.print');

--- a/tests/expected/matlab/TemplatedFunctionRot3.m
+++ b/tests/expected/matlab/TemplatedFunctionRot3.m
@@ -1,6 +1,6 @@
 function varargout = TemplatedFunctionRot3(varargin)
       if length(varargin) == 1 && isa(varargin{1},'gtsam.Rot3')
-        functions_wrapper(12, varargin{:});
+        functions_wrapper(13, varargin{:});
       else
         error('Arguments do not match any overload of function TemplatedFunctionRot3');
       end

--- a/tests/expected/matlab/class_wrapper.cpp
+++ b/tests/expected/matlab/class_wrapper.cpp
@@ -33,6 +33,8 @@ typedef std::set<boost::shared_ptr<MultipleTemplatesIntDouble>*> Collector_Multi
 static Collector_MultipleTemplatesIntDouble collector_MultipleTemplatesIntDouble;
 typedef std::set<boost::shared_ptr<MultipleTemplatesIntFloat>*> Collector_MultipleTemplatesIntFloat;
 static Collector_MultipleTemplatesIntFloat collector_MultipleTemplatesIntFloat;
+typedef std::set<boost::shared_ptr<ForwardKinematics>*> Collector_ForwardKinematics;
+static Collector_ForwardKinematics collector_ForwardKinematics;
 typedef std::set<boost::shared_ptr<MyFactorPosePoint2>*> Collector_MyFactorPosePoint2;
 static Collector_MyFactorPosePoint2 collector_MyFactorPosePoint2;
 
@@ -88,6 +90,12 @@ void _deleteAllObjects()
       iter != collector_MultipleTemplatesIntFloat.end(); ) {
     delete *iter;
     collector_MultipleTemplatesIntFloat.erase(iter++);
+    anyDeleted = true;
+  } }
+  { for(Collector_ForwardKinematics::iterator iter = collector_ForwardKinematics.begin();
+      iter != collector_ForwardKinematics.end(); ) {
+    delete *iter;
+    collector_ForwardKinematics.erase(iter++);
     anyDeleted = true;
   } }
   { for(Collector_MyFactorPosePoint2::iterator iter = collector_MyFactorPosePoint2.begin();
@@ -624,7 +632,45 @@ void MultipleTemplatesIntFloat_deconstructor_51(int nargout, mxArray *out[], int
   }
 }
 
-void MyFactorPosePoint2_collectorInsertAndMakeBase_52(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void ForwardKinematics_collectorInsertAndMakeBase_52(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  mexAtExit(&_deleteAllObjects);
+  typedef boost::shared_ptr<ForwardKinematics> Shared;
+
+  Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
+  collector_ForwardKinematics.insert(self);
+}
+
+void ForwardKinematics_constructor_53(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  mexAtExit(&_deleteAllObjects);
+  typedef boost::shared_ptr<ForwardKinematics> Shared;
+
+  gtdynamics::Robot& robot = *unwrap_shared_ptr< gtdynamics::Robot >(in[0], "ptr_gtdynamicsRobot");
+  string& start_link_name = *unwrap_shared_ptr< string >(in[1], "ptr_string");
+  string& end_link_name = *unwrap_shared_ptr< string >(in[2], "ptr_string");
+  gtsam::Values& joint_angles = *unwrap_shared_ptr< gtsam::Values >(in[3], "ptr_gtsamValues");
+  gtsam::Pose3& l2Tp = *unwrap_shared_ptr< gtsam::Pose3 >(in[4], "ptr_gtsamPose3");
+  Shared *self = new Shared(new ForwardKinematics(robot,start_link_name,end_link_name,joint_angles,l2Tp));
+  collector_ForwardKinematics.insert(self);
+  out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
+  *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
+}
+
+void ForwardKinematics_deconstructor_54(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  typedef boost::shared_ptr<ForwardKinematics> Shared;
+  checkArguments("delete_ForwardKinematics",nargout,nargin,1);
+  Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
+  Collector_ForwardKinematics::iterator item;
+  item = collector_ForwardKinematics.find(self);
+  if(item != collector_ForwardKinematics.end()) {
+    delete self;
+    collector_ForwardKinematics.erase(item);
+  }
+}
+
+void MyFactorPosePoint2_collectorInsertAndMakeBase_55(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>> Shared;
@@ -633,7 +679,7 @@ void MyFactorPosePoint2_collectorInsertAndMakeBase_52(int nargout, mxArray *out[
   collector_MyFactorPosePoint2.insert(self);
 }
 
-void MyFactorPosePoint2_constructor_53(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyFactorPosePoint2_constructor_56(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>> Shared;
@@ -648,7 +694,7 @@ void MyFactorPosePoint2_constructor_53(int nargout, mxArray *out[], int nargin, 
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void MyFactorPosePoint2_deconstructor_54(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyFactorPosePoint2_deconstructor_57(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>> Shared;
   checkArguments("delete_MyFactorPosePoint2",nargout,nargin,1);
@@ -661,7 +707,7 @@ void MyFactorPosePoint2_deconstructor_54(int nargout, mxArray *out[], int nargin
   }
 }
 
-void MyFactorPosePoint2_print_55(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyFactorPosePoint2_print_58(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("print",nargout,nargin-1,2);
   auto obj = unwrap_shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>>(in[0], "ptr_MyFactorPosePoint2");
@@ -839,16 +885,25 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       MultipleTemplatesIntFloat_deconstructor_51(nargout, out, nargin-1, in+1);
       break;
     case 52:
-      MyFactorPosePoint2_collectorInsertAndMakeBase_52(nargout, out, nargin-1, in+1);
+      ForwardKinematics_collectorInsertAndMakeBase_52(nargout, out, nargin-1, in+1);
       break;
     case 53:
-      MyFactorPosePoint2_constructor_53(nargout, out, nargin-1, in+1);
+      ForwardKinematics_constructor_53(nargout, out, nargin-1, in+1);
       break;
     case 54:
-      MyFactorPosePoint2_deconstructor_54(nargout, out, nargin-1, in+1);
+      ForwardKinematics_deconstructor_54(nargout, out, nargin-1, in+1);
       break;
     case 55:
-      MyFactorPosePoint2_print_55(nargout, out, nargin-1, in+1);
+      MyFactorPosePoint2_collectorInsertAndMakeBase_55(nargout, out, nargin-1, in+1);
+      break;
+    case 56:
+      MyFactorPosePoint2_constructor_56(nargout, out, nargin-1, in+1);
+      break;
+    case 57:
+      MyFactorPosePoint2_deconstructor_57(nargout, out, nargin-1, in+1);
+      break;
+    case 58:
+      MyFactorPosePoint2_print_58(nargout, out, nargin-1, in+1);
       break;
     }
   } catch(const std::exception& e) {

--- a/tests/expected/matlab/functions_wrapper.cpp
+++ b/tests/expected/matlab/functions_wrapper.cpp
@@ -33,6 +33,8 @@ typedef std::set<boost::shared_ptr<MultipleTemplatesIntDouble>*> Collector_Multi
 static Collector_MultipleTemplatesIntDouble collector_MultipleTemplatesIntDouble;
 typedef std::set<boost::shared_ptr<MultipleTemplatesIntFloat>*> Collector_MultipleTemplatesIntFloat;
 static Collector_MultipleTemplatesIntFloat collector_MultipleTemplatesIntFloat;
+typedef std::set<boost::shared_ptr<ForwardKinematics>*> Collector_ForwardKinematics;
+static Collector_ForwardKinematics collector_ForwardKinematics;
 typedef std::set<boost::shared_ptr<MyFactorPosePoint2>*> Collector_MyFactorPosePoint2;
 static Collector_MyFactorPosePoint2 collector_MyFactorPosePoint2;
 
@@ -88,6 +90,12 @@ void _deleteAllObjects()
       iter != collector_MultipleTemplatesIntFloat.end(); ) {
     delete *iter;
     collector_MultipleTemplatesIntFloat.erase(iter++);
+    anyDeleted = true;
+  } }
+  { for(Collector_ForwardKinematics::iterator iter = collector_ForwardKinematics.begin();
+      iter != collector_ForwardKinematics.end(); ) {
+    delete *iter;
+    collector_ForwardKinematics.erase(iter++);
     anyDeleted = true;
   } }
   { for(Collector_MyFactorPosePoint2::iterator iter = collector_MyFactorPosePoint2.begin();
@@ -226,7 +234,13 @@ void DefaultFuncZero_11(int nargout, mxArray *out[], int nargin, const mxArray *
   bool e = unwrap< bool >(in[4]);
   DefaultFuncZero(a,b,c,d,e);
 }
-void TemplatedFunctionRot3_12(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void setPose_12(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("setPose",nargout,nargin,1);
+  gtsam::Pose3& pose = *unwrap_shared_ptr< gtsam::Pose3 >(in[0], "ptr_gtsamPose3");
+  setPose(pose);
+}
+void TemplatedFunctionRot3_13(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("TemplatedFunctionRot3",nargout,nargin,1);
   gtsam::Rot3& t = *unwrap_shared_ptr< gtsam::Rot3 >(in[0], "ptr_gtsamRot3");
@@ -281,7 +295,10 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       DefaultFuncZero_11(nargout, out, nargin-1, in+1);
       break;
     case 12:
-      TemplatedFunctionRot3_12(nargout, out, nargin-1, in+1);
+      setPose_12(nargout, out, nargin-1, in+1);
+      break;
+    case 13:
+      TemplatedFunctionRot3_13(nargout, out, nargin-1, in+1);
       break;
     }
   } catch(const std::exception& e) {

--- a/tests/expected/matlab/geometry_wrapper.cpp
+++ b/tests/expected/matlab/geometry_wrapper.cpp
@@ -36,6 +36,8 @@ typedef std::set<boost::shared_ptr<MultipleTemplatesIntDouble>*> Collector_Multi
 static Collector_MultipleTemplatesIntDouble collector_MultipleTemplatesIntDouble;
 typedef std::set<boost::shared_ptr<MultipleTemplatesIntFloat>*> Collector_MultipleTemplatesIntFloat;
 static Collector_MultipleTemplatesIntFloat collector_MultipleTemplatesIntFloat;
+typedef std::set<boost::shared_ptr<ForwardKinematics>*> Collector_ForwardKinematics;
+static Collector_ForwardKinematics collector_ForwardKinematics;
 typedef std::set<boost::shared_ptr<MyFactorPosePoint2>*> Collector_MyFactorPosePoint2;
 static Collector_MyFactorPosePoint2 collector_MyFactorPosePoint2;
 typedef std::set<boost::shared_ptr<gtsam::Point2>*> Collector_gtsamPoint2;
@@ -95,6 +97,12 @@ void _deleteAllObjects()
       iter != collector_MultipleTemplatesIntFloat.end(); ) {
     delete *iter;
     collector_MultipleTemplatesIntFloat.erase(iter++);
+    anyDeleted = true;
+  } }
+  { for(Collector_ForwardKinematics::iterator iter = collector_ForwardKinematics.begin();
+      iter != collector_ForwardKinematics.end(); ) {
+    delete *iter;
+    collector_ForwardKinematics.erase(iter++);
     anyDeleted = true;
   } }
   { for(Collector_MyFactorPosePoint2::iterator iter = collector_MyFactorPosePoint2.begin();

--- a/tests/expected/matlab/inheritance_wrapper.cpp
+++ b/tests/expected/matlab/inheritance_wrapper.cpp
@@ -38,6 +38,8 @@ typedef std::set<boost::shared_ptr<MultipleTemplatesIntDouble>*> Collector_Multi
 static Collector_MultipleTemplatesIntDouble collector_MultipleTemplatesIntDouble;
 typedef std::set<boost::shared_ptr<MultipleTemplatesIntFloat>*> Collector_MultipleTemplatesIntFloat;
 static Collector_MultipleTemplatesIntFloat collector_MultipleTemplatesIntFloat;
+typedef std::set<boost::shared_ptr<ForwardKinematics>*> Collector_ForwardKinematics;
+static Collector_ForwardKinematics collector_ForwardKinematics;
 typedef std::set<boost::shared_ptr<MyFactorPosePoint2>*> Collector_MyFactorPosePoint2;
 static Collector_MyFactorPosePoint2 collector_MyFactorPosePoint2;
 typedef std::set<boost::shared_ptr<gtsam::Point2>*> Collector_gtsamPoint2;
@@ -105,6 +107,12 @@ void _deleteAllObjects()
       iter != collector_MultipleTemplatesIntFloat.end(); ) {
     delete *iter;
     collector_MultipleTemplatesIntFloat.erase(iter++);
+    anyDeleted = true;
+  } }
+  { for(Collector_ForwardKinematics::iterator iter = collector_ForwardKinematics.begin();
+      iter != collector_ForwardKinematics.end(); ) {
+    delete *iter;
+    collector_ForwardKinematics.erase(iter++);
     anyDeleted = true;
   } }
   { for(Collector_MyFactorPosePoint2::iterator iter = collector_MyFactorPosePoint2.begin();

--- a/tests/expected/matlab/namespaces_wrapper.cpp
+++ b/tests/expected/matlab/namespaces_wrapper.cpp
@@ -43,6 +43,8 @@ typedef std::set<boost::shared_ptr<MultipleTemplatesIntDouble>*> Collector_Multi
 static Collector_MultipleTemplatesIntDouble collector_MultipleTemplatesIntDouble;
 typedef std::set<boost::shared_ptr<MultipleTemplatesIntFloat>*> Collector_MultipleTemplatesIntFloat;
 static Collector_MultipleTemplatesIntFloat collector_MultipleTemplatesIntFloat;
+typedef std::set<boost::shared_ptr<ForwardKinematics>*> Collector_ForwardKinematics;
+static Collector_ForwardKinematics collector_ForwardKinematics;
 typedef std::set<boost::shared_ptr<MyFactorPosePoint2>*> Collector_MyFactorPosePoint2;
 static Collector_MyFactorPosePoint2 collector_MyFactorPosePoint2;
 typedef std::set<boost::shared_ptr<gtsam::Point2>*> Collector_gtsamPoint2;
@@ -122,6 +124,12 @@ void _deleteAllObjects()
       iter != collector_MultipleTemplatesIntFloat.end(); ) {
     delete *iter;
     collector_MultipleTemplatesIntFloat.erase(iter++);
+    anyDeleted = true;
+  } }
+  { for(Collector_ForwardKinematics::iterator iter = collector_ForwardKinematics.begin();
+      iter != collector_ForwardKinematics.end(); ) {
+    delete *iter;
+    collector_ForwardKinematics.erase(iter++);
     anyDeleted = true;
   } }
   { for(Collector_MyFactorPosePoint2::iterator iter = collector_MyFactorPosePoint2.begin();

--- a/tests/expected/matlab/special_cases_wrapper.cpp
+++ b/tests/expected/matlab/special_cases_wrapper.cpp
@@ -46,6 +46,8 @@ typedef std::set<boost::shared_ptr<MultipleTemplatesIntDouble>*> Collector_Multi
 static Collector_MultipleTemplatesIntDouble collector_MultipleTemplatesIntDouble;
 typedef std::set<boost::shared_ptr<MultipleTemplatesIntFloat>*> Collector_MultipleTemplatesIntFloat;
 static Collector_MultipleTemplatesIntFloat collector_MultipleTemplatesIntFloat;
+typedef std::set<boost::shared_ptr<ForwardKinematics>*> Collector_ForwardKinematics;
+static Collector_ForwardKinematics collector_ForwardKinematics;
 typedef std::set<boost::shared_ptr<MyFactorPosePoint2>*> Collector_MyFactorPosePoint2;
 static Collector_MyFactorPosePoint2 collector_MyFactorPosePoint2;
 typedef std::set<boost::shared_ptr<gtsam::Point2>*> Collector_gtsamPoint2;
@@ -133,6 +135,12 @@ void _deleteAllObjects()
       iter != collector_MultipleTemplatesIntFloat.end(); ) {
     delete *iter;
     collector_MultipleTemplatesIntFloat.erase(iter++);
+    anyDeleted = true;
+  } }
+  { for(Collector_ForwardKinematics::iterator iter = collector_ForwardKinematics.begin();
+      iter != collector_ForwardKinematics.end(); ) {
+    delete *iter;
+    collector_ForwardKinematics.erase(iter++);
     anyDeleted = true;
   } }
   { for(Collector_MyFactorPosePoint2::iterator iter = collector_MyFactorPosePoint2.begin();

--- a/tests/expected/python/class_pybind.cpp
+++ b/tests/expected/python/class_pybind.cpp
@@ -82,6 +82,9 @@ PYBIND11_MODULE(class_py, m_) {
 
     py::class_<MultipleTemplates<int, float>, std::shared_ptr<MultipleTemplates<int, float>>>(m_, "MultipleTemplatesIntFloat");
 
+    py::class_<ForwardKinematics, std::shared_ptr<ForwardKinematics>>(m_, "ForwardKinematics")
+        .def(py::init<const gtdynamics::Robot&, const string&, const string&, const gtsam::Values&, const gtsam::Pose3&>(), py::arg("robot"), py::arg("start_link_name"), py::arg("end_link_name"), py::arg("joint_angles"), py::arg("l2Tp") = gtsam::Pose3());
+
     py::class_<MyFactor<gtsam::Pose2, gtsam::Matrix>, std::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>>>(m_, "MyFactorPosePoint2")
         .def(py::init<size_t, size_t, double, const std::shared_ptr<gtsam::noiseModel::Base>>(), py::arg("key1"), py::arg("key2"), py::arg("measured"), py::arg("noiseModel"))
         .def("print_",[](MyFactor<gtsam::Pose2, gtsam::Matrix>* self, const string& s, const gtsam::KeyFormatter& keyFormatter){ py::scoped_ostream_redirect output; self->print(s, keyFormatter);}, py::arg("s") = "factor: ", py::arg("keyFormatter") = gtsam::DefaultKeyFormatter)

--- a/tests/expected/python/functions_pybind.cpp
+++ b/tests/expected/python/functions_pybind.cpp
@@ -34,6 +34,7 @@ PYBIND11_MODULE(functions_py, m_) {
     m_.def("DefaultFuncString",[](const string& s, const string& name){ ::DefaultFuncString(s, name);}, py::arg("s") = "hello", py::arg("name") = "");
     m_.def("DefaultFuncObj",[](const gtsam::KeyFormatter& keyFormatter){ ::DefaultFuncObj(keyFormatter);}, py::arg("keyFormatter") = gtsam::DefaultKeyFormatter);
     m_.def("DefaultFuncZero",[](int a, int b, double c, bool d, bool e){ ::DefaultFuncZero(a, b, c, d, e);}, py::arg("a") = 0, py::arg("b"), py::arg("c") = 0.0, py::arg("d") = false, py::arg("e"));
+    m_.def("setPose",[](const gtsam::Pose3& pose){ ::setPose(pose);}, py::arg("pose") = gtsam::Pose3());
     m_.def("TemplatedFunctionRot3",[](const gtsam::Rot3& t){ ::TemplatedFunction<Rot3>(t);}, py::arg("t"));
 
 #include "python/specializations.h"

--- a/tests/fixtures/class.i
+++ b/tests/fixtures/class.i
@@ -106,3 +106,11 @@ class MyVector {
 // Class with multiple instantiated templates
 template<T = {int}, U = {double, float}>
 class MultipleTemplates {};
+
+// Test for default args in constructor
+class ForwardKinematics {
+  ForwardKinematics(const gtdynamics::Robot& robot,
+                    const string& start_link_name, const string& end_link_name,
+                    const gtsam::Values& joint_angles,
+                    const gtsam::Pose3& l2Tp = gtsam::Pose3());
+};

--- a/tests/fixtures/functions.i
+++ b/tests/fixtures/functions.i
@@ -32,3 +32,6 @@ void DefaultFuncInt(int a = 123, int b = 0);
 void DefaultFuncString(const string& s = "hello", const string& name = "");
 void DefaultFuncObj(const gtsam::KeyFormatter& keyFormatter = gtsam::DefaultKeyFormatter);
 void DefaultFuncZero(int a = 0, int b, double c = 0.0, bool d = false, bool e);
+
+// Test for non-trivial default constructor
+void setPose(const gtsam::Pose3& pose = gtsam::Pose3());

--- a/tests/test_interface_parser.py
+++ b/tests/test_interface_parser.py
@@ -182,25 +182,26 @@ class TestInterfaceParser(unittest.TestCase):
         """Tests any expression that is a valid default argument"""
         args = ArgumentList.rule.parseString("""
             string c = "", int z = 0, double z2 = 0.0, bool f = false,
-            string s="hello", char c='a', int a=3,
+            string s="hello"+"goodbye", char c='a', int a=3,
             int b, double pi = 3.1415""")[0].args_list
 
         # Test for basic types
         self.assertEqual(args[0].default, '""')
-        self.assertEqual(args[1].default, 0)
-        self.assertEqual(args[2].default, 0)
+        self.assertEqual(args[1].default, '0')
+        self.assertEqual(args[2].default, '0.0')
         self.assertEqual(args[3].default, "false")
-        self.assertEqual(args[4].default, '"hello"')
+        self.assertEqual(args[4].default, '"hello"+"goodbye"')
         self.assertEqual(args[5].default, "'a'")
-        self.assertEqual(args[6].default, 3)
+        self.assertEqual(args[6].default, '3')
         # No default argument should set `default` to None
         self.assertIsNone(args[7].default)
-        self.assertEqual(args[8].default, 3.1415)
+        self.assertEqual(args[8].default, '3.1415')
 
         args = ArgumentList.rule.parseString("""
             gtsam::KeyFormatter kf = gtsam::DefaultKeyFormatter,
             std::vector<size_t> v = std::vector<size_t>(),
-            std::vector<size_t> l = {},
+            std::vector<size_t> l = {1, 2},
+            gtsam::KeyFormatter lambda = [&c1, &c2](string s=5, int a){return s+"hello"+a+c1+c2;},
             gtsam::Pose3 p = gtsam::Pose3(),
             Factor<gtsam::Pose3, gtsam::Point3> x = Factor<gtsam::Pose3, gtsam::Point3>(),
             gtsam::Point3 x = gtsam::Point3(1, 2, 3),
@@ -211,15 +212,16 @@ class TestInterfaceParser(unittest.TestCase):
         self.assertEqual(args[0].default, 'gtsam::DefaultKeyFormatter')
         # Test templated type
         self.assertEqual(args[1].default, 'std::vector<size_t>()')
-        self.assertEqual(args[2].default, '{}')
-        self.assertEqual(args[3].default, 'gtsam::Pose3()')
+        self.assertEqual(args[2].default, '{1, 2}')
+        self.assertEqual(args[3].default, '[&c1, &c2](string s=5, int a){return s+"hello"+a+c1+c2;}')
+        self.assertEqual(args[4].default, 'gtsam::Pose3()')
         # Test for allowing multiple templates in default argument
-        self.assertEqual(args[4].default,
+        self.assertEqual(args[5].default,
                          'Factor<gtsam::Pose3, gtsam::Point3>()')
         # Test for default argument with params
-        self.assertEqual(args[5].default, 'gtsam::Point3(1, 2, 3)')
+        self.assertEqual(args[6].default, 'gtsam::Point3(1, 2, 3)')
         # Test for default argument with multiple templates and params
-        self.assertEqual(args[6].default, 'ns::Class<T, U>(3, 2, 1, "name")')
+        self.assertEqual(args[7].default, 'ns::Class<T, U>(3, 2, 1, "name")')
 
     def test_return_type(self):
         """Test ReturnType"""
@@ -504,14 +506,14 @@ class TestInterfaceParser(unittest.TestCase):
         variable = Variable.rule.parseString("string kGravity = 9.81;")[0]
         self.assertEqual(variable.name, "kGravity")
         self.assertEqual(variable.ctype.typename.name, "string")
-        self.assertEqual(variable.default, 9.81)
+        self.assertEqual(variable.default, "9.81")
 
         variable = Variable.rule.parseString(
             "const string kGravity = 9.81;")[0]
         self.assertEqual(variable.name, "kGravity")
         self.assertEqual(variable.ctype.typename.name, "string")
         self.assertTrue(variable.ctype.is_const)
-        self.assertEqual(variable.default, 9.81)
+        self.assertEqual(variable.default, "9.81")
 
         variable = Variable.rule.parseString(
             "gtsam::Pose3 wTc = gtsam::Pose3();")[0]

--- a/tests/test_interface_parser.py
+++ b/tests/test_interface_parser.py
@@ -203,7 +203,8 @@ class TestInterfaceParser(unittest.TestCase):
             std::vector<size_t> l = {},
             gtsam::Pose3 p = gtsam::Pose3(),
             Factor<gtsam::Pose3, gtsam::Point3> x = Factor<gtsam::Pose3, gtsam::Point3>(),
-            gtsam::Point3 x = gtsam::Point3(1, 2)
+            gtsam::Point3 x = gtsam::Point3(1, 2, 3),
+            ns::Class<T, U> obj = ns::Class<T, U>(3, 2, 1, "name")
             """)[0].args_list
 
         # Test non-basic type
@@ -216,7 +217,9 @@ class TestInterfaceParser(unittest.TestCase):
         self.assertEqual(args[4].default,
                          'Factor<gtsam::Pose3, gtsam::Point3>()')
         # Test for default argument with params
-        self.assertEqual(args[5].default, 'gtsam::Point3(1, 2)')
+        self.assertEqual(args[5].default, 'gtsam::Point3(1, 2, 3)')
+        # Test for default argument with multiple templates and params
+        self.assertEqual(args[6].default, 'ns::Class<T, U>(3, 2, 1, "name")')
 
     def test_return_type(self):
         """Test ReturnType"""

--- a/tests/test_interface_parser.py
+++ b/tests/test_interface_parser.py
@@ -188,7 +188,7 @@ class TestInterfaceParser(unittest.TestCase):
             std::vector<size_t> v = std::vector<size_t>(),
             gtsam::Pose3 p = gtsam::Pose3(),
             std::vector<size_t> l = (1, 2, 'a', "name", "random", 3.1415)"""
-        )[0].args_list
+                                             )[0].args_list
 
         # Test for basic types
         self.assertEqual(args[0].default, '""')
@@ -207,12 +207,14 @@ class TestInterfaceParser(unittest.TestCase):
         self.assertEqual(repr(args[9].default.typename),
                          'gtsam::DefaultKeyFormatter')
         # Test templated type
-        self.assertEqual(repr(args[10].default.typename), 'std::vector<size_t>')
+        self.assertEqual(repr(args[10].default.typename),
+                         'std::vector<size_t>')
         self.assertTrue(args[10].default_has_parens)
         self.assertEqual(repr(args[11].default.typename), 'gtsam::Pose3')
         self.assertTrue(args[11].default_has_parens)
         # Test for allowing list as default argument
-        self.assertEqual(args[12].default, (1, 2, "'a'", '"name"', '"random"', 3.1415))
+        self.assertEqual(args[12].default,
+                         (1, 2, "'a'", '"name"', '"random"', 3.1415))
 
     def test_return_type(self):
         """Test ReturnType"""
@@ -486,6 +488,13 @@ class TestInterfaceParser(unittest.TestCase):
         self.assertEqual(variable.ctype.typename.name, "string")
         self.assertTrue(variable.ctype.is_const)
         self.assertEqual(variable.default, 9.81)
+
+        variable = Variable.rule.parseString(
+            "gtsam::Pose3 wTc = gtsam::Pose3();")[0]
+        self.assertEqual(variable.name, "wTc")
+        self.assertEqual(variable.ctype.typename.name, "Pose3")
+        self.assertEqual(repr(variable.default), "gtsam::Pose3")
+        self.assertTrue(variable.default_has_parens)
 
     def test_enumerator(self):
         """Test for enumerator."""

--- a/tests/test_interface_parser.py
+++ b/tests/test_interface_parser.py
@@ -181,11 +181,12 @@ class TestInterfaceParser(unittest.TestCase):
     def test_default_arguments(self):
         """Tests any expression that is a valid default argument"""
         args = ArgumentList.rule.parseString("""\
-            string c = "", int z = 0, double z2 = 0.0, bool f = false, 
-            string s="hello", char c='a', int a=3, 
-            int b, double pi = 3.1415, 
-            gtsam::KeyFormatter kf = gtsam::DefaultKeyFormatter, 
-            std::vector<size_t> p = std::vector<size_t>(), 
+            string c = "", int z = 0, double z2 = 0.0, bool f = false,
+            string s="hello", char c='a', int a=3,
+            int b, double pi = 3.1415,
+            gtsam::KeyFormatter kf = gtsam::DefaultKeyFormatter,
+            std::vector<size_t> v = std::vector<size_t>(),
+            gtsam::Pose3 p = gtsam::Pose3(),
             std::vector<size_t> l = (1, 2, 'a', "name", "random", 3.1415)"""
         )[0].args_list
 
@@ -207,8 +208,11 @@ class TestInterfaceParser(unittest.TestCase):
                          'gtsam::DefaultKeyFormatter')
         # Test templated type
         self.assertEqual(repr(args[10].default.typename), 'std::vector<size_t>')
+        self.assertTrue(args[10].default_has_parens)
+        self.assertEqual(repr(args[11].default.typename), 'gtsam::Pose3')
+        self.assertTrue(args[11].default_has_parens)
         # Test for allowing list as default argument
-        self.assertEqual(args[11].default, (1, 2, "'a'", '"name"', '"random"', 3.1415))
+        self.assertEqual(args[12].default, (1, 2, "'a'", '"name"', '"random"', 3.1415))
 
     def test_return_type(self):
         """Test ReturnType"""


### PR DESCRIPTION
This PR will allow us to define default arguments for object types via the default constructor.

E.g.
```cpp
void setPose(const gtsam::Pose3& pose = gtsam::Pose3());
```

will assign the default value to `pose`.