### PR TITLE
Allow forward declarations to be used for typedefs

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -100,7 +100,8 @@ The python wrapper supports keyword arguments for functions/methods. Hence, the 
         ```
 
 - Using classes defined in other modules
-    - If you are using a class `OtherClass` not wrapped in an interface file, add `class OtherClass;` as a forward declaration to avoid a dependency error. `OtherClass` should be in the same project.
+    - If you are using a class `OtherClass` not wrapped in an interface file, add `class OtherClass;` as a forward declaration to avoid a dependency error.
+    - `OtherClass` may not be in the same project. If this is the case, include the header for the appropriate project `#include <other_project/OtherClass.h>`.
 
 - Virtual inheritance
     - Specify fully-qualified base classes, i.e. `virtual class Derived : ns::Base {` where `ns` is the namespace.

--- a/gtwrap/interface_parser/declaration.py
+++ b/gtwrap/interface_parser/declaration.py
@@ -15,6 +15,7 @@ from pyparsing import CharsNotIn, Optional
 from .tokens import (CLASS, COLON, INCLUDE, LOPBRACK, ROPBRACK, SEMI_COLON,
                      VIRTUAL)
 from .type import Typename
+from .utils import collect_namespaces
 
 
 class Include:
@@ -47,7 +48,7 @@ class ForwardDeclaration:
                  is_virtual: str,
                  parent: str = ''):
         self.name = typename.name
-        self.namespaces = typename.namespaces
+        self.typename = typename
         if parent_type:
             self.parent_type = parent_type
         else:
@@ -55,6 +56,10 @@ class ForwardDeclaration:
 
         self.is_virtual = is_virtual
         self.parent = parent
+
+    def namespaces(self) -> list:
+        """Get the namespaces which this class is nested under as a list."""
+        return collect_namespaces(self)
 
     def __repr__(self) -> str:
         return "ForwardDeclaration: {} {}".format(self.is_virtual, self.name)

--- a/gtwrap/interface_parser/declaration.py
+++ b/gtwrap/interface_parser/declaration.py
@@ -42,11 +42,12 @@ class ForwardDeclaration:
                 t.name, t.parent_type, t.is_virtual))
 
     def __init__(self,
-                 name: Typename,
+                 typename: Typename,
                  parent_type: str,
                  is_virtual: str,
                  parent: str = ''):
-        self.name = name
+        self.name = typename.name
+        self.namespaces = typename.namespaces
         if parent_type:
             self.parent_type = parent_type
         else:
@@ -56,5 +57,4 @@ class ForwardDeclaration:
         self.parent = parent
 
     def __repr__(self) -> str:
-        return "ForwardDeclaration: {} {}({})".format(self.is_virtual,
-                                                      self.name, self.parent)
+        return "ForwardDeclaration: {} {}".format(self.is_virtual, self.name)

--- a/gtwrap/interface_parser/namespace.py
+++ b/gtwrap/interface_parser/namespace.py
@@ -102,8 +102,9 @@ class Namespace:
         res = []
         for namespace in found_namespaces:
             classes_and_funcs = (c for c in namespace.content
-                                 if isinstance(c, (Class, GlobalFunction)))
+                                 if isinstance(c, (Class, GlobalFunction, ForwardDeclaration)))
             res += [c for c in classes_and_funcs if c.name == typename.name]
+        print(res)
         if not res:
             raise ValueError("Cannot find class {} in module!".format(
                 typename.name))

--- a/gtwrap/interface_parser/namespace.py
+++ b/gtwrap/interface_parser/namespace.py
@@ -104,7 +104,6 @@ class Namespace:
             classes_and_funcs = (c for c in namespace.content
                                  if isinstance(c, (Class, GlobalFunction, ForwardDeclaration)))
             res += [c for c in classes_and_funcs if c.name == typename.name]
-        print(res)
         if not res:
             raise ValueError("Cannot find class {} in module!".format(
                 typename.name))

--- a/gtwrap/pybind_wrapper.py
+++ b/gtwrap/pybind_wrapper.py
@@ -350,6 +350,23 @@ class PybindWrapper:
                     wrapped_operators=self.wrap_operators(
                         instantiated_class.operators, cpp_class)))
 
