### PR TITLE
IPython repr methods

### DIFF
--- a/gtwrap/pybind_wrapper.py
+++ b/gtwrap/pybind_wrapper.py
@@ -112,32 +112,6 @@ class PybindWrapper:
         return serialize_method + deserialize_method + \
             pickle_method.format(cpp_class=cpp_class, indent=self.method_indent)
 
-    def _wrap_ipython_method(self, method: parser.Method, cpp_class: str,
-                             args_names: List[str], cpp_args: str,
-                             py_args: str):
-        """
-        Wrap special methods used by IPython/Jupyter notebooks.
-        The list of methods is defined in `_ipython_special_methods`.
-
-        Args:
-            method (parser.Method): The method to be wrapped.
-            cpp_class (str): The C++ name of the class to which the method belongs.
-            args_names (List[str]): List of argument variable names passed to the method.
-            cpp_args (str): The C++ version of the argument list.
-            py_args (str): The pybind11 formatted version of the argument list.
-
-        Returns:
-            str: Wrapped method as a string.
-        """
-        opt_comma = ', ' if args_names else ''
-        method_args = ", ".join(args_names) if args_names else ''
-
-        method = self.method_indent + \
-            f'.def("_repr_{method.name}_", []({cpp_class}* self{opt_comma}{cpp_args})' \
-                f'{{return self->{method.name}({method_args});}}' \
-                    f'{py_args})'
-        return method
-
     def _wrap_print(self, ret: str, method: parser.Method, cpp_class: str,
                     args_names: List[str], args_signature_with_names: str,
                     py_args_names: str, prefix: str, suffix: str):
@@ -209,9 +183,8 @@ class PybindWrapper:
         # Special handling of ipython specific methods
         # https://ipython.readthedocs.io/en/stable/config/integrating.html
         if cpp_method in self._ipython_special_methods:
-            return self._wrap_ipython_method(method, cpp_class, args_names,
-                                             args_signature_with_names,
-                                             py_args_names)
+            idx = self._ipython_special_methods.index(cpp_method)
+            py_method = f"_repr_{self._ipython_special_methods[idx]}_"
 
         # Add underscore to disambiguate if the method name matches a python keyword
         if py_method in self.python_keywords:

--- a/gtwrap/pybind_wrapper.py
+++ b/gtwrap/pybind_wrapper.py
@@ -14,6 +14,7 @@ Author: Duy Nguyen Ta, Fan Jiang, Matthew Sklar, Varun Agrawal, and Frank Dellae
 
 import re
 from pathlib import Path
+from typing import List
 
 import gtwrap.interface_parser as parser
 import gtwrap.template_instantiator as instantiator
@@ -45,6 +46,11 @@ class PybindWrapper:
 
         # amount of indentation to add before each function/method declaration.
         self.method_indent = '\n' + (' ' * 8)
+
+        # Special methods which are leveraged by ipython/jupyter notebooks
+        self._ipython_special_methods = [
+            "svg", "png", "jpeg", "html", "javascript", "markdown", "latex"
+        ]
 
     def _py_args_names(self, args):
         """Set the argument names in Pybind11 format."""
@@ -86,6 +92,93 @@ class PybindWrapper:
                 ))
         return res
 
+    def _wrap_serialization(self, cpp_class):
+        """Helper method to add serialize, deserialize and pickle methods to the wrapped class."""
+        if not cpp_class in self._serializing_classes:
+            self._serializing_classes.append(cpp_class)
+
+        serialize_method = self.method_indent + \
+            ".def(\"serialize\", []({class_inst} self){{ return gtsam::serialize(*self); }})".format(class_inst=cpp_class + '*')
+
+        deserialize_method = self.method_indent + \
+                    '.def("deserialize", []({class_inst} self, string serialized)' \
+                    '{{ gtsam::deserialize(serialized, *self); }}, py::arg("serialized"))' \
+                    .format(class_inst=cpp_class + '*')
+
+        # Since this class supports serialization, we also add the pickle method.
+        pickle_method = self.method_indent + \
+            ".def(py::pickle({indent}    [](const {cpp_class} &a){{ /* __getstate__: Returns a string that encodes the state of the object */ return py::make_tuple(gtsam::serialize(a)); }},{indent}    [](py::tuple t){{ /* __setstate__ */ {cpp_class} obj; gtsam::deserialize(t[0].cast<std::string>(), obj); return obj; }}))"
+
+        return serialize_method + deserialize_method + \
+            pickle_method.format(cpp_class=cpp_class, indent=self.method_indent)
+
+    def _wrap_ipython_method(self, method: parser.Method, cpp_class: str,
+                             args_names: List[str], cpp_args: str,
+                             py_args: str):
+        """
+        Wrap special methods used by IPython/Jupyter notebooks.
+        The list of methods is defined in `_ipython_special_methods`.
+
+        Args:
+            method (parser.Method): The method to be wrapped.
+            cpp_class (str): The C++ name of the class to which the method belongs.
+            args_names (List[str]): List of argument variable names passed to the method.
+            cpp_args (str): The C++ version of the argument list.
+            py_args (str): The pybind11 formatted version of the argument list.
+
+        Returns:
+            str: Wrapped method as a string.
+        """
+        opt_comma = ', ' if args_names else ''
+        method_args = ", ".join(args_names) if args_names else ''
+
+        method = self.method_indent + \
+            f'.def("_repr_{method.name}_", []({cpp_class}* self{opt_comma}{cpp_args})' \
+                f'{{return self->{method.name}({method_args});}}' \
+                    f'{py_args})'
+        return method
+
+    def _wrap_print(self, ret: str, method: parser.Method, cpp_class: str,
+                    args_names: List[str], args_signature_with_names: str,
+                    py_args_names: str, prefix: str, suffix: str):
+        """
+        Update the print method to print to the output stream and append a __repr__ method.
+
+        Args:
+            ret (str): The result of the parser.
+            method (parser.Method): The method to be wrapped.
+            cpp_class (str): The C++ name of the class to which the method belongs.
+            args_names (List[str]): List of argument variable names passed to the method.
+            args_signature_with_names (str): C++ arguments containing their names and type signatures.
+            py_args_names (str): The pybind11 formatted version of the argument list.
+            prefix (str): Prefix to add to the wrapped method when writing to the cpp file.
+            suffix (str): Suffix to add to the wrapped method when writing to the cpp file.
+
+        Returns:
+            str: The wrapped print method.
+        """
+        # Redirect stdout - see pybind docs for why this is a good idea:
+        # https://pybind11.readthedocs.io/en/stable/advanced/pycpp/utilities.html#capturing-standard-output-from-ostream
+        ret = ret.replace('self->print',
+                          'py::scoped_ostream_redirect output; self->print')
+
+        # Make __repr__() call .print() internally
+        ret += '''{prefix}.def("__repr__",
+                    [](const {cpp_class}& self{opt_comma}{args_signature_with_names}){{
+                        gtsam::RedirectCout redirect;
+                        self.{method_name}({method_args});
+                        return redirect.str();
+                    }}{py_args_names}){suffix}'''.format(
+            prefix=prefix,
+            cpp_class=cpp_class,
+            opt_comma=', ' if args_names else '',
+            args_signature_with_names=args_signature_with_names,
+            method_name=method.name,
+            method_args=", ".join(args_names) if args_names else '',
+            py_args_names=py_args_names,
+            suffix=suffix)
+        return ret
+
     def _wrap_method(self,
                      method,
                      cpp_class,
@@ -105,22 +198,20 @@ class PybindWrapper:
         py_method = method.name + method_suffix
         cpp_method = method.to_cpp()
 
+        args_names = method.args.names()
+        py_args_names = self._py_args_names(method.args)
+        args_signature_with_names = self._method_args_signature(method.args)
+
         # Special handling for the serialize/serializable method
         if cpp_method in ["serialize", "serializable"]:
-            if not cpp_class in self._serializing_classes:
-                self._serializing_classes.append(cpp_class)
-            serialize_method = self.method_indent + \
-                ".def(\"serialize\", []({class_inst} self){{ return gtsam::serialize(*self); }})".format(class_inst=cpp_class + '*')
-            deserialize_method = self.method_indent + \
-                     '.def("deserialize", []({class_inst} self, string serialized)' \
-                     '{{ gtsam::deserialize(serialized, *self); }}, py::arg("serialized"))' \
-                       .format(class_inst=cpp_class + '*')
+            return self._wrap_serialization(cpp_class)
 
-            # Since this class supports serialization, we also add the pickle method.
-            pickle_method = self.method_indent + \
-                ".def(py::pickle({indent}    [](const {cpp_class} &a){{ /* __getstate__: Returns a string that encodes the state of the object */ return py::make_tuple(gtsam::serialize(a)); }},{indent}    [](py::tuple t){{ /* __setstate__ */ {cpp_class} obj; gtsam::deserialize(t[0].cast<std::string>(), obj); return obj; }}))"
-            return serialize_method + deserialize_method + \
-                pickle_method.format(cpp_class=cpp_class, indent=self.method_indent)
+        # Special handling of ipython specific methods
+        # https://ipython.readthedocs.io/en/stable/config/integrating.html
+        if cpp_method in self._ipython_special_methods:
+            return self._wrap_ipython_method(method, cpp_class, args_names,
+                                             args_signature_with_names,
+                                             py_args_names)
 
         # Add underscore to disambiguate if the method name matches a python keyword
         if py_method in self.python_keywords:
@@ -132,9 +223,6 @@ class PybindWrapper:
             method,
             (parser.StaticMethod, instantiator.InstantiatedStaticMethod))
         return_void = method.return_type.is_void()
