### PR TITLE
Cleanup

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
 
     steps:
       - name: Checkout

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
 
     steps:
       - name: Checkout

--- a/gtwrap/interface_parser/classes.py
+++ b/gtwrap/interface_parser/classes.py
@@ -189,7 +189,7 @@ class Operator:
 
         # Check to ensure arg and return type are the same.
         if len(args) == 1 and self.operator not in ("()", "[]"):
-            assert args.args_list[0].ctype.typename.name == return_type.type1.typename.name, \
+            assert args.list()[0].ctype.typename.name == return_type.type1.typename.name, \
                 "Mixed type overloading not supported. Both arg and return type must be the same."
 
     def __repr__(self) -> str:

--- a/gtwrap/interface_parser/function.py
+++ b/gtwrap/interface_parser/function.py
@@ -86,9 +86,13 @@ class ArgumentList:
     def __len__(self) -> int:
         return len(self.args_list)
 
-    def args_names(self) -> List[str]:
+    def names(self) -> List[str]:
         """Return a list of the names of all the arguments."""
         return [arg.name for arg in self.args_list]
+
+    def list(self) -> List[Argument]:
+        """Return a list of the names of all the arguments."""
+        return self.args_list
 
     def to_cpp(self, use_boost: bool) -> List[str]:
         """Generate the C++ code for wrapping."""

--- a/gtwrap/matlab_wrapper.py
+++ b/gtwrap/matlab_wrapper.py
@@ -373,14 +373,14 @@ class MatlabWrapper(object):
         """
         arg_wrap = ''
 
-        for i, arg in enumerate(args.args_list, 1):
+        for i, arg in enumerate(args.list(), 1):
             c_type = self._format_type_name(arg.ctype.typename,
                                             include_namespace=False)
 
             arg_wrap += '{c_type} {arg_name}{comma}'.format(
                 c_type=c_type,
                 arg_name=arg.name,
-                comma='' if i == len(args.args_list) else ', ')
+                comma='' if i == len(args.list()) else ', ')
 
         return arg_wrap
 
@@ -395,7 +395,7 @@ class MatlabWrapper(object):
         """
         var_arg_wrap = ''
 
-        for i, arg in enumerate(args.args_list, 1):
+        for i, arg in enumerate(args.list(), 1):
             name = arg.ctype.typename.name
             if name in self.not_check_type:
                 continue
@@ -441,7 +441,7 @@ class MatlabWrapper(object):
         var_list_wrap = ''
         first = True
 
-        for i in range(1, len(args.args_list) + 1):
+        for i in range(1, len(args.list()) + 1):
             if first:
                 var_list_wrap += 'varargin{{{}}}'.format(i)
                 first = False
@@ -461,9 +461,9 @@ class MatlabWrapper(object):
         if check_statement == '':
             check_statement = \
                 'if length(varargin) == {param_count}'.format(
-                    param_count=len(args.args_list))
+                    param_count=len(args.list()))
 
-        for _, arg in enumerate(args.args_list):
+        for _, arg in enumerate(args.list()):
             name = arg.ctype.typename.name
 
             if name in self.not_check_type:
@@ -515,7 +515,7 @@ class MatlabWrapper(object):
         params = ''
         body_args = ''
 
-        for arg in args.args_list:
+        for arg in args.list():
             if params != '':
                 params += ','
 
@@ -724,10 +724,10 @@ class MatlabWrapper(object):
             param_wrap += '      if' if i == 0 else '      elseif'
             param_wrap += ' length(varargin) == '
 
-            if len(overload.args.args_list) == 0:
+            if len(overload.args.list()) == 0:
                 param_wrap += '0\n'
             else:
-                param_wrap += str(len(overload.args.args_list)) \
+                param_wrap += str(len(overload.args.list())) \
                               + self._wrap_variable_arguments(overload.args, False) + '\n'
 
             # Determine format of return and varargout statements
