### PR TITLE
Matlab - Support for parsing multiple interface files

### DIFF
--- a/gtwrap/interface_parser/namespace.py
+++ b/gtwrap/interface_parser/namespace.py
@@ -115,7 +115,7 @@ class Namespace:
             return res[0]
 
     def top_level(self) -> "Namespace":
-        """Return the top leve namespace."""
+        """Return the top level namespace."""
         if self.name == '' or self.parent == '':
             return self
         else:

--- a/gtwrap/matlab_wrapper/wrapper.py
+++ b/gtwrap/matlab_wrapper/wrapper.py
@@ -68,7 +68,7 @@ class MatlabWrapper(CheckMixin, FormatMixin):
         }
         # The amount of times the wrapper has created a call to geometry_wrapper
         self.wrapper_id = 0
-        # Map each wrapper id to what its collector function namespace, class, type, and string format
+        # Map each wrapper id to its collector function namespace, class, type, and string format
         self.wrapper_map: Dict = {}
         # Set of all the includes in the namespace
         self.includes: List[parser.Include] = []
@@ -1533,7 +1533,6 @@ class MatlabWrapper(CheckMixin, FormatMixin):
                 if len(c) == 0:
                     continue
 
-                logger.debug("c object: {}".format(c[0][0]))
                 path_to_folder = osp.join(path, c[0][0])
 
                 if not osp.isdir(path_to_folder):
@@ -1548,8 +1547,6 @@ class MatlabWrapper(CheckMixin, FormatMixin):
             elif isinstance(c[1], list):
                 path_to_folder = osp.join(path, c[0])
 
-                logger.debug(
-                    "[generate_content_global]: {}".format(path_to_folder))
                 if not osp.isdir(path_to_folder):
                     try:
                         os.makedirs(path_to_folder, exist_ok=True)
@@ -1557,14 +1554,11 @@ class MatlabWrapper(CheckMixin, FormatMixin):
                         pass
                 for sub_content in c[1]:
                     path_to_file = osp.join(path_to_folder, sub_content[0])
-                    logger.debug(
-                        "[generate_global_method]: {}".format(path_to_file))
                     with open(path_to_file, 'w') as f:
                         f.write(sub_content[1])
             else:
                 path_to_file = osp.join(path, c[0])
 
-                logger.debug("[generate_content]: {}".format(path_to_file))
                 if not osp.isdir(path_to_file):
                     try:
                         os.mkdir(path)
@@ -1589,7 +1583,8 @@ class MatlabWrapper(CheckMixin, FormatMixin):
             module = instantiator.instantiate_namespace(parsed_result)
 
             if module.name in modules:
-                modules[module.name].content[0].content += module.content[0].content
+                modules[module.
+                        name].content[0].content += module.content[0].content
             else:
                 modules[module.name] = module
 

--- a/gtwrap/template_instantiator.py
+++ b/gtwrap/template_instantiator.py
@@ -345,9 +345,9 @@ class InstantiatedClass(parser.Class):
         )
 
     def __repr__(self):