-        args_names = method.args.names()
-        py_args_names = self._py_args_names(method.args)
-        args_signature_with_names = self._method_args_signature(method.args)
 
         caller = cpp_class + "::" if not is_method else "self->"
         function_call = ('{opt_return} {caller}{method_name}'
@@ -165,27 +253,9 @@ class PybindWrapper:
         # Create __repr__ override
         # We allow all arguments to .print() and let the compiler handle type mismatches.
         if method.name == 'print':
-            # Redirect stdout - see pybind docs for why this is a good idea:
-            # https://pybind11.readthedocs.io/en/stable/advanced/pycpp/utilities.html#capturing-standard-output-from-ostream
-            ret = ret.replace(
-                'self->print',
-                'py::scoped_ostream_redirect output; self->print')
-
-            # Make __repr__() call .print() internally
-            ret += '''{prefix}.def("__repr__",
-                    [](const {cpp_class}& self{opt_comma}{args_signature_with_names}){{
-                        gtsam::RedirectCout redirect;
-                        self.{method_name}({method_args});
-                        return redirect.str();
-                    }}{py_args_names}){suffix}'''.format(
-                prefix=prefix,
-                cpp_class=cpp_class,
-                opt_comma=', ' if args_names else '',
-                args_signature_with_names=args_signature_with_names,
-                method_name=method.name,
-                method_args=", ".join(args_names) if args_names else '',
-                py_args_names=py_args_names,
-                suffix=suffix)
+            ret = self._wrap_print(ret, method, cpp_class, args_names,
+                                   args_signature_with_names, py_args_names,
+                                   prefix, suffix)
 
         return ret
 

--- a/tests/expected/matlab/ForwardKinematics.m
+++ b/tests/expected/matlab/ForwardKinematics.m
@@ -12,11 +12,11 @@ classdef ForwardKinematics < handle
     function obj = ForwardKinematics(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(55, my_ptr);
+        class_wrapper(57, my_ptr);
       elseif nargin == 5 && isa(varargin{1},'gtdynamics.Robot') && isa(varargin{2},'char') && isa(varargin{3},'char') && isa(varargin{4},'gtsam.Values') && isa(varargin{5},'gtsam.Pose3')
-        my_ptr = class_wrapper(56, varargin{1}, varargin{2}, varargin{3}, varargin{4}, varargin{5});
+        my_ptr = class_wrapper(58, varargin{1}, varargin{2}, varargin{3}, varargin{4}, varargin{5});
       elseif nargin == 4 && isa(varargin{1},'gtdynamics.Robot') && isa(varargin{2},'char') && isa(varargin{3},'char') && isa(varargin{4},'gtsam.Values')
-        my_ptr = class_wrapper(57, varargin{1}, varargin{2}, varargin{3}, varargin{4});
+        my_ptr = class_wrapper(59, varargin{1}, varargin{2}, varargin{3}, varargin{4});
       else
         error('Arguments do not match any overload of ForwardKinematics constructor');
       end
@@ -24,7 +24,7 @@ classdef ForwardKinematics < handle
     end
 
     function delete(obj)
-      class_wrapper(58, obj.ptr_ForwardKinematics);
+      class_wrapper(60, obj.ptr_ForwardKinematics);
     end
 
     function display(obj), obj.print(''); end

--- a/tests/expected/matlab/MultipleTemplatesIntDouble.m
+++ b/tests/expected/matlab/MultipleTemplatesIntDouble.m
@@ -9,7 +9,7 @@ classdef MultipleTemplatesIntDouble < handle
     function obj = MultipleTemplatesIntDouble(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(51, my_ptr);
+        class_wrapper(53, my_ptr);
       else
         error('Arguments do not match any overload of MultipleTemplatesIntDouble constructor');
       end
@@ -17,7 +17,7 @@ classdef MultipleTemplatesIntDouble < handle
     end
 
     function delete(obj)
-      class_wrapper(52, obj.ptr_MultipleTemplatesIntDouble);
+      class_wrapper(54, obj.ptr_MultipleTemplatesIntDouble);
     end
 
     function display(obj), obj.print(''); end

--- a/tests/expected/matlab/MultipleTemplatesIntFloat.m
+++ b/tests/expected/matlab/MultipleTemplatesIntFloat.m
@@ -9,7 +9,7 @@ classdef MultipleTemplatesIntFloat < handle
     function obj = MultipleTemplatesIntFloat(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(53, my_ptr);
+        class_wrapper(55, my_ptr);
       else
         error('Arguments do not match any overload of MultipleTemplatesIntFloat constructor');
       end
@@ -17,7 +17,7 @@ classdef MultipleTemplatesIntFloat < handle
     end
 
     function delete(obj)
-      class_wrapper(54, obj.ptr_MultipleTemplatesIntFloat);
+      class_wrapper(56, obj.ptr_MultipleTemplatesIntFloat);
     end
 
     function display(obj), obj.print(''); end

--- a/tests/expected/matlab/MyFactorPosePoint2.m
+++ b/tests/expected/matlab/MyFactorPosePoint2.m
@@ -15,9 +15,9 @@ classdef MyFactorPosePoint2 < handle
     function obj = MyFactorPosePoint2(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(65, my_ptr);
+        class_wrapper(67, my_ptr);
       elseif nargin == 4 && isa(varargin{1},'numeric') && isa(varargin{2},'numeric') && isa(varargin{3},'double') && isa(varargin{4},'gtsam.noiseModel.Base')
-        my_ptr = class_wrapper(66, varargin{1}, varargin{2}, varargin{3}, varargin{4});
+        my_ptr = class_wrapper(68, varargin{1}, varargin{2}, varargin{3}, varargin{4});
       else
         error('Arguments do not match any overload of MyFactorPosePoint2 constructor');
       end
@@ -25,7 +25,7 @@ classdef MyFactorPosePoint2 < handle
     end
 
     function delete(obj)
-      class_wrapper(67, obj.ptr_MyFactorPosePoint2);
+      class_wrapper(69, obj.ptr_MyFactorPosePoint2);
     end
 
     function display(obj), obj.print(''); end
@@ -36,19 +36,19 @@ classdef MyFactorPosePoint2 < handle
       % PRINT usage: print(string s, KeyFormatter keyFormatter) : returns void
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 2 && isa(varargin{1},'char') && isa(varargin{2},'gtsam.KeyFormatter')
-        class_wrapper(68, this, varargin{:});
+        class_wrapper(70, this, varargin{:});
         return
       end
       % PRINT usage: print(string s) : returns void
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'char')
-        class_wrapper(69, this, varargin{:});
+        class_wrapper(71, this, varargin{:});
         return
       end
       % PRINT usage: print() : returns void
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 0
-        class_wrapper(70, this, varargin{:});
+        class_wrapper(72, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function MyFactorPosePoint2.print');

--- a/tests/expected/matlab/MyVector12.m
+++ b/tests/expected/matlab/MyVector12.m
@@ -12,9 +12,9 @@ classdef MyVector12 < handle
     function obj = MyVector12(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(48, my_ptr);
+        class_wrapper(50, my_ptr);
       elseif nargin == 0
-        my_ptr = class_wrapper(49);
+        my_ptr = class_wrapper(51);
       else
         error('Arguments do not match any overload of MyVector12 constructor');
       end
@@ -22,7 +22,7 @@ classdef MyVector12 < handle
     end
 
     function delete(obj)
-      class_wrapper(50, obj.ptr_MyVector12);
+      class_wrapper(52, obj.ptr_MyVector12);
     end
 
     function display(obj), obj.print(''); end

--- a/tests/expected/matlab/MyVector3.m
+++ b/tests/expected/matlab/MyVector3.m
@@ -12,9 +12,9 @@ classdef MyVector3 < handle
     function obj = MyVector3(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(45, my_ptr);
+        class_wrapper(47, my_ptr);
       elseif nargin == 0
-        my_ptr = class_wrapper(46);
+        my_ptr = class_wrapper(48);
       else
         error('Arguments do not match any overload of MyVector3 constructor');
       end
@@ -22,7 +22,7 @@ classdef MyVector3 < handle
     end
 
     function delete(obj)
-      class_wrapper(47, obj.ptr_MyVector3);
+      class_wrapper(49, obj.ptr_MyVector3);
     end
 
     function display(obj), obj.print(''); end

--- a/tests/expected/matlab/PrimitiveRefDouble.m
+++ b/tests/expected/matlab/PrimitiveRefDouble.m
@@ -19,9 +19,9 @@ classdef PrimitiveRefDouble < handle
     function obj = PrimitiveRefDouble(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(41, my_ptr);
+        class_wrapper(43, my_ptr);
       elseif nargin == 0
-        my_ptr = class_wrapper(42);
+        my_ptr = class_wrapper(44);
       else
         error('Arguments do not match any overload of PrimitiveRefDouble constructor');
       end
@@ -29,7 +29,7 @@ classdef PrimitiveRefDouble < handle
     end
 
     function delete(obj)
-      class_wrapper(43, obj.ptr_PrimitiveRefDouble);
+      class_wrapper(45, obj.ptr_PrimitiveRefDouble);
     end
 
     function display(obj), obj.print(''); end
@@ -43,7 +43,7 @@ classdef PrimitiveRefDouble < handle
       % BRUTAL usage: Brutal(double t) : returns PrimitiveRefdouble
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'double')
-        varargout{1} = class_wrapper(44, varargin{:});
+        varargout{1} = class_wrapper(46, varargin{:});
         return
       end
 

--- a/tests/expected/matlab/Test.m
+++ b/tests/expected/matlab/Test.m
@@ -11,6 +11,7 @@
 %create_ptrs() : returns pair< Test, Test >
 %get_container() : returns std::vector<testing::Test>
 %lambda() : returns void
+%markdown(KeyFormatter keyFormatter) : returns string
 %print() : returns void
 %return_Point2Ptr(bool value) : returns Point2
 %return_Test(Test value) : returns Test
@@ -109,11 +110,27 @@ classdef Test < handle
       error('Arguments do not match any overload of function Test.lambda');
     end
 
+    function varargout = markdown(this, varargin)
+      % MARKDOWN usage: markdown(KeyFormatter keyFormatter) : returns string
+      % Doxygen can be found at https://gtsam.org/doxygen/
+      if length(varargin) == 1 && isa(varargin{1},'gtsam.KeyFormatter')
+        varargout{1} = class_wrapper(21, this, varargin{:});
+        return
+      end
+      % MARKDOWN usage: markdown() : returns string
+      % Doxygen can be found at https://gtsam.org/doxygen/
+      if length(varargin) == 0
+        varargout{1} = class_wrapper(22, this, varargin{:});
+        return
+      end
+      error('Arguments do not match any overload of function Test.markdown');
+    end
+
     function varargout = print(this, varargin)
       % PRINT usage: print() : returns void
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 0
-        class_wrapper(21, this, varargin{:});
+        class_wrapper(23, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.print');
@@ -123,7 +140,7 @@ classdef Test < handle
       % RETURN_POINT2PTR usage: return_Point2Ptr(bool value) : returns Point2
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'logical')
-        varargout{1} = class_wrapper(22, this, varargin{:});
+        varargout{1} = class_wrapper(24, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_Point2Ptr');
@@ -133,7 +150,7 @@ classdef Test < handle
       % RETURN_TEST usage: return_Test(Test value) : returns Test
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'Test')
-        varargout{1} = class_wrapper(23, this, varargin{:});
+        varargout{1} = class_wrapper(25, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_Test');
@@ -143,7 +160,7 @@ classdef Test < handle
       % RETURN_TESTPTR usage: return_TestPtr(Test value) : returns Test
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'Test')
-        varargout{1} = class_wrapper(24, this, varargin{:});
+        varargout{1} = class_wrapper(26, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_TestPtr');
@@ -153,7 +170,7 @@ classdef Test < handle
       % RETURN_BOOL usage: return_bool(bool value) : returns bool
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'logical')
-        varargout{1} = class_wrapper(25, this, varargin{:});
+        varargout{1} = class_wrapper(27, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_bool');
@@ -163,7 +180,7 @@ classdef Test < handle
       % RETURN_DOUBLE usage: return_double(double value) : returns double
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'double')
-        varargout{1} = class_wrapper(26, this, varargin{:});
+        varargout{1} = class_wrapper(28, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_double');
@@ -173,7 +190,7 @@ classdef Test < handle
       % RETURN_FIELD usage: return_field(Test t) : returns bool
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'Test')
-        varargout{1} = class_wrapper(27, this, varargin{:});
+        varargout{1} = class_wrapper(29, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_field');
@@ -183,7 +200,7 @@ classdef Test < handle
       % RETURN_INT usage: return_int(int value) : returns int
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'numeric')
-        varargout{1} = class_wrapper(28, this, varargin{:});
+        varargout{1} = class_wrapper(30, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_int');
@@ -193,7 +210,7 @@ classdef Test < handle
       % RETURN_MATRIX1 usage: return_matrix1(Matrix value) : returns Matrix
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'double')
-        varargout{1} = class_wrapper(29, this, varargin{:});
+        varargout{1} = class_wrapper(31, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_matrix1');
@@ -203,7 +220,7 @@ classdef Test < handle
       % RETURN_MATRIX2 usage: return_matrix2(Matrix value) : returns Matrix
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'double')
-        varargout{1} = class_wrapper(30, this, varargin{:});
+        varargout{1} = class_wrapper(32, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_matrix2');
@@ -213,13 +230,13 @@ classdef Test < handle
       % RETURN_PAIR usage: return_pair(Vector v, Matrix A) : returns pair< Vector, Matrix >
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 2 && isa(varargin{1},'double') && size(varargin{1},2)==1 && isa(varargin{2},'double')
-        [ varargout{1} varargout{2} ] = class_wrapper(31, this, varargin{:});
+        [ varargout{1} varargout{2} ] = class_wrapper(33, this, varargin{:});
         return
       end
       % RETURN_PAIR usage: return_pair(Vector v) : returns pair< Vector, Matrix >
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'double') && size(varargin{1},2)==1
-        [ varargout{1} varargout{2} ] = class_wrapper(32, this, varargin{:});
+        [ varargout{1} varargout{2} ] = class_wrapper(34, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_pair');
@@ -229,7 +246,7 @@ classdef Test < handle
       % RETURN_PTRS usage: return_ptrs(Test p1, Test p2) : returns pair< Test, Test >
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 2 && isa(varargin{1},'Test') && isa(varargin{2},'Test')
-        [ varargout{1} varargout{2} ] = class_wrapper(33, this, varargin{:});
+        [ varargout{1} varargout{2} ] = class_wrapper(35, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_ptrs');
@@ -239,7 +256,7 @@ classdef Test < handle
       % RETURN_SIZE_T usage: return_size_t(size_t value) : returns size_t
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'numeric')
-        varargout{1} = class_wrapper(34, this, varargin{:});
+        varargout{1} = class_wrapper(36, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_size_t');
@@ -249,7 +266,7 @@ classdef Test < handle
       % RETURN_STRING usage: return_string(string value) : returns string
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'char')
-        varargout{1} = class_wrapper(35, this, varargin{:});
+        varargout{1} = class_wrapper(37, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_string');
@@ -259,7 +276,7 @@ classdef Test < handle
       % RETURN_VECTOR1 usage: return_vector1(Vector value) : returns Vector
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'double') && size(varargin{1},2)==1
-        varargout{1} = class_wrapper(36, this, varargin{:});
+        varargout{1} = class_wrapper(38, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_vector1');
@@ -269,7 +286,7 @@ classdef Test < handle
       % RETURN_VECTOR2 usage: return_vector2(Vector value) : returns Vector
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'double') && size(varargin{1},2)==1
-        varargout{1} = class_wrapper(37, this, varargin{:});
+        varargout{1} = class_wrapper(39, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.return_vector2');
@@ -279,19 +296,19 @@ classdef Test < handle
       % SET_CONTAINER usage: set_container(vector<Test> container) : returns void
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'std.vectorTest')
-        class_wrapper(38, this, varargin{:});
-        return
-      end
-      % SET_CONTAINER usage: set_container(vector<Test> container) : returns void
-      % Doxygen can be found at https://gtsam.org/doxygen/
-      if length(varargin) == 1 && isa(varargin{1},'std.vectorTest')
-        class_wrapper(39, this, varargin{:});
-        return
-      end
-      % SET_CONTAINER usage: set_container(vector<Test> container) : returns void
-      % Doxygen can be found at https://gtsam.org/doxygen/
-      if length(varargin) == 1 && isa(varargin{1},'std.vectorTest')
         class_wrapper(40, this, varargin{:});
+        return
+      end
+      % SET_CONTAINER usage: set_container(vector<Test> container) : returns void
+      % Doxygen can be found at https://gtsam.org/doxygen/
+      if length(varargin) == 1 && isa(varargin{1},'std.vectorTest')
+        class_wrapper(41, this, varargin{:});
+        return
+      end
+      % SET_CONTAINER usage: set_container(vector<Test> container) : returns void
+      % Doxygen can be found at https://gtsam.org/doxygen/
+      if length(varargin) == 1 && isa(varargin{1},'std.vectorTest')
+        class_wrapper(42, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function Test.set_container');

--- a/tests/expected/matlab/class_wrapper.cpp
+++ b/tests/expected/matlab/class_wrapper.cpp
@@ -346,14 +346,29 @@ void Test_lambda_20(int nargout, mxArray *out[], int nargin, const mxArray *in[]
   obj->lambda();
 }
 
-void Test_print_21(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_markdown_21(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("markdown",nargout,nargin-1,1);
+  auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
+  gtsam::KeyFormatter& keyFormatter = *unwrap_shared_ptr< gtsam::KeyFormatter >(in[1], "ptr_gtsamKeyFormatter");
+  out[0] = wrap< string >(obj->markdown(keyFormatter));
+}
+
+void Test_markdown_22(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("markdown",nargout,nargin-1,0);
+  auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
+  out[0] = wrap< string >(obj->markdown(gtsam::DefaultKeyFormatter));
+}
+
+void Test_print_23(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("print",nargout,nargin-1,0);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
   obj->print();
 }
 
-void Test_return_Point2Ptr_22(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_Point2Ptr_24(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_Point2Ptr",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -364,7 +379,7 @@ void Test_return_Point2Ptr_22(int nargout, mxArray *out[], int nargin, const mxA
   }
 }
 
-void Test_return_Test_23(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_Test_25(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_Test",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -372,7 +387,7 @@ void Test_return_Test_23(int nargout, mxArray *out[], int nargin, const mxArray 
   out[0] = wrap_shared_ptr(boost::make_shared<Test>(obj->return_Test(value)),"Test", false);
 }
 
-void Test_return_TestPtr_24(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_TestPtr_26(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_TestPtr",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -380,7 +395,7 @@ void Test_return_TestPtr_24(int nargout, mxArray *out[], int nargin, const mxArr
   out[0] = wrap_shared_ptr(obj->return_TestPtr(value),"Test", false);
 }
 
-void Test_return_bool_25(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_bool_27(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_bool",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -388,7 +403,7 @@ void Test_return_bool_25(int nargout, mxArray *out[], int nargin, const mxArray 
   out[0] = wrap< bool >(obj->return_bool(value));
 }
 
-void Test_return_double_26(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_double_28(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_double",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -396,7 +411,7 @@ void Test_return_double_26(int nargout, mxArray *out[], int nargin, const mxArra
   out[0] = wrap< double >(obj->return_double(value));
 }
 
-void Test_return_field_27(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_field_29(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_field",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -404,7 +419,7 @@ void Test_return_field_27(int nargout, mxArray *out[], int nargin, const mxArray
   out[0] = wrap< bool >(obj->return_field(t));
 }
 
-void Test_return_int_28(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_int_30(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_int",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -412,7 +427,7 @@ void Test_return_int_28(int nargout, mxArray *out[], int nargin, const mxArray *
   out[0] = wrap< int >(obj->return_int(value));
 }
 
-void Test_return_matrix1_29(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_matrix1_31(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_matrix1",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -420,7 +435,7 @@ void Test_return_matrix1_29(int nargout, mxArray *out[], int nargin, const mxArr
   out[0] = wrap< Matrix >(obj->return_matrix1(value));
 }
 
-void Test_return_matrix2_30(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_matrix2_32(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_matrix2",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -428,7 +443,7 @@ void Test_return_matrix2_30(int nargout, mxArray *out[], int nargin, const mxArr
   out[0] = wrap< Matrix >(obj->return_matrix2(value));
 }
 
-void Test_return_pair_31(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_pair_33(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_pair",nargout,nargin-1,2);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -439,7 +454,7 @@ void Test_return_pair_31(int nargout, mxArray *out[], int nargin, const mxArray 
   out[1] = wrap< Matrix >(pairResult.second);
 }
 
-void Test_return_pair_32(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_pair_34(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_pair",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -449,7 +464,7 @@ void Test_return_pair_32(int nargout, mxArray *out[], int nargin, const mxArray 
   out[1] = wrap< Matrix >(pairResult.second);
 }
 
-void Test_return_ptrs_33(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_ptrs_35(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_ptrs",nargout,nargin-1,2);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -460,7 +475,7 @@ void Test_return_ptrs_33(int nargout, mxArray *out[], int nargin, const mxArray 
   out[1] = wrap_shared_ptr(pairResult.second,"Test", false);
 }
 
-void Test_return_size_t_34(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_size_t_36(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_size_t",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -468,7 +483,7 @@ void Test_return_size_t_34(int nargout, mxArray *out[], int nargin, const mxArra
   out[0] = wrap< size_t >(obj->return_size_t(value));
 }
 
-void Test_return_string_35(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_string_37(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_string",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -476,7 +491,7 @@ void Test_return_string_35(int nargout, mxArray *out[], int nargin, const mxArra
   out[0] = wrap< string >(obj->return_string(value));
 }
 
-void Test_return_vector1_36(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_vector1_38(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_vector1",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
@@ -484,28 +499,12 @@ void Test_return_vector1_36(int nargout, mxArray *out[], int nargin, const mxArr
   out[0] = wrap< Vector >(obj->return_vector1(value));
 }
 
-void Test_return_vector2_37(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_return_vector2_39(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_vector2",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
   Vector value = unwrap< Vector >(in[1]);
   out[0] = wrap< Vector >(obj->return_vector2(value));
-}
-
-void Test_set_container_38(int nargout, mxArray *out[], int nargin, const mxArray *in[])
-{
-  checkArguments("set_container",nargout,nargin-1,1);
-  auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
-  boost::shared_ptr<std::vector<testing::Test>> container = unwrap_shared_ptr< std::vector<testing::Test> >(in[1], "ptr_stdvectorTest");
-  obj->set_container(*container);
-}
-
-void Test_set_container_39(int nargout, mxArray *out[], int nargin, const mxArray *in[])
-{
-  checkArguments("set_container",nargout,nargin-1,1);
-  auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
-  boost::shared_ptr<std::vector<testing::Test>> container = unwrap_shared_ptr< std::vector<testing::Test> >(in[1], "ptr_stdvectorTest");
-  obj->set_container(*container);
 }
 
 void Test_set_container_40(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -516,7 +515,23 @@ void Test_set_container_40(int nargout, mxArray *out[], int nargin, const mxArra
   obj->set_container(*container);
 }
 
-void PrimitiveRefDouble_collectorInsertAndMakeBase_41(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_set_container_41(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("set_container",nargout,nargin-1,1);
+  auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
+  boost::shared_ptr<std::vector<testing::Test>> container = unwrap_shared_ptr< std::vector<testing::Test> >(in[1], "ptr_stdvectorTest");
+  obj->set_container(*container);
+}
+
+void Test_set_container_42(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("set_container",nargout,nargin-1,1);
+  auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
+  boost::shared_ptr<std::vector<testing::Test>> container = unwrap_shared_ptr< std::vector<testing::Test> >(in[1], "ptr_stdvectorTest");
+  obj->set_container(*container);
+}
+
+void PrimitiveRefDouble_collectorInsertAndMakeBase_43(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<PrimitiveRef<double>> Shared;
@@ -525,7 +540,7 @@ void PrimitiveRefDouble_collectorInsertAndMakeBase_41(int nargout, mxArray *out[
   collector_PrimitiveRefDouble.insert(self);
 }
 
-void PrimitiveRefDouble_constructor_42(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void PrimitiveRefDouble_constructor_44(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<PrimitiveRef<double>> Shared;
@@ -536,7 +551,7 @@ void PrimitiveRefDouble_constructor_42(int nargout, mxArray *out[], int nargin, 
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void PrimitiveRefDouble_deconstructor_43(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void PrimitiveRefDouble_deconstructor_45(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<PrimitiveRef<double>> Shared;
   checkArguments("delete_PrimitiveRefDouble",nargout,nargin,1);
@@ -549,14 +564,14 @@ void PrimitiveRefDouble_deconstructor_43(int nargout, mxArray *out[], int nargin
   delete self;
 }
 
-void PrimitiveRefDouble_Brutal_44(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void PrimitiveRefDouble_Brutal_46(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("PrimitiveRef<double>.Brutal",nargout,nargin,1);
   double t = unwrap< double >(in[0]);
   out[0] = wrap_shared_ptr(boost::make_shared<PrimitiveRef<double>>(PrimitiveRef<double>::Brutal(t)),"PrimitiveRefdouble", false);
 }
 
-void MyVector3_collectorInsertAndMakeBase_45(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyVector3_collectorInsertAndMakeBase_47(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MyVector<3>> Shared;
@@ -565,7 +580,7 @@ void MyVector3_collectorInsertAndMakeBase_45(int nargout, mxArray *out[], int na
   collector_MyVector3.insert(self);
 }
 
-void MyVector3_constructor_46(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyVector3_constructor_48(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MyVector<3>> Shared;
@@ -576,7 +591,7 @@ void MyVector3_constructor_46(int nargout, mxArray *out[], int nargin, const mxA
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void MyVector3_deconstructor_47(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyVector3_deconstructor_49(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<MyVector<3>> Shared;
   checkArguments("delete_MyVector3",nargout,nargin,1);
@@ -589,7 +604,7 @@ void MyVector3_deconstructor_47(int nargout, mxArray *out[], int nargin, const m
   delete self;
 }
 
-void MyVector12_collectorInsertAndMakeBase_48(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyVector12_collectorInsertAndMakeBase_50(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MyVector<12>> Shared;
@@ -598,7 +613,7 @@ void MyVector12_collectorInsertAndMakeBase_48(int nargout, mxArray *out[], int n
   collector_MyVector12.insert(self);
 }
 
-void MyVector12_constructor_49(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyVector12_constructor_51(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MyVector<12>> Shared;
@@ -609,7 +624,7 @@ void MyVector12_constructor_49(int nargout, mxArray *out[], int nargin, const mx
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void MyVector12_deconstructor_50(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyVector12_deconstructor_52(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<MyVector<12>> Shared;
   checkArguments("delete_MyVector12",nargout,nargin,1);
@@ -622,7 +637,7 @@ void MyVector12_deconstructor_50(int nargout, mxArray *out[], int nargin, const 
   delete self;
 }
 
-void MultipleTemplatesIntDouble_collectorInsertAndMakeBase_51(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MultipleTemplatesIntDouble_collectorInsertAndMakeBase_53(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MultipleTemplates<int, double>> Shared;
@@ -631,7 +646,7 @@ void MultipleTemplatesIntDouble_collectorInsertAndMakeBase_51(int nargout, mxArr
   collector_MultipleTemplatesIntDouble.insert(self);
 }
 
-void MultipleTemplatesIntDouble_deconstructor_52(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MultipleTemplatesIntDouble_deconstructor_54(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<MultipleTemplates<int, double>> Shared;
   checkArguments("delete_MultipleTemplatesIntDouble",nargout,nargin,1);
@@ -644,7 +659,7 @@ void MultipleTemplatesIntDouble_deconstructor_52(int nargout, mxArray *out[], in
   delete self;
 }
 
-void MultipleTemplatesIntFloat_collectorInsertAndMakeBase_53(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MultipleTemplatesIntFloat_collectorInsertAndMakeBase_55(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MultipleTemplates<int, float>> Shared;
@@ -653,7 +668,7 @@ void MultipleTemplatesIntFloat_collectorInsertAndMakeBase_53(int nargout, mxArra
   collector_MultipleTemplatesIntFloat.insert(self);
 }
 
-void MultipleTemplatesIntFloat_deconstructor_54(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MultipleTemplatesIntFloat_deconstructor_56(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<MultipleTemplates<int, float>> Shared;
   checkArguments("delete_MultipleTemplatesIntFloat",nargout,nargin,1);
@@ -666,7 +681,7 @@ void MultipleTemplatesIntFloat_deconstructor_54(int nargout, mxArray *out[], int
   delete self;
 }
 
-void ForwardKinematics_collectorInsertAndMakeBase_55(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void ForwardKinematics_collectorInsertAndMakeBase_57(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<ForwardKinematics> Shared;
@@ -675,7 +690,7 @@ void ForwardKinematics_collectorInsertAndMakeBase_55(int nargout, mxArray *out[]
   collector_ForwardKinematics.insert(self);
 }
 
-void ForwardKinematics_constructor_56(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void ForwardKinematics_constructor_58(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<ForwardKinematics> Shared;
@@ -691,7 +706,7 @@ void ForwardKinematics_constructor_56(int nargout, mxArray *out[], int nargin, c
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void ForwardKinematics_constructor_57(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void ForwardKinematics_constructor_59(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<ForwardKinematics> Shared;
@@ -706,7 +721,7 @@ void ForwardKinematics_constructor_57(int nargout, mxArray *out[], int nargin, c
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void ForwardKinematics_deconstructor_58(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void ForwardKinematics_deconstructor_60(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<ForwardKinematics> Shared;
   checkArguments("delete_ForwardKinematics",nargout,nargin,1);
@@ -719,7 +734,7 @@ void ForwardKinematics_deconstructor_58(int nargout, mxArray *out[], int nargin,
   delete self;
 }
 
-void TemplatedConstructor_collectorInsertAndMakeBase_59(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void TemplatedConstructor_collectorInsertAndMakeBase_61(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<TemplatedConstructor> Shared;
@@ -728,7 +743,7 @@ void TemplatedConstructor_collectorInsertAndMakeBase_59(int nargout, mxArray *ou
   collector_TemplatedConstructor.insert(self);
 }
 
-void TemplatedConstructor_constructor_60(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void TemplatedConstructor_constructor_62(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<TemplatedConstructor> Shared;
@@ -739,7 +754,7 @@ void TemplatedConstructor_constructor_60(int nargout, mxArray *out[], int nargin
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void TemplatedConstructor_constructor_61(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void TemplatedConstructor_constructor_63(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<TemplatedConstructor> Shared;
@@ -751,7 +766,7 @@ void TemplatedConstructor_constructor_61(int nargout, mxArray *out[], int nargin
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void TemplatedConstructor_constructor_62(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void TemplatedConstructor_constructor_64(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<TemplatedConstructor> Shared;
@@ -763,7 +778,7 @@ void TemplatedConstructor_constructor_62(int nargout, mxArray *out[], int nargin
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void TemplatedConstructor_constructor_63(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void TemplatedConstructor_constructor_65(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<TemplatedConstructor> Shared;
@@ -775,7 +790,7 @@ void TemplatedConstructor_constructor_63(int nargout, mxArray *out[], int nargin
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void TemplatedConstructor_deconstructor_64(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void TemplatedConstructor_deconstructor_66(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<TemplatedConstructor> Shared;
   checkArguments("delete_TemplatedConstructor",nargout,nargin,1);
@@ -788,7 +803,7 @@ void TemplatedConstructor_deconstructor_64(int nargout, mxArray *out[], int narg
   delete self;
 }
 
-void MyFactorPosePoint2_collectorInsertAndMakeBase_65(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyFactorPosePoint2_collectorInsertAndMakeBase_67(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>> Shared;
@@ -797,7 +812,7 @@ void MyFactorPosePoint2_collectorInsertAndMakeBase_65(int nargout, mxArray *out[
   collector_MyFactorPosePoint2.insert(self);
 }
 
-void MyFactorPosePoint2_constructor_66(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyFactorPosePoint2_constructor_68(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>> Shared;
@@ -812,7 +827,7 @@ void MyFactorPosePoint2_constructor_66(int nargout, mxArray *out[], int nargin, 
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void MyFactorPosePoint2_deconstructor_67(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyFactorPosePoint2_deconstructor_69(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>> Shared;
   checkArguments("delete_MyFactorPosePoint2",nargout,nargin,1);
@@ -825,7 +840,7 @@ void MyFactorPosePoint2_deconstructor_67(int nargout, mxArray *out[], int nargin
   delete self;
 }
 
-void MyFactorPosePoint2_print_68(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyFactorPosePoint2_print_70(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("print",nargout,nargin-1,2);
   auto obj = unwrap_shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>>(in[0], "ptr_MyFactorPosePoint2");
@@ -834,7 +849,7 @@ void MyFactorPosePoint2_print_68(int nargout, mxArray *out[], int nargin, const 
   obj->print(s,keyFormatter);
 }
 
-void MyFactorPosePoint2_print_69(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyFactorPosePoint2_print_71(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("print",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>>(in[0], "ptr_MyFactorPosePoint2");
@@ -842,7 +857,7 @@ void MyFactorPosePoint2_print_69(int nargout, mxArray *out[], int nargin, const 
   obj->print(s,gtsam::DefaultKeyFormatter);
 }
 
-void MyFactorPosePoint2_print_70(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyFactorPosePoint2_print_72(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("print",nargout,nargin-1,0);
   auto obj = unwrap_shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>>(in[0], "ptr_MyFactorPosePoint2");
@@ -925,127 +940,127 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       Test_lambda_20(nargout, out, nargin-1, in+1);
       break;
     case 21:
-      Test_print_21(nargout, out, nargin-1, in+1);
+      Test_markdown_21(nargout, out, nargin-1, in+1);
       break;
     case 22:
-      Test_return_Point2Ptr_22(nargout, out, nargin-1, in+1);
+      Test_markdown_22(nargout, out, nargin-1, in+1);
       break;
     case 23:
-      Test_return_Test_23(nargout, out, nargin-1, in+1);
+      Test_print_23(nargout, out, nargin-1, in+1);
       break;
     case 24:
-      Test_return_TestPtr_24(nargout, out, nargin-1, in+1);
+      Test_return_Point2Ptr_24(nargout, out, nargin-1, in+1);
       break;
     case 25:
-      Test_return_bool_25(nargout, out, nargin-1, in+1);
+      Test_return_Test_25(nargout, out, nargin-1, in+1);
       break;
     case 26:
-      Test_return_double_26(nargout, out, nargin-1, in+1);
+      Test_return_TestPtr_26(nargout, out, nargin-1, in+1);
       break;
     case 27:
-      Test_return_field_27(nargout, out, nargin-1, in+1);
+      Test_return_bool_27(nargout, out, nargin-1, in+1);
       break;
     case 28:
-      Test_return_int_28(nargout, out, nargin-1, in+1);
+      Test_return_double_28(nargout, out, nargin-1, in+1);
       break;
     case 29:
-      Test_return_matrix1_29(nargout, out, nargin-1, in+1);
+      Test_return_field_29(nargout, out, nargin-1, in+1);
       break;
     case 30:
-      Test_return_matrix2_30(nargout, out, nargin-1, in+1);
+      Test_return_int_30(nargout, out, nargin-1, in+1);
       break;
     case 31:
-      Test_return_pair_31(nargout, out, nargin-1, in+1);
+      Test_return_matrix1_31(nargout, out, nargin-1, in+1);
       break;
     case 32:
-      Test_return_pair_32(nargout, out, nargin-1, in+1);
+      Test_return_matrix2_32(nargout, out, nargin-1, in+1);
       break;
     case 33:
-      Test_return_ptrs_33(nargout, out, nargin-1, in+1);
+      Test_return_pair_33(nargout, out, nargin-1, in+1);
       break;
     case 34:
-      Test_return_size_t_34(nargout, out, nargin-1, in+1);
+      Test_return_pair_34(nargout, out, nargin-1, in+1);
       break;
     case 35:
-      Test_return_string_35(nargout, out, nargin-1, in+1);
+      Test_return_ptrs_35(nargout, out, nargin-1, in+1);
       break;
     case 36:
-      Test_return_vector1_36(nargout, out, nargin-1, in+1);
+      Test_return_size_t_36(nargout, out, nargin-1, in+1);
       break;
     case 37:
-      Test_return_vector2_37(nargout, out, nargin-1, in+1);
+      Test_return_string_37(nargout, out, nargin-1, in+1);
       break;
     case 38:
-      Test_set_container_38(nargout, out, nargin-1, in+1);
+      Test_return_vector1_38(nargout, out, nargin-1, in+1);
       break;
     case 39:
-      Test_set_container_39(nargout, out, nargin-1, in+1);
+      Test_return_vector2_39(nargout, out, nargin-1, in+1);
       break;
     case 40:
       Test_set_container_40(nargout, out, nargin-1, in+1);
       break;
     case 41:
-      PrimitiveRefDouble_collectorInsertAndMakeBase_41(nargout, out, nargin-1, in+1);
+      Test_set_container_41(nargout, out, nargin-1, in+1);
       break;
     case 42:
-      PrimitiveRefDouble_constructor_42(nargout, out, nargin-1, in+1);
+      Test_set_container_42(nargout, out, nargin-1, in+1);
       break;
     case 43:
-      PrimitiveRefDouble_deconstructor_43(nargout, out, nargin-1, in+1);
+      PrimitiveRefDouble_collectorInsertAndMakeBase_43(nargout, out, nargin-1, in+1);
       break;
     case 44:
-      PrimitiveRefDouble_Brutal_44(nargout, out, nargin-1, in+1);
+      PrimitiveRefDouble_constructor_44(nargout, out, nargin-1, in+1);
       break;
     case 45:
-      MyVector3_collectorInsertAndMakeBase_45(nargout, out, nargin-1, in+1);
+      PrimitiveRefDouble_deconstructor_45(nargout, out, nargin-1, in+1);
       break;
     case 46:
-      MyVector3_constructor_46(nargout, out, nargin-1, in+1);
+      PrimitiveRefDouble_Brutal_46(nargout, out, nargin-1, in+1);
       break;
     case 47:
-      MyVector3_deconstructor_47(nargout, out, nargin-1, in+1);
+      MyVector3_collectorInsertAndMakeBase_47(nargout, out, nargin-1, in+1);
       break;
     case 48:
-      MyVector12_collectorInsertAndMakeBase_48(nargout, out, nargin-1, in+1);
+      MyVector3_constructor_48(nargout, out, nargin-1, in+1);
       break;
     case 49:
-      MyVector12_constructor_49(nargout, out, nargin-1, in+1);
+      MyVector3_deconstructor_49(nargout, out, nargin-1, in+1);
       break;
     case 50:
-      MyVector12_deconstructor_50(nargout, out, nargin-1, in+1);
+      MyVector12_collectorInsertAndMakeBase_50(nargout, out, nargin-1, in+1);
       break;
     case 51:
-      MultipleTemplatesIntDouble_collectorInsertAndMakeBase_51(nargout, out, nargin-1, in+1);
+      MyVector12_constructor_51(nargout, out, nargin-1, in+1);
       break;
     case 52:
-      MultipleTemplatesIntDouble_deconstructor_52(nargout, out, nargin-1, in+1);
+      MyVector12_deconstructor_52(nargout, out, nargin-1, in+1);
       break;
     case 53:
-      MultipleTemplatesIntFloat_collectorInsertAndMakeBase_53(nargout, out, nargin-1, in+1);
+      MultipleTemplatesIntDouble_collectorInsertAndMakeBase_53(nargout, out, nargin-1, in+1);
       break;
     case 54:
-      MultipleTemplatesIntFloat_deconstructor_54(nargout, out, nargin-1, in+1);
+      MultipleTemplatesIntDouble_deconstructor_54(nargout, out, nargin-1, in+1);
       break;
     case 55:
-      ForwardKinematics_collectorInsertAndMakeBase_55(nargout, out, nargin-1, in+1);
+      MultipleTemplatesIntFloat_collectorInsertAndMakeBase_55(nargout, out, nargin-1, in+1);
       break;
     case 56:
-      ForwardKinematics_constructor_56(nargout, out, nargin-1, in+1);
+      MultipleTemplatesIntFloat_deconstructor_56(nargout, out, nargin-1, in+1);
       break;
     case 57:
-      ForwardKinematics_constructor_57(nargout, out, nargin-1, in+1);
+      ForwardKinematics_collectorInsertAndMakeBase_57(nargout, out, nargin-1, in+1);
       break;
     case 58:
-      ForwardKinematics_deconstructor_58(nargout, out, nargin-1, in+1);
+      ForwardKinematics_constructor_58(nargout, out, nargin-1, in+1);
       break;
     case 59:
-      TemplatedConstructor_collectorInsertAndMakeBase_59(nargout, out, nargin-1, in+1);
+      ForwardKinematics_constructor_59(nargout, out, nargin-1, in+1);
       break;
     case 60:
-      TemplatedConstructor_constructor_60(nargout, out, nargin-1, in+1);
+      ForwardKinematics_deconstructor_60(nargout, out, nargin-1, in+1);
       break;
     case 61:
-      TemplatedConstructor_constructor_61(nargout, out, nargin-1, in+1);
+      TemplatedConstructor_collectorInsertAndMakeBase_61(nargout, out, nargin-1, in+1);
       break;
     case 62:
       TemplatedConstructor_constructor_62(nargout, out, nargin-1, in+1);
@@ -1054,25 +1069,31 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       TemplatedConstructor_constructor_63(nargout, out, nargin-1, in+1);
       break;
     case 64:
-      TemplatedConstructor_deconstructor_64(nargout, out, nargin-1, in+1);
+      TemplatedConstructor_constructor_64(nargout, out, nargin-1, in+1);
       break;
     case 65:
-      MyFactorPosePoint2_collectorInsertAndMakeBase_65(nargout, out, nargin-1, in+1);
+      TemplatedConstructor_constructor_65(nargout, out, nargin-1, in+1);
       break;
     case 66:
-      MyFactorPosePoint2_constructor_66(nargout, out, nargin-1, in+1);
+      TemplatedConstructor_deconstructor_66(nargout, out, nargin-1, in+1);
       break;
     case 67:
-      MyFactorPosePoint2_deconstructor_67(nargout, out, nargin-1, in+1);
+      MyFactorPosePoint2_collectorInsertAndMakeBase_67(nargout, out, nargin-1, in+1);
       break;
     case 68:
-      MyFactorPosePoint2_print_68(nargout, out, nargin-1, in+1);
+      MyFactorPosePoint2_constructor_68(nargout, out, nargin-1, in+1);
       break;
     case 69:
-      MyFactorPosePoint2_print_69(nargout, out, nargin-1, in+1);
+      MyFactorPosePoint2_deconstructor_69(nargout, out, nargin-1, in+1);
       break;
     case 70:
       MyFactorPosePoint2_print_70(nargout, out, nargin-1, in+1);
+      break;
+    case 71:
+      MyFactorPosePoint2_print_71(nargout, out, nargin-1, in+1);
+      break;
+    case 72:
+      MyFactorPosePoint2_print_72(nargout, out, nargin-1, in+1);
       break;
     }
   } catch(const std::exception& e) {

--- a/tests/expected/python/class_pybind.cpp
+++ b/tests/expected/python/class_pybind.cpp
@@ -69,6 +69,7 @@ PYBIND11_MODULE(class_py, m_) {
         .def("set_container",[](Test* self, std::vector<std::shared_ptr<testing::Test>> container){ self->set_container(container);}, py::arg("container"))
         .def("set_container",[](Test* self, std::vector<testing::Test&> container){ self->set_container(container);}, py::arg("container"))
         .def("get_container",[](Test* self){return self->get_container();})
+        .def("_repr_markdown_", [](Test* self, const gtsam::KeyFormatter& keyFormatter){return self->markdown(keyFormatter);}, py::arg("keyFormatter") = gtsam::DefaultKeyFormatter)
         .def_readwrite("model_ptr", &Test::model_ptr);
 
     py::class_<PrimitiveRef<double>, std::shared_ptr<PrimitiveRef<double>>>(m_, "PrimitiveRefDouble")

--- a/tests/expected/python/class_pybind.cpp
+++ b/tests/expected/python/class_pybind.cpp
@@ -69,7 +69,7 @@ PYBIND11_MODULE(class_py, m_) {
         .def("set_container",[](Test* self, std::vector<std::shared_ptr<testing::Test>> container){ self->set_container(container);}, py::arg("container"))
         .def("set_container",[](Test* self, std::vector<testing::Test&> container){ self->set_container(container);}, py::arg("container"))
         .def("get_container",[](Test* self){return self->get_container();})
-        .def("_repr_markdown_", [](Test* self, const gtsam::KeyFormatter& keyFormatter){return self->markdown(keyFormatter);}, py::arg("keyFormatter") = gtsam::DefaultKeyFormatter)
+        .def("_repr_markdown_",[](Test* self, const gtsam::KeyFormatter& keyFormatter){return self->markdown(keyFormatter);}, py::arg("keyFormatter") = gtsam::DefaultKeyFormatter)
         .def_readwrite("model_ptr", &Test::model_ptr);
 
     py::class_<PrimitiveRef<double>, std::shared_ptr<PrimitiveRef<double>>>(m_, "PrimitiveRefDouble")

--- a/tests/fixtures/class.i
+++ b/tests/fixtures/class.i
@@ -77,6 +77,10 @@ class Test {
   void set_container(std::vector<testing::Test&> container);
   std::vector<testing::Test*> get_container() const;
 
+  // special ipython method
+  string markdown(const gtsam::KeyFormatter& keyFormatter =
+                 gtsam::DefaultKeyFormatter) const;
+
   // comments at the end!
 
   // even more comments at the end!

--- a/tests/test_interface_parser.py
+++ b/tests/test_interface_parser.py
@@ -657,8 +657,6 @@ class TestInterfaceParser(unittest.TestCase):
         int globalVar;
         """)
 
-        # print("module: ", module)
-        # print(dir(module.content[0].name))
         self.assertEqual(["one", "Global", "globalVar"],
                          [x.name for x in module.content])
         self.assertEqual(["two", "two_dummy", "two", "oneVar"],


### PR DESCRIPTION
This PR adds support for the various `_repr_*_` methods in IPython as detailed [here](https://ipython.readthedocs.io/en/stable/config/integrating.html).

Only the `_repr_mimetype_` method is not supported since that requires some special handling.

@dellaert the main unit test you need to look at is in `class.i` and the `class_pybind.cpp` and `class_py.cpp` files.