### PR TITLE
[Python Wrapper] Compile modules only when changed

### DIFF
--- a/cmake/PybindWrap.cmake
+++ b/cmake/PybindWrap.cmake
@@ -59,7 +59,7 @@ function(
   set(interface_files ${interface_headers})
 
   # Pop the main interface file so that interface_files has only submodules.
-  LIST(POP_FRONT interface_files main_interface)
+  list(POP_FRONT interface_files main_interface)
 
   # Convert .i file names to .cpp file names.
   foreach(interface_file ${interface_files})

--- a/cmake/PybindWrap.cmake
+++ b/cmake/PybindWrap.cmake
@@ -67,9 +67,8 @@ function(
   foreach(interface_file ${interface_files})
     # This block gets the interface file name and does the replacement
     get_filename_component(interface ${interface_file} NAME_WLE)
-    get_filename_component(dir ${interface_file} DIRECTORY)
     set(cpp_file "${interface}.cpp")
-    list(APPEND cpp_files "${interface}.cpp")
+    list(APPEND cpp_files ${cpp_file})
 
     # Wrap the specific interface header
     # This is done so that we can create CMake dependencies in such a way so that when changing a single .i file,

--- a/cmake/PybindWrap.cmake
+++ b/cmake/PybindWrap.cmake
@@ -82,13 +82,13 @@ function(
           --out "${cpp_file}"  --module_name ${module_name}
           --top_module_namespaces "${top_namespace}" --ignore ${ignore_classes}
           --template ${module_template} --is_submodule ${_WRAP_BOOST_ARG}
-      DEPENDS "${interface_file}" ${module_template}
+      DEPENDS "${interface_file}" ${module_template} "${module_name}/specializations/${interface}.h" "${module_name}/preamble/${interface}.h"
       VERBATIM)
 
   endforeach()
 
-  get_filename_component(main_interface_name ${main_interface} NAME)
-  string(REPLACE ".i" ".cpp" main_cpp_file ${main_interface_name})
+  get_filename_component(main_interface_name ${main_interface} NAME_WLE)
+  set(main_cpp_file "${main_interface_name}.cpp")
   list(PREPEND cpp_files ${main_cpp_file})
 
   add_custom_command(
@@ -100,7 +100,7 @@ function(
       --out "${generated_cpp}" --module_name ${module_name}
       --top_module_namespaces "${top_namespace}" --ignore ${ignore_classes}
       --template ${module_template} ${_WRAP_BOOST_ARG}
-    DEPENDS "${main_interface}" ${module_template}
+    DEPENDS "${main_interface}" ${module_template} "${module_name}/specializations/${main_interface_name}.h" "${module_name}/specializations/${main_interface_name}.h"
     VERBATIM)
 
     add_custom_target(pybind_wrap_${module_name} DEPENDS ${cpp_files})

--- a/scripts/pybind_wrap.py
+++ b/scripts/pybind_wrap.py
@@ -19,7 +19,7 @@ def main():
     arg_parser.add_argument("--src",
                             type=str,
                             required=True,
-                            help="Input interface .i/.h file")
+                            help="Input interface .i/.h file(s)")
     arg_parser.add_argument(
         "--module_name",
         type=str,
@@ -31,7 +31,7 @@ def main():
         "--out",
         type=str,
         required=True,
-        help="Name of the output pybind .cc file",
+        help="Name of the output pybind .cc file(s)",
     )
     arg_parser.add_argument(
         "--use-boost",
@@ -60,7 +60,10 @@ def main():
     )
     arg_parser.add_argument("--template",
                             type=str,
-                            help="The module template file")
+                            help="The module template file (e.g. module.tpl).")
+    arg_parser.add_argument("--is_submodule",
+                            default=False,
+                            action="store_true")
     args = arg_parser.parse_args()
 
     top_module_namespaces = args.top_module_namespaces.split("::")
@@ -78,9 +81,13 @@ def main():
         module_template=template_content,
     )
 
-    # Wrap the code and get back the cpp/cc code.
-    sources = args.src.split(';')
-    wrapper.wrap(sources, args.out)
+    if args.is_submodule:
+        wrapper.wrap_submodule(args.src)
+
+    else:
+        # Wrap the code and get back the cpp/cc code.
+        sources = args.src.split(';')
+        wrapper.wrap(sources, args.out)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes #137 

We add a new method and command line arg to the pybind wrapper for handling submodules (e.g. navigation.i) separately from the main module (gtsam.i). This then makes updating the CMake to have multiple command calls easy to do.

Unfortunately, I seem to be doing something wrong since now the python module rebuilds every time, even when no changes have been made to any of the files. @jlblancoc can you please take a look and provide comments/feedback? I feel we're close and missing a minor thing.