### PR TITLE
Fix bug for default in methods

### DIFF
--- a/gtwrap/pybind_wrapper.py
+++ b/gtwrap/pybind_wrapper.py
@@ -46,11 +46,11 @@ class PybindWrapper:
             py_args = []
             for arg in args_list.args_list:
                 if arg.default is not None:
-                    arg.default = ' = {arg.default}'.format(arg=arg)
+                    default = ' = {arg.default}'.format(arg=arg)
                 else:
-                    arg.default = ''
+                    default = ''
                 argument = 'py::arg("{name}"){default}'.format(
-                    name=arg.name, default='{0}'.format(arg.default))
+                    name=arg.name, default='{0}'.format(default))
                 py_args.append(argument)
             return ", " + ", ".join(py_args)
         else:
@@ -179,7 +179,7 @@ class PybindWrapper:
         res = ""
         for method in methods:
 
-            # To avoid type confusion for insert, currently unused
+            # To avoid type confusion for insert
             if method.name == 'insert' and cpp_class == 'gtsam::Values':
                 name_list = method.args.args_names()
                 type_list = method.args.to_cpp(self.use_boost)

--- a/tests/expected/matlab/namespaces_wrapper.cpp
+++ b/tests/expected/matlab/namespaces_wrapper.cpp
@@ -8,6 +8,7 @@
 #include <folder/path/to/Test.h>
 #include <gtsam/geometry/Point2.h>
 #include <gtsam/geometry/Point3.h>
+#include <gtsam/nonlinear/Values.h>
 #include <path/to/ns1.h>
 #include <path/to/ns1/ClassB.h>
 #include <path/to/ns2.h>
@@ -71,6 +72,8 @@ typedef std::set<boost::shared_ptr<ns2::ClassC>*> Collector_ns2ClassC;
 static Collector_ns2ClassC collector_ns2ClassC;
 typedef std::set<boost::shared_ptr<ClassD>*> Collector_ClassD;
 static Collector_ClassD collector_ClassD;
+typedef std::set<boost::shared_ptr<gtsam::Values>*> Collector_gtsamValues;
+static Collector_gtsamValues collector_gtsamValues;
 
 void _deleteAllObjects()
 {
@@ -208,6 +211,12 @@ void _deleteAllObjects()
       iter != collector_ClassD.end(); ) {
     delete *iter;
     collector_ClassD.erase(iter++);
+    anyDeleted = true;
+  } }
+  { for(Collector_gtsamValues::iterator iter = collector_gtsamValues.begin();
+      iter != collector_gtsamValues.end(); ) {
+    delete *iter;
+    collector_gtsamValues.erase(iter++);
     anyDeleted = true;
   } }
   if(anyDeleted)
@@ -499,6 +508,69 @@ void ClassD_deconstructor_25(int nargout, mxArray *out[], int nargin, const mxAr
   }
 }
 
+void gtsamValues_collectorInsertAndMakeBase_26(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  mexAtExit(&_deleteAllObjects);
+  typedef boost::shared_ptr<gtsam::Values> Shared;
+
+  Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
+  collector_gtsamValues.insert(self);
+}
+
+void gtsamValues_constructor_27(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  mexAtExit(&_deleteAllObjects);
+  typedef boost::shared_ptr<gtsam::Values> Shared;
+
+  Shared *self = new Shared(new gtsam::Values());
+  collector_gtsamValues.insert(self);
+  out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
+  *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
+}
+
+void gtsamValues_constructor_28(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  mexAtExit(&_deleteAllObjects);
+  typedef boost::shared_ptr<gtsam::Values> Shared;
+
+  gtsam::Values& other = *unwrap_shared_ptr< gtsam::Values >(in[0], "ptr_gtsamValues");
+  Shared *self = new Shared(new gtsam::Values(other));
+  collector_gtsamValues.insert(self);
+  out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
+  *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
+}
+
+void gtsamValues_deconstructor_29(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  typedef boost::shared_ptr<gtsam::Values> Shared;
+  checkArguments("delete_gtsamValues",nargout,nargin,1);
+  Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
+  Collector_gtsamValues::iterator item;
+  item = collector_gtsamValues.find(self);
+  if(item != collector_gtsamValues.end()) {
+    delete self;
+    collector_gtsamValues.erase(item);
+  }
+}
+
+void gtsamValues_insert_30(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("insert",nargout,nargin-1,2);
+  auto obj = unwrap_shared_ptr<gtsam::Values>(in[0], "ptr_gtsamValues");
+  size_t j = unwrap< size_t >(in[1]);
+  Vector vector = unwrap< Vector >(in[2]);
+  obj->insert(j,vector);
+}
+
+void gtsamValues_insert_31(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("insert",nargout,nargin-1,2);
+  auto obj = unwrap_shared_ptr<gtsam::Values>(in[0], "ptr_gtsamValues");
+  size_t j = unwrap< size_t >(in[1]);
+  Matrix matrix = unwrap< Matrix >(in[2]);
+  obj->insert(j,matrix);
+}
+
 
 void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
@@ -588,6 +660,24 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       break;
     case 25:
       ClassD_deconstructor_25(nargout, out, nargin-1, in+1);
