### PR TITLE
Matlab default arguments

### DIFF
--- a/gtwrap/matlab_wrapper/wrapper.py
+++ b/gtwrap/matlab_wrapper/wrapper.py
@@ -10,6 +10,7 @@ import os.path as osp
 import textwrap
 from functools import partial, reduce
 from typing import Dict, Iterable, List, Union
+import copy
 
 import gtwrap.interface_parser as parser
 import gtwrap.template_instantiator as instantiator
@@ -137,6 +138,28 @@ class MatlabWrapper(CheckMixin, FormatMixin):
         """
         return x + '\n' + ('' if y == '' else '  ') + y
 
+    @staticmethod
+    def _expand_default_arguments(method, save_backup=True):
+        """Recursively expand all possibilities for optional default arguments.
+        We create "overload" functions with fewer arguments, but since we have to "remember" what
+        the default arguments are for later, we make a backup.
+        """
+        if save_backup:
+            method.args.backup = copy.deepcopy(method.args)
+            method = copy.deepcopy(method)
+        for arg in method.args.list():
+            if arg.default is not None:
+                arg.default = None
+                methodWithArg = copy.deepcopy(method)
+                method.args.list().remove(arg)
+                return [
+                    *MatlabWrapper._expand_default_arguments(methodWithArg, save_backup=False),
+                    *MatlabWrapper._expand_default_arguments(
+                        method,
+                        save_backup=False)  # can not-expand this to disallow skipping arguments
+                ]
+        return [method]
+
     def _group_methods(self, methods):
         """Group overloaded methods together"""
         method_map = {}
@@ -147,9 +170,9 @@ class MatlabWrapper(CheckMixin, FormatMixin):
 
             if method_index is None:
                 method_map[method.name] = len(method_out)
-                method_out.append([method])
+                method_out.append(MatlabWrapper._expand_default_arguments(method))
             else:
-                method_out[method_index].append(method)
+                method_out[method_index] += MatlabWrapper._expand_default_arguments(method)
 
         return method_out
 
@@ -301,13 +324,9 @@ class MatlabWrapper(CheckMixin, FormatMixin):
             ((a), Test& t = *unwrap_shared_ptr< Test >(in[1], "ptr_Test");),
             ((a), std::shared_ptr<Test> p1 = unwrap_shared_ptr< Test >(in[1], "ptr_Test");)
         """
-        params = ''
         body_args = ''
 
         for arg in args.list():
-            if params != '':
-                params += ','
-
             if self.is_ref(arg.ctype):  # and not constructor:
                 ctype_camel = self._format_type_name(arg.ctype.typename,
                                                      separator='')
@@ -336,8 +355,6 @@ class MatlabWrapper(CheckMixin, FormatMixin):
                            name=arg.name,
                            id=arg_id)),
                                              prefix='  ')