-        return "{virtual} class {name} [{cpp_class}]: {parent_class}\n"\
+        return "{virtual}Class {cpp_class} : {parent_class}\n"\
             "{ctors}\n{static_methods}\n{methods}\n{operators}".format(
-               virtual="virtual" if self.is_virtual else '',
+               virtual="virtual " if self.is_virtual else '',
                name=self.name,
                cpp_class=self.to_cpp(),
                parent_class=self.parent,

--- a/scripts/matlab_wrap.py
+++ b/scripts/matlab_wrap.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 """
 Helper script to wrap C++ to Matlab.
 This script is installed via CMake to the user's binary directory
@@ -7,19 +6,24 @@ and invoked during the wrapping by CMake.
 """
 
 import argparse
-import os
 import sys
 
-from gtwrap.matlab_wrapper import MatlabWrapper, generate_content
+from gtwrap.matlab_wrapper import MatlabWrapper
 
 if __name__ == "__main__":
     arg_parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    arg_parser.add_argument("--src", type=str, required=True,
+    arg_parser.add_argument("--src",
+                            type=str,
+                            required=True,
                             help="Input interface .h file.")
-    arg_parser.add_argument("--module_name", type=str, required=True,
+    arg_parser.add_argument("--module_name",
+                            type=str,
+                            required=True,
                             help="Name of the C++ class being wrapped.")
-    arg_parser.add_argument("--out", type=str, required=True,
+    arg_parser.add_argument("--out",
+                            type=str,
+                            required=True,
                             help="Name of the output folder.")
     arg_parser.add_argument(
         "--top_module_namespaces",
@@ -33,28 +37,22 @@ if __name__ == "__main__":
         "`<module_name>.Class` of the corresponding C++ `ns1::ns2::ns3::Class`"
         ", and `from <module_name> import ns4` gives you access to a Python "
         "`ns4.Class` of the C++ `ns1::ns2::ns3::ns4::Class`. ")
-    arg_parser.add_argument("--ignore",
-                            nargs='*',
-                            type=str,
-                            help="A space-separated list of classes to ignore. "
-                                 "Class names must include their full namespaces.")
+    arg_parser.add_argument(
+        "--ignore",
+        nargs='*',
+        type=str,
+        help="A space-separated list of classes to ignore. "
+        "Class names must include their full namespaces.")
     args = arg_parser.parse_args()
 
     top_module_namespaces = args.top_module_namespaces.split("::")
     if top_module_namespaces[0]:
         top_module_namespaces = [''] + top_module_namespaces
 
-    with open(args.src, 'r') as f:
-        content = f.read()
-
-    if not os.path.exists(args.src):
-        os.mkdir(args.src)
-
-    print("Ignoring classes: {}".format(args.ignore), file=sys.stderr)
+    print("[MatlabWrapper] Ignoring classes: {}".format(args.ignore), file=sys.stderr)
     wrapper = MatlabWrapper(module_name=args.module_name,
                             top_module_namespace=top_module_namespaces,
                             ignore_classes=args.ignore)
 
-    cc_content = wrapper.wrap(content)
-
-    generate_content(cc_content, args.out)
+    sources = args.src.split(';')
+    cc_content = wrapper.wrap(sources, path=args.out)

--- a/tests/expected/matlab/+gtsam/Class1.m
+++ b/tests/expected/matlab/+gtsam/Class1.m
@@ -1,0 +1,36 @@
+%class Class1, see Doxygen page for details
+%at https://gtsam.org/doxygen/
+%
+%-------Constructors-------
+%Class1()
+%
+classdef Class1 < handle
+  properties
+    ptr_gtsamClass1 = 0
+  end
+  methods
+    function obj = Class1(varargin)
+      if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
+        my_ptr = varargin{2};
+        multiple_files_wrapper(0, my_ptr);
+      elseif nargin == 0
+        my_ptr = multiple_files_wrapper(1);
+      else
+        error('Arguments do not match any overload of gtsam.Class1 constructor');
+      end
+      obj.ptr_gtsamClass1 = my_ptr;
+    end
+
+    function delete(obj)
+      multiple_files_wrapper(2, obj.ptr_gtsamClass1);
+    end
+
+    function display(obj), obj.print(''); end
+    %DISPLAY Calls print on the object
+    function disp(obj), obj.display; end
+    %DISP Calls print on the object
+  end
+
+  methods(Static = true)
+  end
+end

--- a/tests/expected/matlab/+gtsam/Class2.m
+++ b/tests/expected/matlab/+gtsam/Class2.m
@@ -1,0 +1,36 @@
+%class Class2, see Doxygen page for details
+%at https://gtsam.org/doxygen/
+%
+%-------Constructors-------
+%Class2()
+%
+classdef Class2 < handle
+  properties
+    ptr_gtsamClass2 = 0
+  end
+  methods
+    function obj = Class2(varargin)
+      if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
+        my_ptr = varargin{2};
+        multiple_files_wrapper(3, my_ptr);
+      elseif nargin == 0
+        my_ptr = multiple_files_wrapper(4);
+      else
+        error('Arguments do not match any overload of gtsam.Class2 constructor');
+      end
+      obj.ptr_gtsamClass2 = my_ptr;
+    end
+
+    function delete(obj)
+      multiple_files_wrapper(5, obj.ptr_gtsamClass2);
+    end
+
+    function display(obj), obj.print(''); end
+    %DISPLAY Calls print on the object
+    function disp(obj), obj.display; end
+    %DISP Calls print on the object
+  end
+
+  methods(Static = true)
+  end
+end

--- a/tests/expected/matlab/+gtsam/ClassA.m
+++ b/tests/expected/matlab/+gtsam/ClassA.m
@@ -1,0 +1,36 @@
+%class ClassA, see Doxygen page for details
+%at https://gtsam.org/doxygen/
+%
+%-------Constructors-------
+%ClassA()
+%
+classdef ClassA < handle
+  properties
+    ptr_gtsamClassA = 0
+  end
+  methods
+    function obj = ClassA(varargin)
+      if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
+        my_ptr = varargin{2};
+        multiple_files_wrapper(6, my_ptr);
+      elseif nargin == 0
+        my_ptr = multiple_files_wrapper(7);
+      else
+        error('Arguments do not match any overload of gtsam.ClassA constructor');
+      end
+      obj.ptr_gtsamClassA = my_ptr;
+    end
+
+    function delete(obj)
+      multiple_files_wrapper(8, obj.ptr_gtsamClassA);
+    end
+
+    function display(obj), obj.print(''); end
+    %DISPLAY Calls print on the object
+    function disp(obj), obj.display; end
+    %DISP Calls print on the object
+  end
+
+  methods(Static = true)
+  end
+end

--- a/tests/expected/matlab/multiple_files_wrapper.cpp
+++ b/tests/expected/matlab/multiple_files_wrapper.cpp
@@ -1,0 +1,229 @@
+#include <gtwrap/matlab.h>
+#include <map>
+
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/serialization/export.hpp>
+
+
+
+
+
+typedef std::set<boost::shared_ptr<gtsam::Class1>*> Collector_gtsamClass1;
+static Collector_gtsamClass1 collector_gtsamClass1;
+typedef std::set<boost::shared_ptr<gtsam::Class2>*> Collector_gtsamClass2;
+static Collector_gtsamClass2 collector_gtsamClass2;
+typedef std::set<boost::shared_ptr<gtsam::ClassA>*> Collector_gtsamClassA;
+static Collector_gtsamClassA collector_gtsamClassA;
+
+
+void _deleteAllObjects()
+{
+  mstream mout;
+  std::streambuf *outbuf = std::cout.rdbuf(&mout);
+
+  bool anyDeleted = false;
+  { for(Collector_gtsamClass1::iterator iter = collector_gtsamClass1.begin();
+      iter != collector_gtsamClass1.end(); ) {
+    delete *iter;
+    collector_gtsamClass1.erase(iter++);
+    anyDeleted = true;
+  } }
+  { for(Collector_gtsamClass2::iterator iter = collector_gtsamClass2.begin();
+      iter != collector_gtsamClass2.end(); ) {
+    delete *iter;
+    collector_gtsamClass2.erase(iter++);
+    anyDeleted = true;
+  } }
+  { for(Collector_gtsamClassA::iterator iter = collector_gtsamClassA.begin();
+      iter != collector_gtsamClassA.end(); ) {
+    delete *iter;
+    collector_gtsamClassA.erase(iter++);
+    anyDeleted = true;
+  } }
+
+  if(anyDeleted)
+    cout <<
+      "WARNING:  Wrap modules with variables in the workspace have been reloaded due to\n"
+      "calling destructors, call 'clear all' again if you plan to now recompile a wrap\n"
+      "module, so that your recompiled module is used instead of the old one." << endl;
+  std::cout.rdbuf(outbuf);
+}
+
+void _multiple_files_RTTIRegister() {
+  const mxArray *alreadyCreated = mexGetVariablePtr("global", "gtsam_multiple_files_rttiRegistry_created");
+  if(!alreadyCreated) {
+    std::map<std::string, std::string> types;
+
+
+
+    mxArray *registry = mexGetVariable("global", "gtsamwrap_rttiRegistry");
+    if(!registry)
+      registry = mxCreateStructMatrix(1, 1, 0, NULL);
+    typedef std::pair<std::string, std::string> StringPair;
+    for(const StringPair& rtti_matlab: types) {
+      int fieldId = mxAddField(registry, rtti_matlab.first.c_str());
+      if(fieldId < 0) {
+        mexErrMsgTxt("gtsam wrap:  Error indexing RTTI types, inheritance will not work correctly");
+      }
+      mxArray *matlabName = mxCreateString(rtti_matlab.second.c_str());
+      mxSetFieldByNumber(registry, 0, fieldId, matlabName);
+    }
+    if(mexPutVariable("global", "gtsamwrap_rttiRegistry", registry) != 0) {
+      mexErrMsgTxt("gtsam wrap:  Error indexing RTTI types, inheritance will not work correctly");
+    }
+    mxDestroyArray(registry);
+
+    mxArray *newAlreadyCreated = mxCreateNumericMatrix(0, 0, mxINT8_CLASS, mxREAL);
+    if(mexPutVariable("global", "gtsam_geometry_rttiRegistry_created", newAlreadyCreated) != 0) {
+      mexErrMsgTxt("gtsam wrap:  Error indexing RTTI types, inheritance will not work correctly");
+    }
+    mxDestroyArray(newAlreadyCreated);
+  }
+}
+
+void gtsamClass1_collectorInsertAndMakeBase_0(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  mexAtExit(&_deleteAllObjects);
+  typedef boost::shared_ptr<gtsam::Class1> Shared;
+
+  Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
+  collector_gtsamClass1.insert(self);
+}
+
+void gtsamClass1_constructor_1(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  mexAtExit(&_deleteAllObjects);
+  typedef boost::shared_ptr<gtsam::Class1> Shared;
+
+  Shared *self = new Shared(new gtsam::Class1());
+  collector_gtsamClass1.insert(self);
+  out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
+  *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
+}
+
+void gtsamClass1_deconstructor_2(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  typedef boost::shared_ptr<gtsam::Class1> Shared;
+  checkArguments("delete_gtsamClass1",nargout,nargin,1);
+  Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
+  Collector_gtsamClass1::iterator item;
+  item = collector_gtsamClass1.find(self);
+  if(item != collector_gtsamClass1.end()) {
+    delete self;
+    collector_gtsamClass1.erase(item);
+  }
+}
+
+void gtsamClass2_collectorInsertAndMakeBase_3(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  mexAtExit(&_deleteAllObjects);
+  typedef boost::shared_ptr<gtsam::Class2> Shared;
+
+  Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
+  collector_gtsamClass2.insert(self);
+}
+
+void gtsamClass2_constructor_4(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  mexAtExit(&_deleteAllObjects);
+  typedef boost::shared_ptr<gtsam::Class2> Shared;
+
+  Shared *self = new Shared(new gtsam::Class2());
+  collector_gtsamClass2.insert(self);
+  out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
+  *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
+}
+
+void gtsamClass2_deconstructor_5(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  typedef boost::shared_ptr<gtsam::Class2> Shared;
+  checkArguments("delete_gtsamClass2",nargout,nargin,1);
+  Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
+  Collector_gtsamClass2::iterator item;
+  item = collector_gtsamClass2.find(self);
+  if(item != collector_gtsamClass2.end()) {
+    delete self;
+    collector_gtsamClass2.erase(item);
+  }
+}
+
+void gtsamClassA_collectorInsertAndMakeBase_6(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  mexAtExit(&_deleteAllObjects);
+  typedef boost::shared_ptr<gtsam::ClassA> Shared;
+
+  Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
+  collector_gtsamClassA.insert(self);
+}
+
+void gtsamClassA_constructor_7(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  mexAtExit(&_deleteAllObjects);
+  typedef boost::shared_ptr<gtsam::ClassA> Shared;
+
+  Shared *self = new Shared(new gtsam::ClassA());
+  collector_gtsamClassA.insert(self);
+  out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
+  *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
+}
+
+void gtsamClassA_deconstructor_8(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  typedef boost::shared_ptr<gtsam::ClassA> Shared;
+  checkArguments("delete_gtsamClassA",nargout,nargin,1);
+  Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
+  Collector_gtsamClassA::iterator item;
+  item = collector_gtsamClassA.find(self);
+  if(item != collector_gtsamClassA.end()) {
+    delete self;
+    collector_gtsamClassA.erase(item);
+  }
+}
+
+
+void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  mstream mout;
+  std::streambuf *outbuf = std::cout.rdbuf(&mout);
+
+  _multiple_files_RTTIRegister();
+
+  int id = unwrap<int>(in[0]);
+
+  try {
+    switch(id) {
+    case 0:
+      gtsamClass1_collectorInsertAndMakeBase_0(nargout, out, nargin-1, in+1);
+      break;
+    case 1:
+      gtsamClass1_constructor_1(nargout, out, nargin-1, in+1);
+      break;
+    case 2:
+      gtsamClass1_deconstructor_2(nargout, out, nargin-1, in+1);
+      break;
+    case 3:
+      gtsamClass2_collectorInsertAndMakeBase_3(nargout, out, nargin-1, in+1);
+      break;
+    case 4:
+      gtsamClass2_constructor_4(nargout, out, nargin-1, in+1);
+      break;
+    case 5:
+      gtsamClass2_deconstructor_5(nargout, out, nargin-1, in+1);
+      break;
+    case 6:
+      gtsamClassA_collectorInsertAndMakeBase_6(nargout, out, nargin-1, in+1);
+      break;
+    case 7:
+      gtsamClassA_constructor_7(nargout, out, nargin-1, in+1);
+      break;
+    case 8:
+      gtsamClassA_deconstructor_8(nargout, out, nargin-1, in+1);
+      break;
+    }
+  } catch(const std::exception& e) {
+    mexErrMsgTxt(("Exception from gtsam:\n" + std::string(e.what()) + "\n").c_str());
+  }
+
+  std::cout.rdbuf(outbuf);
+}

--- a/tests/fixtures/part1.i
+++ b/tests/fixtures/part1.i
@@ -1,0 +1,11 @@
+// First file to test for multi-file support.
+
+namespace gtsam {
+class Class1 {
+  Class1();
+};
+
+class Class2 {
+  Class2();
+};
+}  // namespace gtsam

--- a/tests/fixtures/part2.i
+++ b/tests/fixtures/part2.i
@@ -1,0 +1,7 @@
+// Second file to test for multi-file support.
+
+namespace gtsam {
+class ClassA {
+  ClassA();
+};
+}  // namespace gtsam

--- a/tests/test_matlab_wrapper.py
+++ b/tests/test_matlab_wrapper.py
@@ -194,6 +194,31 @@ class TestWrap(unittest.TestCase):
         for file in files:
             self.compare_and_diff(file)
 
+    def test_multiple_files(self):
+        """
+        Test for when multiple interface files are specified.
+        """
+        file1 = osp.join(self.INTERFACE_DIR, 'part1.i')
+        file2 = osp.join(self.INTERFACE_DIR, 'part2.i')
+
+        wrapper = MatlabWrapper(
+            module_name='multiple_files',
+            top_module_namespace=['gtsam'],
+            ignore_classes=[''],
+        )
+
+        wrapper.wrap([file1, file2], path=self.MATLAB_ACTUAL_DIR)
+
+        files = [
+            'multiple_files_wrapper.cpp',
+            '+gtsam/Class1.m',
+            '+gtsam/Class2.m',
+            '+gtsam/ClassA.m',
+        ]
+
+        for file in files:
+            self.compare_and_diff(file)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR makes Matlab wrapping consistent with the Python wrapper with support for multiple files.

I added a unit test to verify this and also tested it out on the `gtsam-project-matlab` example project.