+    def wrap_instantiated_declaration(
+            self, instantiated_decl: instantiator.InstantiatedDeclaration):
+        """Wrap the class."""
+        module_var = self._gen_module_var(instantiated_decl.namespaces())
+        cpp_class = instantiated_decl.to_cpp()
+        if cpp_class in self.ignore_classes:
+            return ""
+
+        res = (
+            '\n    py::class_<{cpp_class}, '
+            '{shared_ptr_type}::shared_ptr<{cpp_class}>>({module_var}, "{class_name}")'
+        ).format(shared_ptr_type=('boost' if self.use_boost else 'std'),
+                 cpp_class=cpp_class,
+                 class_name=instantiated_decl.name,
+                 module_var=module_var)
+        return res
+
     def wrap_stl_class(self, stl_class):
         """Wrap STL containers."""
         module_var = self._gen_module_var(stl_class.namespaces())
@@ -453,6 +470,9 @@ class PybindWrapper:
                 elif isinstance(element, instantiator.InstantiatedClass):
                     wrapped += self.wrap_instantiated_class(element)
                     wrapped += self.wrap_enums(element.enums, element)
+
+                elif isinstance(element, instantiator.InstantiatedDeclaration):
+                    wrapped += self.wrap_instantiated_declaration(element)
 
                 elif isinstance(element, parser.Variable):
                     variable_namespace = self._add_namespaces('', namespaces)

--- a/gtwrap/template_instantiator.py
+++ b/gtwrap/template_instantiator.py
@@ -562,7 +562,7 @@ class InstantiatedDeclaration(parser.ForwardDeclaration):
             super(InstantiatedDeclaration, self).__repr__())
 
 
-def instantiate_namespace(namespace):
+def instantiate_namespace_inplace(namespace):
     """
     Instantiate the classes and other elements in the `namespace` content and
     assign it back to the namespace content attribute.
@@ -631,7 +631,7 @@ def instantiate_namespace(namespace):
                         typedef_inst.new_name))
 
         elif isinstance(element, parser.Namespace):
-            element = instantiate_namespace(element)
+            element = instantiate_namespace_inplace(element)
             instantiated_content.append(element)
         else:
             instantiated_content.append(element)

--- a/gtwrap/template_instantiator.py
+++ b/gtwrap/template_instantiator.py
@@ -130,7 +130,6 @@ def instantiate_name(original_name, instantiations):
     TODO(duy): To avoid conflicts, we should include the instantiation's
     namespaces, but I find that too verbose.
     """
-    inst_name = ''
     instantiated_names = []
     for inst in instantiations:
         # Ensure the first character of the type is capitalized
@@ -205,7 +204,13 @@ class InstantiatedGlobalFunction(parser.GlobalFunction):
 
 class InstantiatedMethod(parser.Method):
     """
-    We can only instantiate template methods with a single template parameter.
+    Instantiate method with template parameters.
+
+    E.g.
+    class A {
+        template<X, Y>
+        void func(X x, Y y);
+    }
     """
     def __init__(self, original, instantiations: List[parser.Typename] = ''):
         self.original = original
@@ -215,7 +220,7 @@ class InstantiatedMethod(parser.Method):
         self.parent = original.parent
 
         # Check for typenames if templated.