@@ -824,14 +824,14 @@ class MatlabWrapper(object):
             methods_wrap += textwrap.indent(textwrap.dedent('''\
                 elseif nargin == {len}{varargin}
                   {ptr}{wrapper}({num}{comma}{var_arg});
-            ''').format(len=len(ctor.args.args_list),
+            ''').format(len=len(ctor.args.list()),
                         varargin=self._wrap_variable_arguments(
                             ctor.args, False),
                         ptr=wrapper_return,
                         wrapper=self._wrapper_name(),
                         num=self._update_wrapper_id(
                             (namespace_name, inst_class, 'constructor', ctor)),
-                        comma='' if len(ctor.args.args_list) == 0 else ', ',
+                        comma='' if len(ctor.args.list()) == 0 else ', ',
                         var_arg=self._wrap_list_variable_arguments(ctor.args)),
                                             prefix='    ')
 
@@ -1074,7 +1074,7 @@ class MatlabWrapper(object):
                         static_overload.return_type,
                         include_namespace=True,
                         separator="."),
-                    length=len(static_overload.args.args_list),
+                    length=len(static_overload.args.list()),
                     var_args_list=self._wrap_variable_arguments(
                         static_overload.args),
                     check_statement=check_statement,
@@ -1548,7 +1548,7 @@ class MatlabWrapper(object):
                     min1='-1' if is_method else '',
                     shared_obj=shared_obj,
                     method_name=method_name,
-                    num_args=len(extra.args.args_list),
+                    num_args=len(extra.args.list()),
                     body_args=body_args,
                     return_body=return_body)
 
@@ -1565,7 +1565,7 @@ class MatlabWrapper(object):
                   checkArguments("{function_name}",nargout,nargin,{len});
             ''').format(function_name=collector_func[1].name,
                         id=self.global_function_id,
-                        len=len(collector_func[1].args.args_list))
+                        len=len(collector_func[1].args.list()))
 
             body += self._wrapper_unwrap_arguments(collector_func[1].args)[1]
             body += self.wrap_collector_function_return(

--- a/gtwrap/matlab_wrapper.py
+++ b/gtwrap/matlab_wrapper.py
@@ -57,7 +57,7 @@ class MatlabWrapper(object):
     # Methods that should be ignored
     ignore_methods = ['pickle']
     # Datatypes that do not need to be checked in methods
-    not_check_type: list = []
+    not_check_type = []  # type: list
     # Data types that are primitive types
     not_ptr_type = ['int', 'double', 'bool', 'char', 'unsigned char', 'size_t']
     # Ignore the namespace for these datatypes
@@ -65,17 +65,18 @@ class MatlabWrapper(object):
     # The amount of times the wrapper has created a call to geometry_wrapper
     wrapper_id = 0
     # Map each wrapper id to what its collector function namespace, class, type, and string format
-    wrapper_map: dict = {}
+    wrapper_map = {}
     # Set of all the includes in the namespace
-    includes: Dict[parser.Include, int] = {}
+    includes = {}  # type: Dict[parser.Include, int]
     # Set of all classes in the namespace
-    classes: List[Union[parser.Class, instantiator.InstantiatedClass]] = []
-    classes_elems: Dict[Union[parser.Class, instantiator.InstantiatedClass],
-                        int] = {}
+    classes = [
+    ]  # type: List[Union[parser.Class, instantiator.InstantiatedClass]]
+    classes_elems = {
+    }  # type: Dict[Union[parser.Class, instantiator.InstantiatedClass], int]
     # Id for ordering global functions in the wrapper
     global_function_id = 0
     # Files and their content
-    content: List[str] = []
+    content = []  # type: List[str]
 
     # Ensure the template file is always picked up from the correct directory.
     dir_path = osp.dirname(osp.realpath(__file__))

--- a/gtwrap/pybind_wrapper.py
+++ b/gtwrap/pybind_wrapper.py
@@ -39,12 +39,12 @@ class PybindWrapper:
         # amount of indentation to add before each function/method declaration.
         self.method_indent = '\n' + (' ' * 8)
 
-    def _py_args_names(self, args_list):
+    def _py_args_names(self, args):
         """Set the argument names in Pybind11 format."""
-        names = args_list.names()
+        names = args.names()
         if names:
             py_args = []
-            for arg in args_list.args_list:
+            for arg in args.list():
                 if arg.default is not None:
                     default = ' = {arg.default}'.format(arg=arg)
                 else:
@@ -56,10 +56,10 @@ class PybindWrapper:
         else:
             return ''
 
-    def _method_args_signature(self, args_list):
+    def _method_args_signature(self, args):
         """Generate the argument types and names as per the method signature."""
-        cpp_types = args_list.to_cpp(self.use_boost)
-        names = args_list.names()
+        cpp_types = args.to_cpp(self.use_boost)
+        names = args.names()
         types_names = [
             "{} {}".format(ctype, name)
             for ctype, name in zip(cpp_types, names)

--- a/gtwrap/pybind_wrapper.py
+++ b/gtwrap/pybind_wrapper.py
@@ -41,7 +41,7 @@ class PybindWrapper:
 
     def _py_args_names(self, args_list):
         """Set the argument names in Pybind11 format."""
-        names = args_list.args_names()
+        names = args_list.names()
         if names:
             py_args = []
             for arg in args_list.args_list:
@@ -59,7 +59,7 @@ class PybindWrapper:
     def _method_args_signature(self, args_list):
         """Generate the argument types and names as per the method signature."""
         cpp_types = args_list.to_cpp(self.use_boost)
-        names = args_list.args_names()
+        names = args_list.names()
         types_names = [
             "{} {}".format(ctype, name)
             for ctype, name in zip(cpp_types, names)
@@ -111,7 +111,7 @@ class PybindWrapper:
         is_method = isinstance(method, instantiator.InstantiatedMethod)
         is_static = isinstance(method, parser.StaticMethod)
         return_void = method.return_type.is_void()
-        args_names = method.args.args_names()
+        args_names = method.args.names()
         py_args_names = self._py_args_names(method.args)
         args_signature_with_names = self._method_args_signature(method.args)
 
@@ -181,7 +181,7 @@ class PybindWrapper:
 
             # To avoid type confusion for insert
             if method.name == 'insert' and cpp_class == 'gtsam::Values':
-                name_list = method.args.args_names()
+                name_list = method.args.names()
                 type_list = method.args.to_cpp(self.use_boost)
                 # inserting non-wrapped value types
                 if type_list[0].strip() == 'size_t':
@@ -413,7 +413,7 @@ class PybindWrapper:
 
             is_static = isinstance(function, parser.StaticMethod)
             return_void = function.return_type.is_void()
-            args_names = function.args.args_names()
+            args_names = function.args.names()
             py_args_names = self._py_args_names(function.args)
             args_signature = self._method_args_signature(function.args)
 

--- a/gtwrap/template_instantiator.py
+++ b/gtwrap/template_instantiator.py
@@ -170,7 +170,7 @@ class InstantiatedGlobalFunction(parser.GlobalFunction):
                 cpp_typename='',
             )
             instantiated_args = instantiate_args_list(
-                original.args.args_list,
+                original.args.list(),
                 self.original.template.typenames,
                 self.instantiations,
                 # Keyword type name `This` should already be replaced in the
@@ -233,7 +233,7 @@ class InstantiatedMethod(parser.Method):
         )
 
         instantiated_args = instantiate_args_list(
-            original.args.args_list,
+            original.args.list(),
             typenames,
             self.instantiations,
             # Keyword type name `This` should already be replaced in the
@@ -368,7 +368,7 @@ class InstantiatedClass(parser.Class):
 
         for ctor in self.original.ctors:
             instantiated_args = instantiate_args_list(
-                ctor.args.args_list,
+                ctor.args.list(),
                 typenames,
                 self.instantiations,
                 self.cpp_typename(),
@@ -393,7 +393,7 @@ class InstantiatedClass(parser.Class):
         instantiated_static_methods = []
         for static_method in self.original.static_methods:
             instantiated_args = instantiate_args_list(
-                static_method.args.args_list, typenames, self.instantiations,
+                static_method.args.list(), typenames, self.instantiations,
                 self.cpp_typename())
             instantiated_static_methods.append(
                 parser.StaticMethod(
@@ -430,7 +430,7 @@ class InstantiatedClass(parser.Class):
         class_instantiated_methods = []
         for method in self.original.methods:
             instantiated_args = instantiate_args_list(
-                method.args.args_list,
+                method.args.list(),
                 typenames,
                 self.instantiations,
                 self.cpp_typename(),
@@ -463,7 +463,7 @@ class InstantiatedClass(parser.Class):
         instantiated_operators = []
         for operator in self.original.operators:
             instantiated_args = instantiate_args_list(
-                operator.args.args_list,
+                operator.args.list(),
                 typenames,
                 self.instantiations,
                 self.cpp_typename(),

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ packages = find_packages()
 setup(
     name='gtwrap',
     description='Library to wrap C++ with Python and Matlab',
-    version='1.1.0',
+    version='2.0.0',
     author="Frank Dellaert et. al.",
     author_email="dellaert@gatech.edu",
     license='BSD',

--- a/tests/test_interface_parser.py
+++ b/tests/test_interface_parser.py
@@ -142,7 +142,7 @@ class TestInterfaceParser(unittest.TestCase):
             "const C6* c6"
         args = ArgumentList.rule.parseString(arg_string)[0]
 
-        self.assertEqual(7, len(args.args_list))
+        self.assertEqual(7, len(args.list()))
         self.assertEqual(['a', 'c1', 'c2', 'c3', 'c4', 'c5', 'c6'],
                          args.names())
 
@@ -153,7 +153,7 @@ class TestInterfaceParser(unittest.TestCase):
         """
         arg_string = "double x1, double* x2, double& x3, double@ x4, " \
             "const double x5, const double* x6, const double& x7, const double@ x8"
-        args = ArgumentList.rule.parseString(arg_string)[0].args_list
+        args = ArgumentList.rule.parseString(arg_string)[0].list()
         self.assertEqual(8, len(args))
         self.assertFalse(args[1].ctype.is_ptr and args[1].ctype.is_shared_ptr
                          and args[1].ctype.is_ref)
@@ -169,7 +169,7 @@ class TestInterfaceParser(unittest.TestCase):
         """Test arguments list where the arguments can be templated."""
         arg_string = "std::pair<string, double> steps, vector<T*> vector_of_pointers"
         args = ArgumentList.rule.parseString(arg_string)[0]
-        args_list = args.args_list
+        args_list = args.list()
         self.assertEqual(2, len(args_list))
         self.assertEqual("std::pair<string, double>",
                          args_list[0].ctype.to_cpp(False))
@@ -183,7 +183,7 @@ class TestInterfaceParser(unittest.TestCase):
         args = ArgumentList.rule.parseString("""
             string c = "", int z = 0, double z2 = 0.0, bool f = false,
             string s="hello"+"goodbye", char c='a', int a=3,
-            int b, double pi = 3.1415""")[0].args_list
+            int b, double pi = 3.1415""")[0].list()
 
         # Test for basic types
         self.assertEqual(args[0].default, '""')
@@ -223,7 +223,7 @@ class TestInterfaceParser(unittest.TestCase):
                        arg5=arg5,
                        arg6=arg6,
                        arg7=arg7)
-        args = ArgumentList.rule.parseString(argument_list)[0].args_list
+        args = ArgumentList.rule.parseString(argument_list)[0].list()
 
         # Test non-basic type
         self.assertEqual(args[0].default, arg0)
@@ -312,7 +312,7 @@ class TestInterfaceParser(unittest.TestCase):
                     const gtsam::Pose3& l2Tp = gtsam::Pose3());""")[0]
         self.assertEqual("ForwardKinematics", ret.name)
         self.assertEqual(5, len(ret.args))
-        self.assertEqual("gtsam::Pose3()", ret.args.args_list[4].default)
+        self.assertEqual("gtsam::Pose3()", ret.args.list()[4].default)
 
     def test_operator_overload(self):
         """Test for operator overloading."""
@@ -337,7 +337,7 @@ class TestInterfaceParser(unittest.TestCase):
                          ret.return_type.type1.typename.to_cpp())
         self.assertTrue(len(ret.args) == 1)
         self.assertEqual("const gtsam::Vector2 &",
-                         repr(ret.args.args_list[0].ctype))
+                         repr(ret.args.list()[0].ctype))
         self.assertTrue(not ret.is_unary)
 
     def test_typedef_template_instantiation(self):

--- a/tests/test_interface_parser.py
+++ b/tests/test_interface_parser.py
@@ -144,7 +144,7 @@ class TestInterfaceParser(unittest.TestCase):
 
         self.assertEqual(7, len(args.args_list))
         self.assertEqual(['a', 'c1', 'c2', 'c3', 'c4', 'c5', 'c6'],
-                         args.args_names())
+                         args.names())
 
     def test_argument_list_qualifiers(self):
         """


### PR DESCRIPTION
- Use `args.names()` instead of `args.args_names()`.
- Use `args.list()` instead of `args.args_list`.
- Version bump since we changed the public API.
- Support Python 3.5 since we build wheels for that version.