### PR TITLE
Allow `.print()` as a class method

### DIFF
--- a/tests/expected/python/class_pybind.cpp
+++ b/tests/expected/python/class_pybind.cpp
@@ -55,7 +55,7 @@ PYBIND11_MODULE(class_py, m_) {
         .def("create_ptrs",[](Test* self){return self->create_ptrs();})
         .def("create_MixedPtrs",[](Test* self){return self->create_MixedPtrs();})
         .def("return_ptrs",[](Test* self, std::shared_ptr<Test> p1, std::shared_ptr<Test> p2){return self->return_ptrs(p1, p2);}, py::arg("p1"), py::arg("p2"))
-        .def("print_",[](Test* self){ py::scoped_ostream_redirect output; self->print();})
+        .def("print",[](Test* self){ py::scoped_ostream_redirect output; self->print();})
         .def("__repr__",
                     [](const Test& self){
                         gtsam::RedirectCout redirect;
@@ -87,7 +87,7 @@ PYBIND11_MODULE(class_py, m_) {
 
     py::class_<MyFactor<gtsam::Pose2, gtsam::Matrix>, std::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>>>(m_, "MyFactorPosePoint2")
         .def(py::init<size_t, size_t, double, const std::shared_ptr<gtsam::noiseModel::Base>>(), py::arg("key1"), py::arg("key2"), py::arg("measured"), py::arg("noiseModel"))
-        .def("print_",[](MyFactor<gtsam::Pose2, gtsam::Matrix>* self, const string& s, const gtsam::KeyFormatter& keyFormatter){ py::scoped_ostream_redirect output; self->print(s, keyFormatter);}, py::arg("s") = "factor: ", py::arg("keyFormatter") = gtsam::DefaultKeyFormatter)
+        .def("print",[](MyFactor<gtsam::Pose2, gtsam::Matrix>* self, const string& s, const gtsam::KeyFormatter& keyFormatter){ py::scoped_ostream_redirect output; self->print(s, keyFormatter);}, py::arg("s") = "factor: ", py::arg("keyFormatter") = gtsam::DefaultKeyFormatter)
         .def("__repr__",
                     [](const MyFactor<gtsam::Pose2, gtsam::Matrix>& self, const string& s, const gtsam::KeyFormatter& keyFormatter){
                         gtsam::RedirectCout redirect;


### PR DESCRIPTION
The fact that we have to use `.print_()` as a class method always seemed odd to me.
The reason this was the case was because the `wrap_method` function was being used for both class methods and global functions (where `print()` is illegal).

This PR adds a separate function `wrap_function` dedicated for global functions, allowing `wrap_method` to only worry about class methods.

This means we can now do:
```python
graph.print()
values.print()
```

__NOTE__: This is a breaking change, but I believe this will make the wrapper more user friendly and increase its adoption.