+      break;
+    case 26:
+      gtsamValues_collectorInsertAndMakeBase_26(nargout, out, nargin-1, in+1);
+      break;
+    case 27:
+      gtsamValues_constructor_27(nargout, out, nargin-1, in+1);
+      break;
+    case 28:
+      gtsamValues_constructor_28(nargout, out, nargin-1, in+1);
+      break;
+    case 29:
+      gtsamValues_deconstructor_29(nargout, out, nargin-1, in+1);
+      break;
+    case 30:
+      gtsamValues_insert_30(nargout, out, nargin-1, in+1);
+      break;
+    case 31:
+      gtsamValues_insert_31(nargout, out, nargin-1, in+1);
       break;
     }
   } catch(const std::exception& e) {

--- a/tests/expected/matlab/special_cases_wrapper.cpp
+++ b/tests/expected/matlab/special_cases_wrapper.cpp
@@ -9,6 +9,7 @@
 #include <gtsam/geometry/Cal3Bundler.h>
 #include <gtsam/geometry/Point2.h>
 #include <gtsam/geometry/Point3.h>
+#include <gtsam/nonlinear/Values.h>
 #include <path/to/ns1.h>
 #include <path/to/ns1/ClassB.h>
 #include <path/to/ns2.h>
@@ -74,6 +75,8 @@ typedef std::set<boost::shared_ptr<ns2::ClassC>*> Collector_ns2ClassC;
 static Collector_ns2ClassC collector_ns2ClassC;
 typedef std::set<boost::shared_ptr<ClassD>*> Collector_ClassD;
 static Collector_ClassD collector_ClassD;
+typedef std::set<boost::shared_ptr<gtsam::Values>*> Collector_gtsamValues;
+static Collector_gtsamValues collector_gtsamValues;
 typedef std::set<boost::shared_ptr<gtsam::NonlinearFactorGraph>*> Collector_gtsamNonlinearFactorGraph;
 static Collector_gtsamNonlinearFactorGraph collector_gtsamNonlinearFactorGraph;
 typedef std::set<boost::shared_ptr<gtsam::SfmTrack>*> Collector_gtsamSfmTrack;
@@ -219,6 +222,12 @@ void _deleteAllObjects()
       iter != collector_ClassD.end(); ) {
     delete *iter;
     collector_ClassD.erase(iter++);
+    anyDeleted = true;
+  } }
+  { for(Collector_gtsamValues::iterator iter = collector_gtsamValues.begin();
+      iter != collector_gtsamValues.end(); ) {
+    delete *iter;
+    collector_gtsamValues.erase(iter++);
     anyDeleted = true;
   } }
   { for(Collector_gtsamNonlinearFactorGraph::iterator iter = collector_gtsamNonlinearFactorGraph.begin();

--- a/tests/expected/python/namespaces_pybind.cpp
+++ b/tests/expected/python/namespaces_pybind.cpp
@@ -11,6 +11,7 @@
 #include "path/to/ns2.h"
 #include "path/to/ns2/ClassA.h"
 #include "path/to/ns3.h"
+#include "gtsam/nonlinear/Values.h"
 
 #include "wrap/serialization.h"
 #include <boost/serialization/export.hpp>
@@ -57,7 +58,16 @@ PYBIND11_MODULE(namespaces_py, m_) {
     py::class_<ClassD, std::shared_ptr<ClassD>>(m_, "ClassD")
         .def(py::init<>());
 
-    m_.attr("aGlobalVar") = aGlobalVar;
+    m_.attr("aGlobalVar") = aGlobalVar;    pybind11::module m_gtsam = m_.def_submodule("gtsam", "gtsam submodule");
+
+    py::class_<gtsam::Values, std::shared_ptr<gtsam::Values>>(m_gtsam, "Values")
+        .def(py::init<>())
+        .def(py::init<const gtsam::Values&>(), py::arg("other"))
+        .def("insert_vector",[](gtsam::Values* self, size_t j, const gtsam::Vector& vector){ self->insert(j, vector);}, py::arg("j"), py::arg("vector"))
+        .def("insert",[](gtsam::Values* self, size_t j, const gtsam::Vector& vector){ self->insert(j, vector);}, py::arg("j"), py::arg("vector"))
+        .def("insert_matrix",[](gtsam::Values* self, size_t j, const gtsam::Matrix& matrix){ self->insert(j, matrix);}, py::arg("j"), py::arg("matrix"))
+        .def("insert",[](gtsam::Values* self, size_t j, const gtsam::Matrix& matrix){ self->insert(j, matrix);}, py::arg("j"), py::arg("matrix"));
+
 
 #include "python/specializations.h"
 

--- a/tests/fixtures/namespaces.i
+++ b/tests/fixtures/namespaces.i
@@ -60,3 +60,14 @@ class ClassD {
 };
 
 int aGlobalVar;
+
+namespace gtsam {
+  #include <gtsam/nonlinear/Values.h>
+class Values {
+  Values();
+  Values(const gtsam::Values& other);
+
+  void insert(size_t j, Vector vector);
+  void insert(size_t j, Matrix matrix);
+};
+}

--- a/tests/test_matlab_wrapper.py
+++ b/tests/test_matlab_wrapper.py
@@ -215,7 +215,7 @@ class TestWrap(unittest.TestCase):
         for file in files:
             self.compare_and_diff(file)
 
-    def test_namspaces(self):
+    def test_namespaces(self):
         """
         Test interface file with full namespace definition.
         """


### PR DESCRIPTION
For overloaded methods (such as `Values::insert`), the pybind wrapper adds a spurious `=` because of an incorrect reassignment. This bug fixes that issue.