-                if call_type == "":
-                    params += "*"
 
             else:
                 body_args += textwrap.indent(textwrap.dedent('''\
@@ -347,9 +364,28 @@ class MatlabWrapper(CheckMixin, FormatMixin):
                            id=arg_id)),
                                              prefix='  ')
 
-            params += arg.name
-
             arg_id += 1
+
+        params = ''
+        explicit_arg_names = [arg.name for arg in args.list()]
+        # when returning the params list, we need to re-include the default args.
+        for arg in args.backup.list():
+            if params != '':
+                params += ','
+
+            if (arg.default is not None) and (arg.name not in explicit_arg_names):
+                params += arg.default
+                continue
+
+            if (not self.is_ref(arg.ctype)) and (self.is_shared_ptr(arg.ctype)) and (self.is_ptr(
+                    arg.ctype)) and (arg.ctype.typename.name not in self.ignore_namespace):
+                if arg.ctype.is_shared_ptr:
+                    call_type = arg.ctype.is_shared_ptr
+                else:
+                    call_type = arg.ctype.is_ptr
+                if call_type == "":
+                    params += "*"
+            params += arg.name
 
         return params, body_args
 
@@ -555,6 +591,8 @@ class MatlabWrapper(CheckMixin, FormatMixin):
         if not isinstance(ctors, Iterable):
             ctors = [ctors]
 
+        ctors = sum((MatlabWrapper._expand_default_arguments(ctor) for ctor in ctors), [])
+
         methods_wrap = textwrap.indent(textwrap.dedent("""\
             methods
               function obj = {class_name}(varargin)
@@ -674,20 +712,7 @@ class MatlabWrapper(CheckMixin, FormatMixin):
 
     def _group_class_methods(self, methods):
         """Group overloaded methods together"""
-        method_map = {}
-        method_out = []
-
-        for method in methods:
-            method_index = method_map.get(method.name)
-
-            if method_index is None:
-                method_map[method.name] = len(method_out)
-                method_out.append([method])
-            else:
-                # print("[_group_methods] Merging {} with {}".format(method_index, method.name))
-                method_out[method_index].append(method)
-
-        return method_out
+        return self._group_methods(methods)
 
     @classmethod
     def _format_varargout(cls, return_type, return_type_formatted):

--- a/gtwrap/matlab_wrapper/wrapper.py
+++ b/gtwrap/matlab_wrapper/wrapper.py
@@ -155,17 +155,19 @@ class MatlabWrapper(CheckMixin, FormatMixin):
         if save_backup:
             method.args.backup = args_copy(method.args)
         method = method_copy(method)
-        for arg in method.args.list():
+        for arg in reversed(method.args.list()):
             if arg.default is not None:
                 arg.default = None
                 methodWithArg = method_copy(method)
                 method.args.list().remove(arg)
                 return [
-                    *MatlabWrapper._expand_default_arguments(methodWithArg, save_backup=False),
-                    *MatlabWrapper._expand_default_arguments(
-                        method,
-                        save_backup=False)  # can not-expand this to disallow skipping arguments
+                    methodWithArg,
+                    *MatlabWrapper._expand_default_arguments(method, save_backup=False)
                 ]
+            break
+        assert all(arg.default is None for arg in method.args.list()), \
+            'In parsing method {:}: Arguments with default values cannot appear before ones ' \
+            'without default values.'.format(method.name)
         return [method]
 
     def _group_methods(self, methods):

--- a/tests/actual/.gitignore
+++ b/tests/actual/.gitignore
@@ -1,0 +1,2 @@
+./*
+!.gitignore

--- a/tests/expected/matlab/DefaultFuncInt.m
+++ b/tests/expected/matlab/DefaultFuncInt.m
@@ -1,6 +1,10 @@
 function varargout = DefaultFuncInt(varargin)
       if length(varargin) == 2 && isa(varargin{1},'numeric') && isa(varargin{2},'numeric')
         functions_wrapper(8, varargin{:});
+      elseif length(varargin) == 1 && isa(varargin{1},'numeric')
+        functions_wrapper(9, varargin{:});
+      elseif length(varargin) == 0
+        functions_wrapper(10, varargin{:});
       else
         error('Arguments do not match any overload of function DefaultFuncInt');
       end

--- a/tests/expected/matlab/DefaultFuncInt.m
+++ b/tests/expected/matlab/DefaultFuncInt.m
@@ -3,8 +3,10 @@ function varargout = DefaultFuncInt(varargin)
         functions_wrapper(8, varargin{:});
       elseif length(varargin) == 1 && isa(varargin{1},'numeric')
         functions_wrapper(9, varargin{:});
-      elseif length(varargin) == 0
+      elseif length(varargin) == 1 && isa(varargin{1},'numeric')
         functions_wrapper(10, varargin{:});
+      elseif length(varargin) == 0
+        functions_wrapper(11, varargin{:});
       else
         error('Arguments do not match any overload of function DefaultFuncInt');
       end

--- a/tests/expected/matlab/DefaultFuncInt.m
+++ b/tests/expected/matlab/DefaultFuncInt.m
@@ -3,10 +3,8 @@ function varargout = DefaultFuncInt(varargin)
         functions_wrapper(8, varargin{:});
       elseif length(varargin) == 1 && isa(varargin{1},'numeric')
         functions_wrapper(9, varargin{:});
-      elseif length(varargin) == 1 && isa(varargin{1},'numeric')
-        functions_wrapper(10, varargin{:});
       elseif length(varargin) == 0
-        functions_wrapper(11, varargin{:});
+        functions_wrapper(10, varargin{:});
       else
         error('Arguments do not match any overload of function DefaultFuncInt');
       end

--- a/tests/expected/matlab/DefaultFuncObj.m
+++ b/tests/expected/matlab/DefaultFuncObj.m
@@ -1,6 +1,8 @@
 function varargout = DefaultFuncObj(varargin)
       if length(varargin) == 1 && isa(varargin{1},'gtsam.KeyFormatter')
-        functions_wrapper(10, varargin{:});
+        functions_wrapper(16, varargin{:});
+      elseif length(varargin) == 0
+        functions_wrapper(17, varargin{:});
       else
         error('Arguments do not match any overload of function DefaultFuncObj');
       end

--- a/tests/expected/matlab/DefaultFuncObj.m
+++ b/tests/expected/matlab/DefaultFuncObj.m
@@ -1,8 +1,8 @@
 function varargout = DefaultFuncObj(varargin)
       if length(varargin) == 1 && isa(varargin{1},'gtsam.KeyFormatter')
-        functions_wrapper(16, varargin{:});
+        functions_wrapper(14, varargin{:});
       elseif length(varargin) == 0
-        functions_wrapper(17, varargin{:});
+        functions_wrapper(15, varargin{:});
       else
         error('Arguments do not match any overload of function DefaultFuncObj');
       end

--- a/tests/expected/matlab/DefaultFuncString.m
+++ b/tests/expected/matlab/DefaultFuncString.m
@@ -1,6 +1,12 @@
 function varargout = DefaultFuncString(varargin)
       if length(varargin) == 2 && isa(varargin{1},'char') && isa(varargin{2},'char')
-        functions_wrapper(9, varargin{:});
+        functions_wrapper(12, varargin{:});
+      elseif length(varargin) == 1 && isa(varargin{1},'char')
+        functions_wrapper(13, varargin{:});
+      elseif length(varargin) == 1 && isa(varargin{1},'char')
+        functions_wrapper(14, varargin{:});
+      elseif length(varargin) == 0
+        functions_wrapper(15, varargin{:});
       else
         error('Arguments do not match any overload of function DefaultFuncString');
       end

--- a/tests/expected/matlab/DefaultFuncString.m
+++ b/tests/expected/matlab/DefaultFuncString.m
@@ -1,12 +1,10 @@
 function varargout = DefaultFuncString(varargin)
       if length(varargin) == 2 && isa(varargin{1},'char') && isa(varargin{2},'char')
+        functions_wrapper(11, varargin{:});
+      elseif length(varargin) == 1 && isa(varargin{1},'char')
         functions_wrapper(12, varargin{:});
-      elseif length(varargin) == 1 && isa(varargin{1},'char')
-        functions_wrapper(13, varargin{:});
-      elseif length(varargin) == 1 && isa(varargin{1},'char')
-        functions_wrapper(14, varargin{:});
       elseif length(varargin) == 0
-        functions_wrapper(15, varargin{:});
+        functions_wrapper(13, varargin{:});
       else
         error('Arguments do not match any overload of function DefaultFuncString');
       end

--- a/tests/expected/matlab/DefaultFuncVector.m
+++ b/tests/expected/matlab/DefaultFuncVector.m
@@ -1,6 +1,12 @@
 function varargout = DefaultFuncVector(varargin)
       if length(varargin) == 2 && isa(varargin{1},'std.vectornumeric') && isa(varargin{2},'std.vectorchar')
-        functions_wrapper(12, varargin{:});
+        functions_wrapper(26, varargin{:});
+      elseif length(varargin) == 1 && isa(varargin{1},'std.vectornumeric')
+        functions_wrapper(27, varargin{:});
+      elseif length(varargin) == 1 && isa(varargin{1},'std.vectorchar')
+        functions_wrapper(28, varargin{:});
+      elseif length(varargin) == 0
+        functions_wrapper(29, varargin{:});
       else
         error('Arguments do not match any overload of function DefaultFuncVector');
       end

--- a/tests/expected/matlab/DefaultFuncVector.m
+++ b/tests/expected/matlab/DefaultFuncVector.m
@@ -1,12 +1,10 @@
 function varargout = DefaultFuncVector(varargin)
       if length(varargin) == 2 && isa(varargin{1},'std.vectornumeric') && isa(varargin{2},'std.vectorchar')
-        functions_wrapper(26, varargin{:});
+        functions_wrapper(20, varargin{:});
       elseif length(varargin) == 1 && isa(varargin{1},'std.vectornumeric')
-        functions_wrapper(27, varargin{:});
-      elseif length(varargin) == 1 && isa(varargin{1},'std.vectorchar')
-        functions_wrapper(28, varargin{:});
+        functions_wrapper(21, varargin{:});
       elseif length(varargin) == 0
-        functions_wrapper(29, varargin{:});
+        functions_wrapper(22, varargin{:});
       else
         error('Arguments do not match any overload of function DefaultFuncVector');
       end

--- a/tests/expected/matlab/DefaultFuncZero.m
+++ b/tests/expected/matlab/DefaultFuncZero.m
@@ -1,6 +1,20 @@
 function varargout = DefaultFuncZero(varargin)
       if length(varargin) == 5 && isa(varargin{1},'numeric') && isa(varargin{2},'numeric') && isa(varargin{3},'double') && isa(varargin{4},'logical') && isa(varargin{5},'logical')
-        functions_wrapper(11, varargin{:});
+        functions_wrapper(18, varargin{:});
+      elseif length(varargin) == 4 && isa(varargin{1},'numeric') && isa(varargin{2},'numeric') && isa(varargin{3},'double') && isa(varargin{4},'logical')
+        functions_wrapper(19, varargin{:});
+      elseif length(varargin) == 4 && isa(varargin{1},'numeric') && isa(varargin{2},'numeric') && isa(varargin{3},'logical') && isa(varargin{4},'logical')
+        functions_wrapper(20, varargin{:});
+      elseif length(varargin) == 3 && isa(varargin{1},'numeric') && isa(varargin{2},'numeric') && isa(varargin{3},'logical')
+        functions_wrapper(21, varargin{:});
+      elseif length(varargin) == 4 && isa(varargin{1},'numeric') && isa(varargin{2},'double') && isa(varargin{3},'logical') && isa(varargin{4},'logical')
+        functions_wrapper(22, varargin{:});
+      elseif length(varargin) == 3 && isa(varargin{1},'numeric') && isa(varargin{2},'double') && isa(varargin{3},'logical')
+        functions_wrapper(23, varargin{:});
+      elseif length(varargin) == 3 && isa(varargin{1},'numeric') && isa(varargin{2},'logical') && isa(varargin{3},'logical')
+        functions_wrapper(24, varargin{:});
+      elseif length(varargin) == 2 && isa(varargin{1},'numeric') && isa(varargin{2},'logical')
+        functions_wrapper(25, varargin{:});
       else
         error('Arguments do not match any overload of function DefaultFuncZero');
       end

--- a/tests/expected/matlab/DefaultFuncZero.m
+++ b/tests/expected/matlab/DefaultFuncZero.m
@@ -1,20 +1,12 @@
 function varargout = DefaultFuncZero(varargin)
-      if length(varargin) == 5 && isa(varargin{1},'numeric') && isa(varargin{2},'numeric') && isa(varargin{3},'double') && isa(varargin{4},'logical') && isa(varargin{5},'logical')
+      if length(varargin) == 5 && isa(varargin{1},'numeric') && isa(varargin{2},'numeric') && isa(varargin{3},'double') && isa(varargin{4},'numeric') && isa(varargin{5},'logical')
+        functions_wrapper(16, varargin{:});
+      elseif length(varargin) == 4 && isa(varargin{1},'numeric') && isa(varargin{2},'numeric') && isa(varargin{3},'double') && isa(varargin{4},'numeric')
+        functions_wrapper(17, varargin{:});
+      elseif length(varargin) == 3 && isa(varargin{1},'numeric') && isa(varargin{2},'numeric') && isa(varargin{3},'double')
         functions_wrapper(18, varargin{:});
-      elseif length(varargin) == 4 && isa(varargin{1},'numeric') && isa(varargin{2},'numeric') && isa(varargin{3},'double') && isa(varargin{4},'logical')
+      elseif length(varargin) == 2 && isa(varargin{1},'numeric') && isa(varargin{2},'numeric')
         functions_wrapper(19, varargin{:});
-      elseif length(varargin) == 4 && isa(varargin{1},'numeric') && isa(varargin{2},'numeric') && isa(varargin{3},'logical') && isa(varargin{4},'logical')
-        functions_wrapper(20, varargin{:});
-      elseif length(varargin) == 3 && isa(varargin{1},'numeric') && isa(varargin{2},'numeric') && isa(varargin{3},'logical')
-        functions_wrapper(21, varargin{:});
-      elseif length(varargin) == 4 && isa(varargin{1},'numeric') && isa(varargin{2},'double') && isa(varargin{3},'logical') && isa(varargin{4},'logical')
-        functions_wrapper(22, varargin{:});
-      elseif length(varargin) == 3 && isa(varargin{1},'numeric') && isa(varargin{2},'double') && isa(varargin{3},'logical')
-        functions_wrapper(23, varargin{:});
-      elseif length(varargin) == 3 && isa(varargin{1},'numeric') && isa(varargin{2},'logical') && isa(varargin{3},'logical')
-        functions_wrapper(24, varargin{:});
-      elseif length(varargin) == 2 && isa(varargin{1},'numeric') && isa(varargin{2},'logical')
-        functions_wrapper(25, varargin{:});
       else
         error('Arguments do not match any overload of function DefaultFuncZero');
       end

--- a/tests/expected/matlab/ForwardKinematics.m
+++ b/tests/expected/matlab/ForwardKinematics.m
@@ -15,6 +15,8 @@ classdef ForwardKinematics < handle
         class_wrapper(55, my_ptr);
       elseif nargin == 5 && isa(varargin{1},'gtdynamics.Robot') && isa(varargin{2},'char') && isa(varargin{3},'char') && isa(varargin{4},'gtsam.Values') && isa(varargin{5},'gtsam.Pose3')
         my_ptr = class_wrapper(56, varargin{1}, varargin{2}, varargin{3}, varargin{4}, varargin{5});
+      elseif nargin == 4 && isa(varargin{1},'gtdynamics.Robot') && isa(varargin{2},'char') && isa(varargin{3},'char') && isa(varargin{4},'gtsam.Values')
+        my_ptr = class_wrapper(57, varargin{1}, varargin{2}, varargin{3}, varargin{4});
       else
         error('Arguments do not match any overload of ForwardKinematics constructor');
       end
@@ -22,7 +24,7 @@ classdef ForwardKinematics < handle
     end
 
     function delete(obj)
-      class_wrapper(57, obj.ptr_ForwardKinematics);
+      class_wrapper(58, obj.ptr_ForwardKinematics);
     end
 
     function display(obj), obj.print(''); end

--- a/tests/expected/matlab/MyFactorPosePoint2.m
+++ b/tests/expected/matlab/MyFactorPosePoint2.m
@@ -15,9 +15,9 @@ classdef MyFactorPosePoint2 < handle
     function obj = MyFactorPosePoint2(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(64, my_ptr);
+        class_wrapper(65, my_ptr);
       elseif nargin == 4 && isa(varargin{1},'numeric') && isa(varargin{2},'numeric') && isa(varargin{3},'double') && isa(varargin{4},'gtsam.noiseModel.Base')
-        my_ptr = class_wrapper(65, varargin{1}, varargin{2}, varargin{3}, varargin{4});
+        my_ptr = class_wrapper(66, varargin{1}, varargin{2}, varargin{3}, varargin{4});
       else
         error('Arguments do not match any overload of MyFactorPosePoint2 constructor');
       end
@@ -25,7 +25,7 @@ classdef MyFactorPosePoint2 < handle
     end
 
     function delete(obj)
-      class_wrapper(66, obj.ptr_MyFactorPosePoint2);
+      class_wrapper(67, obj.ptr_MyFactorPosePoint2);
     end
 
     function display(obj), obj.print(''); end
@@ -36,7 +36,25 @@ classdef MyFactorPosePoint2 < handle
       % PRINT usage: print(string s, KeyFormatter keyFormatter) : returns void
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 2 && isa(varargin{1},'char') && isa(varargin{2},'gtsam.KeyFormatter')
-        class_wrapper(67, this, varargin{:});
+        class_wrapper(68, this, varargin{:});
+        return
+      end
+      % PRINT usage: print(string s) : returns void
+      % Doxygen can be found at https://gtsam.org/doxygen/
+      if length(varargin) == 1 && isa(varargin{1},'char')
+        class_wrapper(69, this, varargin{:});
+        return
+      end
+      % PRINT usage: print(KeyFormatter keyFormatter) : returns void
+      % Doxygen can be found at https://gtsam.org/doxygen/
+      if length(varargin) == 1 && isa(varargin{1},'gtsam.KeyFormatter')
+        class_wrapper(70, this, varargin{:});
+        return
+      end
+      % PRINT usage: print() : returns void
+      % Doxygen can be found at https://gtsam.org/doxygen/
+      if length(varargin) == 0
+        class_wrapper(71, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function MyFactorPosePoint2.print');

--- a/tests/expected/matlab/MyFactorPosePoint2.m
+++ b/tests/expected/matlab/MyFactorPosePoint2.m
@@ -45,16 +45,10 @@ classdef MyFactorPosePoint2 < handle
         class_wrapper(69, this, varargin{:});
         return
       end
-      % PRINT usage: print(KeyFormatter keyFormatter) : returns void
-      % Doxygen can be found at https://gtsam.org/doxygen/
-      if length(varargin) == 1 && isa(varargin{1},'gtsam.KeyFormatter')
-        class_wrapper(70, this, varargin{:});
-        return
-      end
       % PRINT usage: print() : returns void
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 0
-        class_wrapper(71, this, varargin{:});
+        class_wrapper(70, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function MyFactorPosePoint2.print');

--- a/tests/expected/matlab/TemplatedFunctionRot3.m
+++ b/tests/expected/matlab/TemplatedFunctionRot3.m
@@ -1,6 +1,6 @@
 function varargout = TemplatedFunctionRot3(varargin)
       if length(varargin) == 1 && isa(varargin{1},'gtsam.Rot3')
-        functions_wrapper(32, varargin{:});
+        functions_wrapper(25, varargin{:});
       else
         error('Arguments do not match any overload of function TemplatedFunctionRot3');
       end

--- a/tests/expected/matlab/TemplatedFunctionRot3.m
+++ b/tests/expected/matlab/TemplatedFunctionRot3.m
@@ -1,6 +1,6 @@
 function varargout = TemplatedFunctionRot3(varargin)
       if length(varargin) == 1 && isa(varargin{1},'gtsam.Rot3')
-        functions_wrapper(14, varargin{:});
+        functions_wrapper(32, varargin{:});
       else
         error('Arguments do not match any overload of function TemplatedFunctionRot3');
       end

--- a/tests/expected/matlab/class_wrapper.cpp
+++ b/tests/expected/matlab/class_wrapper.cpp
@@ -844,14 +844,6 @@ void MyFactorPosePoint2_print_69(int nargout, mxArray *out[], int nargin, const 
 
 void MyFactorPosePoint2_print_70(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  checkArguments("print",nargout,nargin-1,1);
-  auto obj = unwrap_shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>>(in[0], "ptr_MyFactorPosePoint2");
-  gtsam::KeyFormatter& keyFormatter = *unwrap_shared_ptr< gtsam::KeyFormatter >(in[1], "ptr_gtsamKeyFormatter");
-  obj->print("factor: ",keyFormatter);
-}
-
-void MyFactorPosePoint2_print_71(int nargout, mxArray *out[], int nargin, const mxArray *in[])
-{
   checkArguments("print",nargout,nargin-1,0);
   auto obj = unwrap_shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>>(in[0], "ptr_MyFactorPosePoint2");
   obj->print("factor: ",gtsam::DefaultKeyFormatter);
@@ -1081,9 +1073,6 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       break;
     case 70:
       MyFactorPosePoint2_print_70(nargout, out, nargin-1, in+1);
-      break;
-    case 71:
-      MyFactorPosePoint2_print_71(nargout, out, nargin-1, in+1);
       break;
     }
   } catch(const std::exception& e) {

--- a/tests/expected/matlab/class_wrapper.cpp
+++ b/tests/expected/matlab/class_wrapper.cpp
@@ -691,7 +691,22 @@ void ForwardKinematics_constructor_56(int nargout, mxArray *out[], int nargin, c
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void ForwardKinematics_deconstructor_57(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void ForwardKinematics_constructor_57(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  mexAtExit(&_deleteAllObjects);
+  typedef boost::shared_ptr<ForwardKinematics> Shared;
+
+  gtdynamics::Robot& robot = *unwrap_shared_ptr< gtdynamics::Robot >(in[0], "ptr_gtdynamicsRobot");
+  string& start_link_name = *unwrap_shared_ptr< string >(in[1], "ptr_string");
+  string& end_link_name = *unwrap_shared_ptr< string >(in[2], "ptr_string");
+  gtsam::Values& joint_angles = *unwrap_shared_ptr< gtsam::Values >(in[3], "ptr_gtsamValues");
+  Shared *self = new Shared(new ForwardKinematics(robot,start_link_name,end_link_name,joint_angles,gtsam::Pose3()));
+  collector_ForwardKinematics.insert(self);
+  out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
+  *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
+}
+
+void ForwardKinematics_deconstructor_58(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<ForwardKinematics> Shared;
   checkArguments("delete_ForwardKinematics",nargout,nargin,1);
@@ -704,7 +719,7 @@ void ForwardKinematics_deconstructor_57(int nargout, mxArray *out[], int nargin,
   }
 }
 
-void TemplatedConstructor_collectorInsertAndMakeBase_58(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void TemplatedConstructor_collectorInsertAndMakeBase_59(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<TemplatedConstructor> Shared;
@@ -713,7 +728,7 @@ void TemplatedConstructor_collectorInsertAndMakeBase_58(int nargout, mxArray *ou
   collector_TemplatedConstructor.insert(self);
 }
 
-void TemplatedConstructor_constructor_59(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void TemplatedConstructor_constructor_60(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<TemplatedConstructor> Shared;
@@ -724,7 +739,7 @@ void TemplatedConstructor_constructor_59(int nargout, mxArray *out[], int nargin
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void TemplatedConstructor_constructor_60(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void TemplatedConstructor_constructor_61(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<TemplatedConstructor> Shared;
@@ -736,7 +751,7 @@ void TemplatedConstructor_constructor_60(int nargout, mxArray *out[], int nargin
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void TemplatedConstructor_constructor_61(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void TemplatedConstructor_constructor_62(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<TemplatedConstructor> Shared;
@@ -748,7 +763,7 @@ void TemplatedConstructor_constructor_61(int nargout, mxArray *out[], int nargin
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void TemplatedConstructor_constructor_62(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void TemplatedConstructor_constructor_63(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<TemplatedConstructor> Shared;
@@ -760,7 +775,7 @@ void TemplatedConstructor_constructor_62(int nargout, mxArray *out[], int nargin
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void TemplatedConstructor_deconstructor_63(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void TemplatedConstructor_deconstructor_64(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<TemplatedConstructor> Shared;
   checkArguments("delete_TemplatedConstructor",nargout,nargin,1);
@@ -773,7 +788,7 @@ void TemplatedConstructor_deconstructor_63(int nargout, mxArray *out[], int narg
   }
 }
 
-void MyFactorPosePoint2_collectorInsertAndMakeBase_64(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyFactorPosePoint2_collectorInsertAndMakeBase_65(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>> Shared;
@@ -782,7 +797,7 @@ void MyFactorPosePoint2_collectorInsertAndMakeBase_64(int nargout, mxArray *out[
   collector_MyFactorPosePoint2.insert(self);
 }
 
-void MyFactorPosePoint2_constructor_65(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyFactorPosePoint2_constructor_66(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>> Shared;
@@ -797,7 +812,7 @@ void MyFactorPosePoint2_constructor_65(int nargout, mxArray *out[], int nargin, 
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void MyFactorPosePoint2_deconstructor_66(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyFactorPosePoint2_deconstructor_67(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>> Shared;
   checkArguments("delete_MyFactorPosePoint2",nargout,nargin,1);
@@ -810,13 +825,36 @@ void MyFactorPosePoint2_deconstructor_66(int nargout, mxArray *out[], int nargin
   }
 }
 
-void MyFactorPosePoint2_print_67(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyFactorPosePoint2_print_68(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("print",nargout,nargin-1,2);
   auto obj = unwrap_shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>>(in[0], "ptr_MyFactorPosePoint2");
   string& s = *unwrap_shared_ptr< string >(in[1], "ptr_string");
   gtsam::KeyFormatter& keyFormatter = *unwrap_shared_ptr< gtsam::KeyFormatter >(in[2], "ptr_gtsamKeyFormatter");
   obj->print(s,keyFormatter);
+}
+
+void MyFactorPosePoint2_print_69(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("print",nargout,nargin-1,1);
+  auto obj = unwrap_shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>>(in[0], "ptr_MyFactorPosePoint2");
+  string& s = *unwrap_shared_ptr< string >(in[1], "ptr_string");
+  obj->print(s,gtsam::DefaultKeyFormatter);
+}
+
+void MyFactorPosePoint2_print_70(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("print",nargout,nargin-1,1);
+  auto obj = unwrap_shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>>(in[0], "ptr_MyFactorPosePoint2");
+  gtsam::KeyFormatter& keyFormatter = *unwrap_shared_ptr< gtsam::KeyFormatter >(in[2], "ptr_gtsamKeyFormatter");
+  obj->print("factor: ",keyFormatter);
+}
+
+void MyFactorPosePoint2_print_71(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("print",nargout,nargin-1,0);
+  auto obj = unwrap_shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>>(in[0], "ptr_MyFactorPosePoint2");
+  obj->print("factor: ",gtsam::DefaultKeyFormatter);
 }
 
 
@@ -1003,13 +1041,13 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       ForwardKinematics_constructor_56(nargout, out, nargin-1, in+1);
       break;
     case 57:
-      ForwardKinematics_deconstructor_57(nargout, out, nargin-1, in+1);
+      ForwardKinematics_constructor_57(nargout, out, nargin-1, in+1);
       break;
     case 58:
-      TemplatedConstructor_collectorInsertAndMakeBase_58(nargout, out, nargin-1, in+1);
+      ForwardKinematics_deconstructor_58(nargout, out, nargin-1, in+1);
       break;
     case 59:
-      TemplatedConstructor_constructor_59(nargout, out, nargin-1, in+1);
+      TemplatedConstructor_collectorInsertAndMakeBase_59(nargout, out, nargin-1, in+1);
       break;
     case 60:
       TemplatedConstructor_constructor_60(nargout, out, nargin-1, in+1);
@@ -1021,19 +1059,28 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       TemplatedConstructor_constructor_62(nargout, out, nargin-1, in+1);
       break;
     case 63:
-      TemplatedConstructor_deconstructor_63(nargout, out, nargin-1, in+1);
+      TemplatedConstructor_constructor_63(nargout, out, nargin-1, in+1);
       break;
     case 64:
-      MyFactorPosePoint2_collectorInsertAndMakeBase_64(nargout, out, nargin-1, in+1);
+      TemplatedConstructor_deconstructor_64(nargout, out, nargin-1, in+1);
       break;
     case 65:
-      MyFactorPosePoint2_constructor_65(nargout, out, nargin-1, in+1);
+      MyFactorPosePoint2_collectorInsertAndMakeBase_65(nargout, out, nargin-1, in+1);
       break;
     case 66:
-      MyFactorPosePoint2_deconstructor_66(nargout, out, nargin-1, in+1);
+      MyFactorPosePoint2_constructor_66(nargout, out, nargin-1, in+1);
       break;
     case 67:
-      MyFactorPosePoint2_print_67(nargout, out, nargin-1, in+1);
+      MyFactorPosePoint2_deconstructor_67(nargout, out, nargin-1, in+1);
+      break;
+    case 68:
+      MyFactorPosePoint2_print_68(nargout, out, nargin-1, in+1);
+    case 69:
+      MyFactorPosePoint2_print_69(nargout, out, nargin-1, in+1);
+    case 70:
+      MyFactorPosePoint2_print_70(nargout, out, nargin-1, in+1);
+    case 71:
+      MyFactorPosePoint2_print_71(nargout, out, nargin-1, in+1);
       break;
     }
   } catch(const std::exception& e) {

--- a/tests/expected/matlab/class_wrapper.cpp
+++ b/tests/expected/matlab/class_wrapper.cpp
@@ -846,7 +846,7 @@ void MyFactorPosePoint2_print_70(int nargout, mxArray *out[], int nargin, const 
 {
   checkArguments("print",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>>(in[0], "ptr_MyFactorPosePoint2");
-  gtsam::KeyFormatter& keyFormatter = *unwrap_shared_ptr< gtsam::KeyFormatter >(in[2], "ptr_gtsamKeyFormatter");
+  gtsam::KeyFormatter& keyFormatter = *unwrap_shared_ptr< gtsam::KeyFormatter >(in[1], "ptr_gtsamKeyFormatter");
   obj->print("factor: ",keyFormatter);
 }
 
@@ -1075,10 +1075,13 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       break;
     case 68:
       MyFactorPosePoint2_print_68(nargout, out, nargin-1, in+1);
+      break;
     case 69:
       MyFactorPosePoint2_print_69(nargout, out, nargin-1, in+1);
+      break;
     case 70:
       MyFactorPosePoint2_print_70(nargout, out, nargin-1, in+1);
+      break;
     case 71:
       MyFactorPosePoint2_print_71(nargout, out, nargin-1, in+1);
       break;

--- a/tests/expected/matlab/functions_wrapper.cpp
+++ b/tests/expected/matlab/functions_wrapper.cpp
@@ -130,6 +130,17 @@ void DefaultFuncInt_8(int nargout, mxArray *out[], int nargin, const mxArray *in
   int b = unwrap< int >(in[1]);
   DefaultFuncInt(a,b);
 }
+void DefaultFuncInt_9(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("DefaultFuncInt",nargout,nargin,1);
+  int a = unwrap< int >(in[0]);
+  DefaultFuncInt(a);
+}
+void DefaultFuncInt_10(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("DefaultFuncInt",nargout,nargin,0);
+  DefaultFuncInt();
+}
 void DefaultFuncString_9(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("DefaultFuncString",nargout,nargin,2);

--- a/tests/expected/matlab/functions_wrapper.cpp
+++ b/tests/expected/matlab/functions_wrapper.cpp
@@ -138,154 +138,102 @@ void DefaultFuncInt_9(int nargout, mxArray *out[], int nargin, const mxArray *in
 }
 void DefaultFuncInt_10(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  checkArguments("DefaultFuncInt",nargout,nargin,1);
-  int b = unwrap< int >(in[0]);
-  DefaultFuncInt(123,b);
-}
-void DefaultFuncInt_11(int nargout, mxArray *out[], int nargin, const mxArray *in[])
-{
   checkArguments("DefaultFuncInt",nargout,nargin,0);
   DefaultFuncInt(123,0);
 }
-void DefaultFuncString_12(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void DefaultFuncString_11(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("DefaultFuncString",nargout,nargin,2);
   string& s = *unwrap_shared_ptr< string >(in[0], "ptr_string");
   string& name = *unwrap_shared_ptr< string >(in[1], "ptr_string");
   DefaultFuncString(s,name);
 }
-void DefaultFuncString_13(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void DefaultFuncString_12(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("DefaultFuncString",nargout,nargin,1);
   string& s = *unwrap_shared_ptr< string >(in[0], "ptr_string");
   DefaultFuncString(s,"");
 }
-void DefaultFuncString_14(int nargout, mxArray *out[], int nargin, const mxArray *in[])
-{
-  checkArguments("DefaultFuncString",nargout,nargin,1);
-  string& name = *unwrap_shared_ptr< string >(in[0], "ptr_string");
-  DefaultFuncString("hello",name);
-}
-void DefaultFuncString_15(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void DefaultFuncString_13(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("DefaultFuncString",nargout,nargin,0);
   DefaultFuncString("hello","");
 }
-void DefaultFuncObj_16(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void DefaultFuncObj_14(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("DefaultFuncObj",nargout,nargin,1);
   gtsam::KeyFormatter& keyFormatter = *unwrap_shared_ptr< gtsam::KeyFormatter >(in[0], "ptr_gtsamKeyFormatter");
   DefaultFuncObj(keyFormatter);
 }
-void DefaultFuncObj_17(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void DefaultFuncObj_15(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("DefaultFuncObj",nargout,nargin,0);
   DefaultFuncObj(gtsam::DefaultKeyFormatter);
 }
-void DefaultFuncZero_18(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void DefaultFuncZero_16(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("DefaultFuncZero",nargout,nargin,5);
   int a = unwrap< int >(in[0]);
   int b = unwrap< int >(in[1]);
   double c = unwrap< double >(in[2]);
-  bool d = unwrap< bool >(in[3]);
+  int d = unwrap< int >(in[3]);
   bool e = unwrap< bool >(in[4]);
   DefaultFuncZero(a,b,c,d,e);
 }
-void DefaultFuncZero_19(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void DefaultFuncZero_17(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("DefaultFuncZero",nargout,nargin,4);
   int a = unwrap< int >(in[0]);
   int b = unwrap< int >(in[1]);
   double c = unwrap< double >(in[2]);
-  bool e = unwrap< bool >(in[3]);
-  DefaultFuncZero(a,b,c,false,e);
+  int d = unwrap< int >(in[3]);
+  DefaultFuncZero(a,b,c,d,false);
 }
-void DefaultFuncZero_20(int nargout, mxArray *out[], int nargin, const mxArray *in[])
-{
-  checkArguments("DefaultFuncZero",nargout,nargin,4);
-  int a = unwrap< int >(in[0]);
-  int b = unwrap< int >(in[1]);
-  bool d = unwrap< bool >(in[2]);
-  bool e = unwrap< bool >(in[3]);
-  DefaultFuncZero(a,b,0.0,d,e);
-}
-void DefaultFuncZero_21(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void DefaultFuncZero_18(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("DefaultFuncZero",nargout,nargin,3);
   int a = unwrap< int >(in[0]);
   int b = unwrap< int >(in[1]);
-  bool e = unwrap< bool >(in[2]);
-  DefaultFuncZero(a,b,0.0,false,e);
+  double c = unwrap< double >(in[2]);
+  DefaultFuncZero(a,b,c,0,false);
 }
-void DefaultFuncZero_22(int nargout, mxArray *out[], int nargin, const mxArray *in[])
-{
-  checkArguments("DefaultFuncZero",nargout,nargin,4);
-  int b = unwrap< int >(in[0]);
-  double c = unwrap< double >(in[1]);
-  bool d = unwrap< bool >(in[2]);
-  bool e = unwrap< bool >(in[3]);
-  DefaultFuncZero(0,b,c,d,e);
-}
-void DefaultFuncZero_23(int nargout, mxArray *out[], int nargin, const mxArray *in[])
-{
-  checkArguments("DefaultFuncZero",nargout,nargin,3);
-  int b = unwrap< int >(in[0]);
-  double c = unwrap< double >(in[1]);
-  bool e = unwrap< bool >(in[2]);
-  DefaultFuncZero(0,b,c,false,e);
-}
-void DefaultFuncZero_24(int nargout, mxArray *out[], int nargin, const mxArray *in[])
-{
-  checkArguments("DefaultFuncZero",nargout,nargin,3);
-  int b = unwrap< int >(in[0]);
-  bool d = unwrap< bool >(in[1]);
-  bool e = unwrap< bool >(in[2]);
-  DefaultFuncZero(0,b,0.0,d,e);
-}
-void DefaultFuncZero_25(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void DefaultFuncZero_19(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("DefaultFuncZero",nargout,nargin,2);
-  int b = unwrap< int >(in[0]);
-  bool e = unwrap< bool >(in[1]);
-  DefaultFuncZero(0,b,0.0,false,e);
+  int a = unwrap< int >(in[0]);
+  int b = unwrap< int >(in[1]);
+  DefaultFuncZero(a,b,0.0,0,false);
 }
-void DefaultFuncVector_26(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void DefaultFuncVector_20(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("DefaultFuncVector",nargout,nargin,2);
   std::vector<int>& i = *unwrap_shared_ptr< std::vector<int> >(in[0], "ptr_stdvectorint");
   std::vector<string>& s = *unwrap_shared_ptr< std::vector<string> >(in[1], "ptr_stdvectorstring");
   DefaultFuncVector(i,s);
 }
-void DefaultFuncVector_27(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void DefaultFuncVector_21(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("DefaultFuncVector",nargout,nargin,1);
   std::vector<int>& i = *unwrap_shared_ptr< std::vector<int> >(in[0], "ptr_stdvectorint");
   DefaultFuncVector(i,{"borglab", "gtsam"});
 }
-void DefaultFuncVector_28(int nargout, mxArray *out[], int nargin, const mxArray *in[])
-{
-  checkArguments("DefaultFuncVector",nargout,nargin,1);
-  std::vector<string>& s = *unwrap_shared_ptr< std::vector<string> >(in[0], "ptr_stdvectorstring");
-  DefaultFuncVector({1, 2, 3},s);
-}
-void DefaultFuncVector_29(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void DefaultFuncVector_22(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("DefaultFuncVector",nargout,nargin,0);
   DefaultFuncVector({1, 2, 3},{"borglab", "gtsam"});
 }
-void setPose_30(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void setPose_23(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("setPose",nargout,nargin,1);
   gtsam::Pose3& pose = *unwrap_shared_ptr< gtsam::Pose3 >(in[0], "ptr_gtsamPose3");
   setPose(pose);
 }
-void setPose_31(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void setPose_24(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("setPose",nargout,nargin,0);
   setPose(gtsam::Pose3());
 }
-void TemplatedFunctionRot3_32(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void TemplatedFunctionRot3_25(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("TemplatedFunctionRot3",nargout,nargin,1);
   gtsam::Rot3& t = *unwrap_shared_ptr< gtsam::Rot3 >(in[0], "ptr_gtsamRot3");
@@ -337,7 +285,7 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       DefaultFuncInt_10(nargout, out, nargin-1, in+1);
       break;
     case 11:
-      DefaultFuncInt_11(nargout, out, nargin-1, in+1);
+      DefaultFuncString_11(nargout, out, nargin-1, in+1);
       break;
     case 12:
       DefaultFuncString_12(nargout, out, nargin-1, in+1);
@@ -346,16 +294,16 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       DefaultFuncString_13(nargout, out, nargin-1, in+1);
       break;
     case 14:
-      DefaultFuncString_14(nargout, out, nargin-1, in+1);
+      DefaultFuncObj_14(nargout, out, nargin-1, in+1);
       break;
     case 15:
-      DefaultFuncString_15(nargout, out, nargin-1, in+1);
+      DefaultFuncObj_15(nargout, out, nargin-1, in+1);
       break;
     case 16:
-      DefaultFuncObj_16(nargout, out, nargin-1, in+1);
+      DefaultFuncZero_16(nargout, out, nargin-1, in+1);
       break;
     case 17:
-      DefaultFuncObj_17(nargout, out, nargin-1, in+1);
+      DefaultFuncZero_17(nargout, out, nargin-1, in+1);
       break;
     case 18:
       DefaultFuncZero_18(nargout, out, nargin-1, in+1);
@@ -364,43 +312,22 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       DefaultFuncZero_19(nargout, out, nargin-1, in+1);
       break;
     case 20:
-      DefaultFuncZero_20(nargout, out, nargin-1, in+1);
+      DefaultFuncVector_20(nargout, out, nargin-1, in+1);
       break;
     case 21:
-      DefaultFuncZero_21(nargout, out, nargin-1, in+1);
+      DefaultFuncVector_21(nargout, out, nargin-1, in+1);
       break;
     case 22:
-      DefaultFuncZero_22(nargout, out, nargin-1, in+1);
+      DefaultFuncVector_22(nargout, out, nargin-1, in+1);
       break;
     case 23:
-      DefaultFuncZero_23(nargout, out, nargin-1, in+1);
+      setPose_23(nargout, out, nargin-1, in+1);
       break;
     case 24:
-      DefaultFuncZero_24(nargout, out, nargin-1, in+1);
+      setPose_24(nargout, out, nargin-1, in+1);
       break;
     case 25:
-      DefaultFuncZero_25(nargout, out, nargin-1, in+1);
-      break;
-    case 26:
-      DefaultFuncVector_26(nargout, out, nargin-1, in+1);
-      break;
-    case 27:
-      DefaultFuncVector_27(nargout, out, nargin-1, in+1);
-      break;
-    case 28:
-      DefaultFuncVector_28(nargout, out, nargin-1, in+1);
-      break;
-    case 29:
-      DefaultFuncVector_29(nargout, out, nargin-1, in+1);
-      break;
-    case 30:
-      setPose_30(nargout, out, nargin-1, in+1);
-      break;
-    case 31:
-      setPose_31(nargout, out, nargin-1, in+1);
-      break;
-    case 32:
-      TemplatedFunctionRot3_32(nargout, out, nargin-1, in+1);
+      TemplatedFunctionRot3_25(nargout, out, nargin-1, in+1);
       break;
     }
   } catch(const std::exception& e) {

--- a/tests/expected/matlab/functions_wrapper.cpp
+++ b/tests/expected/matlab/functions_wrapper.cpp
@@ -134,27 +134,55 @@ void DefaultFuncInt_9(int nargout, mxArray *out[], int nargin, const mxArray *in
 {
   checkArguments("DefaultFuncInt",nargout,nargin,1);
   int a = unwrap< int >(in[0]);
-  DefaultFuncInt(a);
+  DefaultFuncInt(a,0);
 }
 void DefaultFuncInt_10(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  checkArguments("DefaultFuncInt",nargout,nargin,0);
-  DefaultFuncInt();
+  checkArguments("DefaultFuncInt",nargout,nargin,1);
+  int b = unwrap< int >(in[0]);
+  DefaultFuncInt(123,b);
 }
-void DefaultFuncString_9(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void DefaultFuncInt_11(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("DefaultFuncInt",nargout,nargin,0);
+  DefaultFuncInt(123,0);
+}
+void DefaultFuncString_12(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("DefaultFuncString",nargout,nargin,2);
   string& s = *unwrap_shared_ptr< string >(in[0], "ptr_string");
   string& name = *unwrap_shared_ptr< string >(in[1], "ptr_string");
   DefaultFuncString(s,name);
 }
-void DefaultFuncObj_10(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void DefaultFuncString_13(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("DefaultFuncString",nargout,nargin,1);
+  string& s = *unwrap_shared_ptr< string >(in[0], "ptr_string");
+  DefaultFuncString(s,"");
+}
+void DefaultFuncString_14(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("DefaultFuncString",nargout,nargin,1);
+  string& name = *unwrap_shared_ptr< string >(in[0], "ptr_string");
+  DefaultFuncString("hello",name);
+}
+void DefaultFuncString_15(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("DefaultFuncString",nargout,nargin,0);
+  DefaultFuncString("hello","");
+}
+void DefaultFuncObj_16(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("DefaultFuncObj",nargout,nargin,1);
   gtsam::KeyFormatter& keyFormatter = *unwrap_shared_ptr< gtsam::KeyFormatter >(in[0], "ptr_gtsamKeyFormatter");
   DefaultFuncObj(keyFormatter);
 }
-void DefaultFuncZero_11(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void DefaultFuncObj_17(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("DefaultFuncObj",nargout,nargin,0);
+  DefaultFuncObj(gtsam::DefaultKeyFormatter);
+}
+void DefaultFuncZero_18(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("DefaultFuncZero",nargout,nargin,5);
   int a = unwrap< int >(in[0]);
@@ -164,20 +192,100 @@ void DefaultFuncZero_11(int nargout, mxArray *out[], int nargin, const mxArray *
   bool e = unwrap< bool >(in[4]);
   DefaultFuncZero(a,b,c,d,e);
 }
-void DefaultFuncVector_12(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void DefaultFuncZero_19(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("DefaultFuncZero",nargout,nargin,4);
+  int a = unwrap< int >(in[0]);
+  int b = unwrap< int >(in[1]);
+  double c = unwrap< double >(in[2]);
+  bool e = unwrap< bool >(in[3]);
+  DefaultFuncZero(a,b,c,false,e);
+}
+void DefaultFuncZero_20(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("DefaultFuncZero",nargout,nargin,4);
+  int a = unwrap< int >(in[0]);
+  int b = unwrap< int >(in[1]);
+  bool d = unwrap< bool >(in[2]);
+  bool e = unwrap< bool >(in[3]);
+  DefaultFuncZero(a,b,0.0,d,e);
+}
+void DefaultFuncZero_21(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("DefaultFuncZero",nargout,nargin,3);
+  int a = unwrap< int >(in[0]);
+  int b = unwrap< int >(in[1]);
+  bool e = unwrap< bool >(in[2]);
+  DefaultFuncZero(a,b,0.0,false,e);
+}
+void DefaultFuncZero_22(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("DefaultFuncZero",nargout,nargin,4);
+  int b = unwrap< int >(in[0]);
+  double c = unwrap< double >(in[1]);
+  bool d = unwrap< bool >(in[2]);
+  bool e = unwrap< bool >(in[3]);
+  DefaultFuncZero(0,b,c,d,e);
+}
+void DefaultFuncZero_23(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("DefaultFuncZero",nargout,nargin,3);
+  int b = unwrap< int >(in[0]);
+  double c = unwrap< double >(in[1]);
+  bool e = unwrap< bool >(in[2]);
+  DefaultFuncZero(0,b,c,false,e);
+}
+void DefaultFuncZero_24(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("DefaultFuncZero",nargout,nargin,3);
+  int b = unwrap< int >(in[0]);
+  bool d = unwrap< bool >(in[1]);
+  bool e = unwrap< bool >(in[2]);
+  DefaultFuncZero(0,b,0.0,d,e);
+}
+void DefaultFuncZero_25(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("DefaultFuncZero",nargout,nargin,2);
+  int b = unwrap< int >(in[0]);
+  bool e = unwrap< bool >(in[1]);
+  DefaultFuncZero(0,b,0.0,false,e);
+}
+void DefaultFuncVector_26(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("DefaultFuncVector",nargout,nargin,2);
   std::vector<int>& i = *unwrap_shared_ptr< std::vector<int> >(in[0], "ptr_stdvectorint");
   std::vector<string>& s = *unwrap_shared_ptr< std::vector<string> >(in[1], "ptr_stdvectorstring");
   DefaultFuncVector(i,s);
 }
-void setPose_13(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void DefaultFuncVector_27(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("DefaultFuncVector",nargout,nargin,1);
+  std::vector<int>& i = *unwrap_shared_ptr< std::vector<int> >(in[0], "ptr_stdvectorint");
+  DefaultFuncVector(i,{"borglab", "gtsam"});
+}
+void DefaultFuncVector_28(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("DefaultFuncVector",nargout,nargin,1);
+  std::vector<string>& s = *unwrap_shared_ptr< std::vector<string> >(in[0], "ptr_stdvectorstring");
+  DefaultFuncVector({1, 2, 3},s);
+}
+void DefaultFuncVector_29(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("DefaultFuncVector",nargout,nargin,0);
+  DefaultFuncVector({1, 2, 3},{"borglab", "gtsam"});
+}
+void setPose_30(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("setPose",nargout,nargin,1);
   gtsam::Pose3& pose = *unwrap_shared_ptr< gtsam::Pose3 >(in[0], "ptr_gtsamPose3");
   setPose(pose);
 }
-void TemplatedFunctionRot3_14(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void setPose_31(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("setPose",nargout,nargin,0);
+  setPose(gtsam::Pose3());
+}
+void TemplatedFunctionRot3_32(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("TemplatedFunctionRot3",nargout,nargin,1);
   gtsam::Rot3& t = *unwrap_shared_ptr< gtsam::Rot3 >(in[0], "ptr_gtsamRot3");
@@ -223,22 +331,76 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       DefaultFuncInt_8(nargout, out, nargin-1, in+1);
       break;
     case 9:
-      DefaultFuncString_9(nargout, out, nargin-1, in+1);
+      DefaultFuncInt_9(nargout, out, nargin-1, in+1);
       break;
     case 10:
-      DefaultFuncObj_10(nargout, out, nargin-1, in+1);
+      DefaultFuncInt_10(nargout, out, nargin-1, in+1);
       break;
     case 11:
-      DefaultFuncZero_11(nargout, out, nargin-1, in+1);
+      DefaultFuncInt_11(nargout, out, nargin-1, in+1);
       break;
     case 12:
-      DefaultFuncVector_12(nargout, out, nargin-1, in+1);
+      DefaultFuncString_12(nargout, out, nargin-1, in+1);
       break;
     case 13:
-      setPose_13(nargout, out, nargin-1, in+1);
+      DefaultFuncString_13(nargout, out, nargin-1, in+1);
       break;
     case 14:
-      TemplatedFunctionRot3_14(nargout, out, nargin-1, in+1);
+      DefaultFuncString_14(nargout, out, nargin-1, in+1);
+      break;
+    case 15:
+      DefaultFuncString_15(nargout, out, nargin-1, in+1);
+      break;
+    case 16:
+      DefaultFuncObj_16(nargout, out, nargin-1, in+1);
+      break;
+    case 17:
+      DefaultFuncObj_17(nargout, out, nargin-1, in+1);
+      break;
+    case 18:
+      DefaultFuncZero_18(nargout, out, nargin-1, in+1);
+      break;
+    case 19:
+      DefaultFuncZero_19(nargout, out, nargin-1, in+1);
+      break;
+    case 20:
+      DefaultFuncZero_20(nargout, out, nargin-1, in+1);
+      break;
+    case 21:
+      DefaultFuncZero_21(nargout, out, nargin-1, in+1);
+      break;
+    case 22:
+      DefaultFuncZero_22(nargout, out, nargin-1, in+1);
+      break;
+    case 23:
+      DefaultFuncZero_23(nargout, out, nargin-1, in+1);
+      break;
+    case 24:
+      DefaultFuncZero_24(nargout, out, nargin-1, in+1);
+      break;
+    case 25:
+      DefaultFuncZero_25(nargout, out, nargin-1, in+1);
+      break;
+    case 26:
+      DefaultFuncVector_26(nargout, out, nargin-1, in+1);
+      break;
+    case 27:
+      DefaultFuncVector_27(nargout, out, nargin-1, in+1);
+      break;
+    case 28:
+      DefaultFuncVector_28(nargout, out, nargin-1, in+1);
+      break;
+    case 29:
+      DefaultFuncVector_29(nargout, out, nargin-1, in+1);
+      break;
+    case 30:
+      setPose_30(nargout, out, nargin-1, in+1);
+      break;
+    case 31:
+      setPose_31(nargout, out, nargin-1, in+1);
+      break;
+    case 32:
+      TemplatedFunctionRot3_32(nargout, out, nargin-1, in+1);
       break;
     }
   } catch(const std::exception& e) {

--- a/tests/expected/matlab/setPose.m
+++ b/tests/expected/matlab/setPose.m
@@ -1,8 +1,8 @@
 function varargout = setPose(varargin)
       if length(varargin) == 1 && isa(varargin{1},'gtsam.Pose3')
-        functions_wrapper(30, varargin{:});
+        functions_wrapper(23, varargin{:});
       elseif length(varargin) == 0
-        functions_wrapper(31, varargin{:});
+        functions_wrapper(24, varargin{:});
       else
         error('Arguments do not match any overload of function setPose');
       end

--- a/tests/expected/matlab/setPose.m
+++ b/tests/expected/matlab/setPose.m
@@ -1,6 +1,8 @@
 function varargout = setPose(varargin)
       if length(varargin) == 1 && isa(varargin{1},'gtsam.Pose3')
-        functions_wrapper(13, varargin{:});
+        functions_wrapper(30, varargin{:});
+      elseif length(varargin) == 0
+        functions_wrapper(31, varargin{:});
       else
         error('Arguments do not match any overload of function setPose');
       end

--- a/tests/expected/python/functions_pybind.cpp
+++ b/tests/expected/python/functions_pybind.cpp
@@ -33,7 +33,7 @@ PYBIND11_MODULE(functions_py, m_) {
     m_.def("DefaultFuncInt",[](int a, int b){ ::DefaultFuncInt(a, b);}, py::arg("a") = 123, py::arg("b") = 0);
     m_.def("DefaultFuncString",[](const string& s, const string& name){ ::DefaultFuncString(s, name);}, py::arg("s") = "hello", py::arg("name") = "");
     m_.def("DefaultFuncObj",[](const gtsam::KeyFormatter& keyFormatter){ ::DefaultFuncObj(keyFormatter);}, py::arg("keyFormatter") = gtsam::DefaultKeyFormatter);
-    m_.def("DefaultFuncZero",[](int a, int b, double c, bool d, bool e){ ::DefaultFuncZero(a, b, c, d, e);}, py::arg("a") = 0, py::arg("b"), py::arg("c") = 0.0, py::arg("d") = false, py::arg("e"));
+    m_.def("DefaultFuncZero",[](int a, int b, double c, int d, bool e){ ::DefaultFuncZero(a, b, c, d, e);}, py::arg("a"), py::arg("b"), py::arg("c") = 0.0, py::arg("d") = 0, py::arg("e") = false);
     m_.def("DefaultFuncVector",[](const std::vector<int>& i, const std::vector<string>& s){ ::DefaultFuncVector(i, s);}, py::arg("i") = {1, 2, 3}, py::arg("s") = {"borglab", "gtsam"});
     m_.def("setPose",[](const gtsam::Pose3& pose){ ::setPose(pose);}, py::arg("pose") = gtsam::Pose3());
     m_.def("TemplatedFunctionRot3",[](const gtsam::Rot3& t){ ::TemplatedFunction<Rot3>(t);}, py::arg("t"));

--- a/tests/fixtures/functions.i
+++ b/tests/fixtures/functions.i
@@ -31,7 +31,7 @@ typedef TemplatedFunction<gtsam::Rot3> TemplatedFunctionRot3;
 void DefaultFuncInt(int a = 123, int b = 0);
 void DefaultFuncString(const string& s = "hello", const string& name = "");
 void DefaultFuncObj(const gtsam::KeyFormatter& keyFormatter = gtsam::DefaultKeyFormatter);
-void DefaultFuncZero(int a = 0, int b, double c = 0.0, bool d = false, bool e);
+void DefaultFuncZero(int a, int b, double c = 0.0, int d = 0, bool e = false);
 void DefaultFuncVector(const std::vector<int> &i = {1, 2, 3}, const std::vector<string> &s = {"borglab", "gtsam"});
 
 // Test for non-trivial default constructor


### PR DESCRIPTION
This addresses #134 

It is done by creating multiple copies of the same function then letting the normal overload handling functionality handle the switch cases for argument deduction.

For a function with a default argument, it's expanded to become the equivalent of:
```
void function(int a, int b = 0);
// turns into:
void function(int a, int b);
void function(int a);
```
Then in the generated .cpp file, for the second version we actually call `function(a, 0)`.

2 things to look out for:  
1. "creating copies" requires care due to the parent-child cyclic references (cannot naively use deepcopy)
2. for the function version where the argument is omitted, we want to "delete" the optional argument.  But this comes with the minor caveat that, when generating the cpp file, we need to explicitly pass the argument, e.g. `function(a, 0)` means we need to "remember" the 0.  To do this, I just create a copy of the virgin argument list and we can get the default values from there.

Haven't tested it yet with gtsam since I haven't configured the matlab wrapper on my computer yet (need to recompile everything including dependencies with intel) but I think it should work.

tag @mattking-smith 