-        # This way, we can gracefully handle bot templated and non-templated methois.
+        # This way, we can gracefully handle both templated and non-templated methods.
         typenames = self.original.template.typenames if self.original.template else []
         self.name = instantiate_name(original.name, self.instantiations)
         self.return_type = instantiate_return_type(
@@ -516,7 +521,48 @@ class InstantiatedClass(parser.Class):
         return parser.Typename(namespaces_name)
 
 
-def instantiate_namespace_inplace(namespace):
+class InstantiatedDeclaration(parser.ForwardDeclaration):
+    """
+    Instantiate typedefs of forward declarations.
+    This is useful when we wish to typedef a templated class
+    which is not defined in the current project.
+
+    E.g.
+        class FactorFromAnotherMother;
+
+        typedef FactorFromAnotherMother<gtsam::Pose3> FactorWeCanUse;
+    """
+    def __init__(self, original, instantiations=(), new_name=''):
+        super().__init__(original.typename,
+                         original.parent_type,
+                         original.is_virtual,
+                         parent=original.parent)
+
+        self.original = original
+        self.instantiations = instantiations
+        self.parent = original.parent
+
+        self.name = instantiate_name(
+            original.name, instantiations) if not new_name else new_name
+
+    def to_cpp(self):
+        """Generate the C++ code for wrapping."""
+        instantiated_names = [
+            inst.qualified_name() for inst in self.instantiations
+        ]
+        name = "{}<{}>".format(self.original.name,
+                                ",".join(instantiated_names))
+        namespaces_name = self.namespaces()
+        namespaces_name.append(name)
+        # Leverage Typename to generate the fully qualified C++ name
+        return parser.Typename(namespaces_name).to_cpp()
+
+    def __repr__(self):
+        return "Instantiated {}".format(
+            super(InstantiatedDeclaration, self).__repr__())
+
+
+def instantiate_namespace(namespace):
     """
     Instantiate the classes and other elements in the `namespace` content and
     assign it back to the namespace content attribute.
@@ -566,7 +612,8 @@ def instantiate_namespace_inplace(namespace):
             original_element = top_level.find_class_or_function(
                 typedef_inst.typename)
 
-            # Check if element is a typedef'd class or function.
+            # Check if element is a typedef'd class, function or
+            # forward declaration from another project.
             if isinstance(original_element, parser.Class):
                 typedef_content.append(
                     InstantiatedClass(original_element,
@@ -577,12 +624,19 @@ def instantiate_namespace_inplace(namespace):
                     InstantiatedGlobalFunction(
                         original_element, typedef_inst.typename.instantiations,
                         typedef_inst.new_name))
+            elif isinstance(original_element, parser.ForwardDeclaration):
+                typedef_content.append(
+                    InstantiatedDeclaration(
+                        original_element, typedef_inst.typename.instantiations,
+                        typedef_inst.new_name))
 
         elif isinstance(element, parser.Namespace):
-            instantiate_namespace_inplace(element)
+            element = instantiate_namespace(element)
             instantiated_content.append(element)
         else:
             instantiated_content.append(element)
 
     instantiated_content.extend(typedef_content)
     namespace.content = instantiated_content
+
+    return namespace

--- a/tests/expected/python/class_pybind.cpp
+++ b/tests/expected/python/class_pybind.cpp
@@ -95,6 +95,7 @@ PYBIND11_MODULE(class_py, m_) {
                         return redirect.str();
                     }, py::arg("s") = "factor: ", py::arg("keyFormatter") = gtsam::DefaultKeyFormatter);
 
+    py::class_<SuperCoolFactor<gtsam::Pose3>, std::shared_ptr<SuperCoolFactor<gtsam::Pose3>>>(m_, "SuperCoolFactorPose3")
 
 #include "python/specializations.h"
 

--- a/tests/fixtures/class.i
+++ b/tests/fixtures/class.i
@@ -114,3 +114,6 @@ class ForwardKinematics {
                     const gtsam::Values& joint_angles,
                     const gtsam::Pose3& l2Tp = gtsam::Pose3());
 };
+
+class SuperCoolFactor;
+typedef SuperCoolFactor<gtsam::Pose3> SuperCoolFactorPose3;

--- a/tests/test_interface_parser.py
+++ b/tests/test_interface_parser.py
@@ -197,27 +197,45 @@ class TestInterfaceParser(unittest.TestCase):
         self.assertIsNone(args[7].default)
         self.assertEqual(args[8].default, '3.1415')
 
-        args = ArgumentList.rule.parseString("""
-            gtsam::KeyFormatter kf = gtsam::DefaultKeyFormatter,
-            std::vector<size_t> v = std::vector<size_t>(),
-            std::vector<size_t> l = {1, 2},
-            gtsam::KeyFormatter lambda = [&c1, &c2](string s=5, int a){return s+"hello"+a+c1+c2;},
-            gtsam::Pose3 p = gtsam::Pose3(),
-            Factor<gtsam::Pose3, gtsam::Point3> x = Factor<gtsam::Pose3, gtsam::Point3>(),
-            gtsam::Point3 x = gtsam::Point3(1, 2, 3),
-            ns::Class<T, U> obj = ns::Class<T, U>(3, 2, 1, "name")
-            """)[0].args_list
+        arg0 = 'gtsam::DefaultKeyFormatter'
+        arg1 = 'std::vector<size_t>()'
+        arg2 = '{1, 2}'
+        arg3 = '[&c1, &c2](string s=5, int a){return s+"hello"+a+c1+c2;}'
+        arg4 = 'gtsam::Pose3()'
+        arg5 = 'Factor<gtsam::Pose3, gtsam::Point3>()'
+        arg6 = 'gtsam::Point3(1, 2, 3)'
+        arg7 = 'ns::Class<T, U>(3, 2, 1, "name")'
+
+        argument_list = """
+            gtsam::KeyFormatter kf = {arg0},
+            std::vector<size_t> v = {arg1},
+            std::vector<size_t> l = {arg2},
+            gtsam::KeyFormatter lambda = {arg3},
+            gtsam::Pose3 p = {arg4},
+            Factor<gtsam::Pose3, gtsam::Point3> x = {arg5},
+            gtsam::Point3 x = {arg6},
+            ns::Class<T, U> obj = {arg7}
+            """.format(arg0=arg0,
+                       arg1=arg1,
+                       arg2=arg2,
+                       arg3=arg3,
+                       arg4=arg4,
+                       arg5=arg5,
+                       arg6=arg6,
+                       arg7=arg7)
+        args = ArgumentList.rule.parseString(argument_list)[0].args_list
 
         # Test non-basic type
-        self.assertEqual(args[0].default, 'gtsam::DefaultKeyFormatter')
+        self.assertEqual(args[0].default, arg0)
         # Test templated type
-        self.assertEqual(args[1].default, 'std::vector<size_t>()')
-        self.assertEqual(args[2].default, '{1, 2}')
-        self.assertEqual(args[3].default, '[&c1, &c2](string s=5, int a){return s+"hello"+a+c1+c2;}')
-        self.assertEqual(args[4].default, 'gtsam::Pose3()')
-        self.assertEqual(args[6].default, 'gtsam::Point3(1, 2, 3)')
+        self.assertEqual(args[1].default, arg1)
+        self.assertEqual(args[2].default, arg2)
+        self.assertEqual(args[3].default, arg3)
+        self.assertEqual(args[4].default, arg4)
+        self.assertEqual(args[5].default, arg5)
+        self.assertEqual(args[6].default, arg6)
         # Test for default argument with multiple templates and params
-        self.assertEqual(args[7].default, 'ns::Class<T, U>(3, 2, 1, "name")')
+        self.assertEqual(args[7].default, arg7)
 
     def test_return_type(self):
         """Test ReturnType"""
@@ -479,8 +497,7 @@ class TestInterfaceParser(unittest.TestCase):
         fwd = ForwardDeclaration.rule.parseString(
             "virtual class Test:gtsam::Point3;")[0]
 
-        fwd_name = fwd.name
-        self.assertEqual("Test", fwd_name.name)
+        self.assertEqual("Test", fwd.name)
         self.assertTrue(fwd.is_virtual)
 
     def test_function(self):


### PR DESCRIPTION
This PR will allow us to use `typedef`s on classes defined in other projects.

E.g. GTSAM has a `ManifoldEvaluationFactor` which takes `RigidBodyState` as a template argument which is defined in DoubleExpresso.

Now in DoubleExpresso, we can do
```cpp
class gtsam::ManifoldEvaluationFactor;  // forward declare class so we can typedef

typedef gtsam::ManifoldEvaluationFactor<gtsam::Chebyshev2,
                                        gtsam::RigidBodyState>
    ManifoldEvaluationFactorChebyshev2RigidBodyState;
```

and everything should work.