### PR TITLE
Fix Matlab wrapping of raw pointer

### DIFF
--- a/gtwrap/matlab_wrapper/mixins.py
+++ b/gtwrap/matlab_wrapper/mixins.py
@@ -26,25 +26,30 @@ class CheckMixin:
                 return True
         return False
 
+    def can_be_pointer(self, arg_type: parser.Type):
+        """
+        Determine if the `arg_type` can have a pointer to it.
+
+        E.g. `Pose3` can have `Pose3*` but 
+        `Matrix` should not have `Matrix*`.
+        """
+        return (arg_type.typename.name not in self.not_ptr_type
+                and arg_type.typename.name not in self.ignore_namespace
+                and arg_type.typename.name != 'string')
+
     def is_shared_ptr(self, arg_type: parser.Type):
         """
         Determine if the `interface_parser.Type` should be treated as a
         shared pointer in the wrapper.
         """
-        return arg_type.is_shared_ptr or (
-            arg_type.typename.name not in self.not_ptr_type
-            and arg_type.typename.name not in self.ignore_namespace
-            and arg_type.typename.name != 'string')
+        return arg_type.is_shared_ptr
 
     def is_ptr(self, arg_type: parser.Type):
         """
         Determine if the `interface_parser.Type` should be treated as a
         raw pointer in the wrapper.
         """
-        return arg_type.is_ptr or (
-            arg_type.typename.name not in self.not_ptr_type
-            and arg_type.typename.name not in self.ignore_namespace
-            and arg_type.typename.name != 'string')
+        return arg_type.is_ptr
 
     def is_ref(self, arg_type: parser.Type):
         """

--- a/gtwrap/matlab_wrapper/wrapper.py
+++ b/gtwrap/matlab_wrapper/wrapper.py
@@ -147,11 +147,13 @@ class MatlabWrapper(CheckMixin, FormatMixin):
         """
         def args_copy(args):
             return ArgumentList([copy.copy(arg) for arg in args.list()])
+
         def method_copy(method):
             method2 = copy.copy(method)
             method2.args = args_copy(method.args)
             method2.args.backup = method.args.backup
             return method2
+
         if save_backup:
             method.args.backup = args_copy(method.args)
         method = method_copy(method)
@@ -162,7 +164,8 @@ class MatlabWrapper(CheckMixin, FormatMixin):
                 method.args.list().remove(arg)
                 return [
                     methodWithArg,
-                    *MatlabWrapper._expand_default_arguments(method, save_backup=False)
+                    *MatlabWrapper._expand_default_arguments(method,
+                                                             save_backup=False)
                 ]
             break
         assert all(arg.default is None for arg in method.args.list()), \
@@ -180,9 +183,12 @@ class MatlabWrapper(CheckMixin, FormatMixin):
 
             if method_index is None:
                 method_map[method.name] = len(method_out)
-                method_out.append(MatlabWrapper._expand_default_arguments(method))
+                method_out.append(
+                    MatlabWrapper._expand_default_arguments(method))
             else:
-                method_out[method_index] += MatlabWrapper._expand_default_arguments(method)
+                method_out[
+                    method_index] += MatlabWrapper._expand_default_arguments(
+                        method)
 
         return method_out
 
@@ -337,43 +343,38 @@ class MatlabWrapper(CheckMixin, FormatMixin):
         body_args = ''
 
         for arg in args.list():
+            ctype_camel = self._format_type_name(arg.ctype.typename,
+                                                 separator='')
             if self.is_ref(arg.ctype):  # and not constructor:
-                ctype_camel = self._format_type_name(arg.ctype.typename,
-                                                     separator='')
-                body_args += textwrap.indent(textwrap.dedent('''\
-                   {ctype}& {name} = *unwrap_shared_ptr< {ctype} >(in[{id}], "ptr_{ctype_camel}");
-                '''.format(ctype=self._format_type_name(arg.ctype.typename),
-                           ctype_camel=ctype_camel,
-                           name=arg.name,
-                           id=arg_id)),
-                                             prefix='  ')
+                arg_type = "{ctype}&".format(
+                    ctype=self._format_type_name(arg.ctype.typename))
+                unwrap = '*unwrap_shared_ptr< {ctype} >(in[{id}], "ptr_{ctype_camel}");'.format(
+                    ctype=self._format_type_name(arg.ctype.typename),
+                    ctype_camel=ctype_camel,
+                    id=arg_id)
 
             elif (self.is_shared_ptr(arg.ctype) or self.is_ptr(arg.ctype)) and \
                     arg.ctype.typename.name not in self.ignore_namespace:
-                if arg.ctype.is_shared_ptr:
-                    call_type = arg.ctype.is_shared_ptr
-                else:
-                    call_type = arg.ctype.is_ptr
+                call_type = arg.ctype.is_shared_ptr
 
-                body_args += textwrap.indent(textwrap.dedent('''\
-                    {std_boost}::shared_ptr<{ctype_sep}> {name} = unwrap_shared_ptr< {ctype_sep} >(in[{id}], "ptr_{ctype}");
-                '''.format(std_boost='boost' if constructor else 'boost',
-                           ctype_sep=self._format_type_name(
-                               arg.ctype.typename),
-                           ctype=self._format_type_name(arg.ctype.typename,
-                                                        separator=''),
-                           name=arg.name,
-                           id=arg_id)),
-                                             prefix='  ')
+                arg_type = "{std_boost}::shared_ptr<{ctype_sep}>".format(
+                    std_boost='boost' if constructor else 'boost',
+                    ctype_sep=self._format_type_name(arg.ctype.typename))
+                unwrap = 'unwrap_shared_ptr< {ctype_sep} >(in[{id}], "ptr_{ctype}");'.format(
+                    ctype_sep=self._format_type_name(arg.ctype.typename),
+                    ctype=ctype_camel,
+                    id=arg_id)
 
             else:
-                body_args += textwrap.indent(textwrap.dedent('''\
-                    {ctype} {name} = unwrap< {ctype} >(in[{id}]);
-                '''.format(ctype=arg.ctype.typename.name,
-                           name=arg.name,
-                           id=arg_id)),
-                                             prefix='  ')
+                arg_type = "{ctype}".format(ctype=arg.ctype.typename.name)
+                unwrap = 'unwrap< {ctype} >(in[{id}]);'.format(
+                    ctype=arg.ctype.typename.name, id=arg_id)
 
+            body_args += textwrap.indent(textwrap.dedent('''\
+                    {arg_type} {name} = {unwrap}
+                    '''.format(arg_type=arg_type, name=arg.name,
+                               unwrap=unwrap)),
+                                         prefix='  ')
             arg_id += 1
 
         params = ''
@@ -383,12 +384,15 @@ class MatlabWrapper(CheckMixin, FormatMixin):
             if params != '':
                 params += ','
 
-            if (arg.default is not None) and (arg.name not in explicit_arg_names):
+            if (arg.default is not None) and (arg.name
+                                              not in explicit_arg_names):
                 params += arg.default
                 continue
 
-            if (not self.is_ref(arg.ctype)) and (self.is_shared_ptr(arg.ctype)) and (self.is_ptr(
-                    arg.ctype)) and (arg.ctype.typename.name not in self.ignore_namespace):
+            if (not self.is_ref(arg.ctype)) and (self.is_shared_ptr(
+                    arg.ctype)) and (self.is_ptr(
+                        arg.ctype)) and (arg.ctype.typename.name
+                                         not in self.ignore_namespace):
                 if arg.ctype.is_shared_ptr:
                     call_type = arg.ctype.is_shared_ptr
                 else:
@@ -601,7 +605,8 @@ class MatlabWrapper(CheckMixin, FormatMixin):
         if not isinstance(ctors, Iterable):
             ctors = [ctors]
 
-        ctors = sum((MatlabWrapper._expand_default_arguments(ctor) for ctor in ctors), [])
+        ctors = sum((MatlabWrapper._expand_default_arguments(ctor)
+                     for ctor in ctors), [])
 
         methods_wrap = textwrap.indent(textwrap.dedent("""\
             methods
@@ -885,10 +890,10 @@ class MatlabWrapper(CheckMixin, FormatMixin):
                     wrapper=self._wrapper_name(),
                     id=self._update_wrapper_id(
                         (namespace_name, instantiated_class,
-                        static_overload.name, static_overload)),
+                         static_overload.name, static_overload)),
                     class_name=instantiated_class.name,
                     end_statement=end_statement),
-                                            prefix='    ')
+                                               prefix='    ')
 
             # If the arguments don't match any of the checks above,
             # throw an error with the class and method name.

--- a/gtwrap/matlab_wrapper/wrapper.py
+++ b/gtwrap/matlab_wrapper/wrapper.py
@@ -345,23 +345,19 @@ class MatlabWrapper(CheckMixin, FormatMixin):
         for arg in args.list():
             ctype_camel = self._format_type_name(arg.ctype.typename,
                                                  separator='')
+            ctype_sep = self._format_type_name(arg.ctype.typename)
+
             if self.is_ref(arg.ctype):  # and not constructor:
-                arg_type = "{ctype}&".format(
-                    ctype=self._format_type_name(arg.ctype.typename))
+                arg_type = "{ctype}&".format(ctype=ctype_sep)
                 unwrap = '*unwrap_shared_ptr< {ctype} >(in[{id}], "ptr_{ctype_camel}");'.format(
-                    ctype=self._format_type_name(arg.ctype.typename),
-                    ctype_camel=ctype_camel,
-                    id=arg_id)
+                    ctype=ctype_sep, ctype_camel=ctype_camel, id=arg_id)
 
             elif self.is_ptr(arg.ctype) and \
                     arg.ctype.typename.name not in self.ignore_namespace:
 
-                arg_type = "{ctype_sep}*".format(
-                    ctype_sep=self._format_type_name(arg.ctype.typename))
+                arg_type = "{ctype_sep}*".format(ctype_sep=ctype_sep)
                 unwrap = 'unwrap_ptr< {ctype_sep} >(in[{id}], "ptr_{ctype}");'.format(
-                    ctype_sep=self._format_type_name(arg.ctype.typename),
-                    ctype=ctype_camel,
-                    id=arg_id)
+                    ctype_sep=ctype_sep, ctype=ctype_camel, id=arg_id)
 
             elif (self.is_shared_ptr(arg.ctype) or self.can_be_pointer(arg.ctype)) and \
                     arg.ctype.typename.name not in self.ignore_namespace:
@@ -369,11 +365,9 @@ class MatlabWrapper(CheckMixin, FormatMixin):
 
                 arg_type = "{std_boost}::shared_ptr<{ctype_sep}>".format(
                     std_boost='boost' if constructor else 'boost',
-                    ctype_sep=self._format_type_name(arg.ctype.typename))
+                    ctype_sep=ctype_sep)
                 unwrap = 'unwrap_shared_ptr< {ctype_sep} >(in[{id}], "ptr_{ctype}");'.format(
-                    ctype_sep=self._format_type_name(arg.ctype.typename),
-                    ctype=ctype_camel,
-                    id=arg_id)
+                    ctype_sep=ctype_sep, ctype=ctype_camel, id=arg_id)
 
             else:
                 arg_type = "{ctype}".format(ctype=arg.ctype.typename.name)

--- a/matlab.h
+++ b/matlab.h
@@ -26,6 +26,7 @@
 #include <gtsam/base/Matrix.h>
 #include <gtsam/geometry/Point2.h>
 #include <gtsam/geometry/Point3.h>
+#include <gtsam/base/utilities.h>
 
 using gtsam::Vector;
 using gtsam::Matrix;
@@ -474,6 +475,14 @@ boost::shared_ptr<Class> unwrap_shared_ptr(const mxArray* obj, const string& pro
 
   boost::shared_ptr<Class>* spp = *reinterpret_cast<boost::shared_ptr<Class>**> (mxGetData(mxh));
   return *spp;
+}
+
+template <typename Class>
+Class* unwrap_ptr(const mxArray* obj, const string& propertyName) {
+
+  mxArray* mxh = mxGetProperty(obj,0, propertyName.c_str());
+  Class* x = reinterpret_cast<Class*> (mxGetData(mxh));
+  return x;
 }
 
 //// throw an error if unwrap_shared_ptr is attempted for an Eigen Vector

--- a/tests/expected/matlab/ForwardKinematicsFactor.m
+++ b/tests/expected/matlab/ForwardKinematicsFactor.m
@@ -11,9 +11,9 @@ classdef ForwardKinematicsFactor < gtsam.BetweenFactor<gtsam.Pose3>
         if nargin == 2
           my_ptr = varargin{2};
         else
-          my_ptr = inheritance_wrapper(36, varargin{2});
+          my_ptr = inheritance_wrapper(52, varargin{2});
         end
-        base_ptr = inheritance_wrapper(35, my_ptr);
+        base_ptr = inheritance_wrapper(51, my_ptr);
       else
         error('Arguments do not match any overload of ForwardKinematicsFactor constructor');
       end
@@ -22,7 +22,7 @@ classdef ForwardKinematicsFactor < gtsam.BetweenFactor<gtsam.Pose3>
     end
 
     function delete(obj)
-      inheritance_wrapper(37, obj.ptr_ForwardKinematicsFactor);
+      inheritance_wrapper(53, obj.ptr_ForwardKinematicsFactor);
     end
 
     function display(obj), obj.print(''); end

--- a/tests/expected/matlab/functions_wrapper.cpp
+++ b/tests/expected/matlab/functions_wrapper.cpp
@@ -86,7 +86,7 @@ void load2D_2(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("load2D",nargout,nargin,2);
   string filename = unwrap< string >(in[0]);
-  boost::shared_ptr<gtsam::noiseModel::Diagonal> model = unwrap_shared_ptr< gtsam::noiseModel::Diagonal >(in[1], "ptr_gtsamnoiseModelDiagonal");
+  gtsam::noiseModel::Diagonal* model = unwrap_ptr< gtsam::noiseModel::Diagonal >(in[1], "ptr_gtsamnoiseModelDiagonal");
   auto pairResult = load2D(filename,model);
   out[0] = wrap_shared_ptr(pairResult.first,"gtsam.NonlinearFactorGraph", false);
   out[1] = wrap_shared_ptr(pairResult.second,"gtsam.Values", false);

--- a/tests/expected/matlab/geometry_wrapper.cpp
+++ b/tests/expected/matlab/geometry_wrapper.cpp
@@ -151,7 +151,7 @@ void gtsamPoint2_argChar_7(int nargout, mxArray *out[], int nargin, const mxArra
 {
   checkArguments("argChar",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<gtsam::Point2>(in[0], "ptr_gtsamPoint2");
-  boost::shared_ptr<char> a = unwrap_shared_ptr< char >(in[1], "ptr_char");
+  char* a = unwrap_ptr< char >(in[1], "ptr_char");
   obj->argChar(a);
 }
 
@@ -175,7 +175,7 @@ void gtsamPoint2_argChar_10(int nargout, mxArray *out[], int nargin, const mxArr
 {
   checkArguments("argChar",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<gtsam::Point2>(in[0], "ptr_gtsamPoint2");
-  boost::shared_ptr<char> a = unwrap_shared_ptr< char >(in[1], "ptr_char");
+  char* a = unwrap_ptr< char >(in[1], "ptr_char");
   obj->argChar(a);
 }
 

--- a/tests/expected/matlab/inheritance_wrapper.cpp
+++ b/tests/expected/matlab/inheritance_wrapper.cpp
@@ -9,6 +9,7 @@
 
 typedef MyTemplate<gtsam::Point2> MyTemplatePoint2;
 typedef MyTemplate<gtsam::Matrix> MyTemplateMatrix;
+typedef MyTemplate<A> MyTemplateA;
 
 typedef std::set<boost::shared_ptr<MyBase>*> Collector_MyBase;
 static Collector_MyBase collector_MyBase;
@@ -16,6 +17,8 @@ typedef std::set<boost::shared_ptr<MyTemplatePoint2>*> Collector_MyTemplatePoint
 static Collector_MyTemplatePoint2 collector_MyTemplatePoint2;
 typedef std::set<boost::shared_ptr<MyTemplateMatrix>*> Collector_MyTemplateMatrix;
 static Collector_MyTemplateMatrix collector_MyTemplateMatrix;
+typedef std::set<boost::shared_ptr<MyTemplateA>*> Collector_MyTemplateA;
+static Collector_MyTemplateA collector_MyTemplateA;
 typedef std::set<boost::shared_ptr<ForwardKinematicsFactor>*> Collector_ForwardKinematicsFactor;
 static Collector_ForwardKinematicsFactor collector_ForwardKinematicsFactor;
 
@@ -44,6 +47,12 @@ void _deleteAllObjects()
     collector_MyTemplateMatrix.erase(iter++);
     anyDeleted = true;
   } }
+  { for(Collector_MyTemplateA::iterator iter = collector_MyTemplateA.begin();
+      iter != collector_MyTemplateA.end(); ) {
+    delete *iter;
+    collector_MyTemplateA.erase(iter++);
+    anyDeleted = true;
+  } }
   { for(Collector_ForwardKinematicsFactor::iterator iter = collector_ForwardKinematicsFactor.begin();
       iter != collector_ForwardKinematicsFactor.end(); ) {
     delete *iter;
@@ -67,6 +76,7 @@ void _inheritance_RTTIRegister() {
     types.insert(std::make_pair(typeid(MyBase).name(), "MyBase"));
     types.insert(std::make_pair(typeid(MyTemplatePoint2).name(), "MyTemplatePoint2"));
     types.insert(std::make_pair(typeid(MyTemplateMatrix).name(), "MyTemplateMatrix"));
+    types.insert(std::make_pair(typeid(MyTemplateA).name(), "MyTemplateA"));
     types.insert(std::make_pair(typeid(ForwardKinematicsFactor).name(), "ForwardKinematicsFactor"));
 
 
@@ -462,7 +472,157 @@ void MyTemplateMatrix_Level_34(int nargout, mxArray *out[], int nargin, const mx
   out[0] = wrap_shared_ptr(boost::make_shared<MyTemplate<Matrix>>(MyTemplate<gtsam::Matrix>::Level(K)),"MyTemplateMatrix", false);
 }
 
-void ForwardKinematicsFactor_collectorInsertAndMakeBase_35(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyTemplateA_collectorInsertAndMakeBase_35(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  mexAtExit(&_deleteAllObjects);
+  typedef boost::shared_ptr<MyTemplate<A>> Shared;
+
+  Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
+  collector_MyTemplateA.insert(self);
+
+  typedef boost::shared_ptr<MyBase> SharedBase;
+  out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
+  *reinterpret_cast<SharedBase**>(mxGetData(out[0])) = new SharedBase(*self);
+}
+
+void MyTemplateA_upcastFromVoid_36(int nargout, mxArray *out[], int nargin, const mxArray *in[]) {
+  mexAtExit(&_deleteAllObjects);
+  typedef boost::shared_ptr<MyTemplate<A>> Shared;
+  boost::shared_ptr<void> *asVoid = *reinterpret_cast<boost::shared_ptr<void>**> (mxGetData(in[0]));
+  out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
+  Shared *self = new Shared(boost::static_pointer_cast<MyTemplate<A>>(*asVoid));
+  *reinterpret_cast<Shared**>(mxGetData(out[0])) = self;
+}
+
+void MyTemplateA_constructor_37(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  mexAtExit(&_deleteAllObjects);
+  typedef boost::shared_ptr<MyTemplate<A>> Shared;
+
+  Shared *self = new Shared(new MyTemplate<A>());
+  collector_MyTemplateA.insert(self);
+  out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
+  *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
+
+  typedef boost::shared_ptr<MyBase> SharedBase;
+  out[1] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
+  *reinterpret_cast<SharedBase**>(mxGetData(out[1])) = new SharedBase(*self);
+}
+
+void MyTemplateA_deconstructor_38(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  typedef boost::shared_ptr<MyTemplate<A>> Shared;
+  checkArguments("delete_MyTemplateA",nargout,nargin,1);
+  Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
+  Collector_MyTemplateA::iterator item;
+  item = collector_MyTemplateA.find(self);
+  if(item != collector_MyTemplateA.end()) {
+    collector_MyTemplateA.erase(item);
+  }
+  delete self;
+}
+
+void MyTemplateA_accept_T_39(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("accept_T",nargout,nargin-1,1);
+  auto obj = unwrap_shared_ptr<MyTemplate<A>>(in[0], "ptr_MyTemplateA");
+  A& value = *unwrap_shared_ptr< A >(in[1], "ptr_A");
+  obj->accept_T(value);
+}
+
+void MyTemplateA_accept_Tptr_40(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("accept_Tptr",nargout,nargin-1,1);
+  auto obj = unwrap_shared_ptr<MyTemplate<A>>(in[0], "ptr_MyTemplateA");
+  boost::shared_ptr<A> value = unwrap_shared_ptr< A >(in[1], "ptr_A");
+  obj->accept_Tptr(value);
+}
+
+void MyTemplateA_create_MixedPtrs_41(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("create_MixedPtrs",nargout,nargin-1,0);
+  auto obj = unwrap_shared_ptr<MyTemplate<A>>(in[0], "ptr_MyTemplateA");
+  auto pairResult = obj->create_MixedPtrs();
+  out[0] = wrap_shared_ptr(boost::make_shared<A>(pairResult.first),"A", false);
+  out[1] = wrap_shared_ptr(pairResult.second,"A", false);
+}
+
+void MyTemplateA_create_ptrs_42(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("create_ptrs",nargout,nargin-1,0);
+  auto obj = unwrap_shared_ptr<MyTemplate<A>>(in[0], "ptr_MyTemplateA");
+  auto pairResult = obj->create_ptrs();
+  out[0] = wrap_shared_ptr(pairResult.first,"A", false);
+  out[1] = wrap_shared_ptr(pairResult.second,"A", false);
+}
+
+void MyTemplateA_return_T_43(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("return_T",nargout,nargin-1,1);
+  auto obj = unwrap_shared_ptr<MyTemplate<A>>(in[0], "ptr_MyTemplateA");
+  A* value = unwrap_ptr< A >(in[1], "ptr_A");
+  out[0] = wrap_shared_ptr(boost::make_shared<A>(obj->return_T(value)),"A", false);
+}
+
+void MyTemplateA_return_Tptr_44(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("return_Tptr",nargout,nargin-1,1);
+  auto obj = unwrap_shared_ptr<MyTemplate<A>>(in[0], "ptr_MyTemplateA");
+  boost::shared_ptr<A> value = unwrap_shared_ptr< A >(in[1], "ptr_A");
+  out[0] = wrap_shared_ptr(obj->return_Tptr(value),"A", false);
+}
+
+void MyTemplateA_return_ptrs_45(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("return_ptrs",nargout,nargin-1,2);
+  auto obj = unwrap_shared_ptr<MyTemplate<A>>(in[0], "ptr_MyTemplateA");
+  boost::shared_ptr<A> p1 = unwrap_shared_ptr< A >(in[1], "ptr_A");
+  boost::shared_ptr<A> p2 = unwrap_shared_ptr< A >(in[2], "ptr_A");
+  auto pairResult = obj->return_ptrs(p1,p2);
+  out[0] = wrap_shared_ptr(pairResult.first,"A", false);
+  out[1] = wrap_shared_ptr(pairResult.second,"A", false);
+}
+
+void MyTemplateA_templatedMethod_46(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("templatedMethodMatrix",nargout,nargin-1,1);
+  auto obj = unwrap_shared_ptr<MyTemplate<A>>(in[0], "ptr_MyTemplateA");
+  Matrix t = unwrap< Matrix >(in[1]);
+  out[0] = wrap< Matrix >(obj->templatedMethod<gtsam::Matrix>(t));
+}
+
+void MyTemplateA_templatedMethod_47(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("templatedMethodPoint2",nargout,nargin-1,1);
+  auto obj = unwrap_shared_ptr<MyTemplate<A>>(in[0], "ptr_MyTemplateA");
+  Point2 t = unwrap< Point2 >(in[1]);
+  out[0] = wrap< Point2 >(obj->templatedMethod<gtsam::Point2>(t));
+}
+
+void MyTemplateA_templatedMethod_48(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("templatedMethodPoint3",nargout,nargin-1,1);
+  auto obj = unwrap_shared_ptr<MyTemplate<A>>(in[0], "ptr_MyTemplateA");
+  Point3 t = unwrap< Point3 >(in[1]);
+  out[0] = wrap< Point3 >(obj->templatedMethod<gtsam::Point3>(t));
+}
+
+void MyTemplateA_templatedMethod_49(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("templatedMethodVector",nargout,nargin-1,1);
+  auto obj = unwrap_shared_ptr<MyTemplate<A>>(in[0], "ptr_MyTemplateA");
+  Vector t = unwrap< Vector >(in[1]);
+  out[0] = wrap< Vector >(obj->templatedMethod<gtsam::Vector>(t));
+}
+
+void MyTemplateA_Level_50(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("MyTemplate<A>.Level",nargout,nargin,1);
+  A& K = *unwrap_shared_ptr< A >(in[0], "ptr_A");
+  out[0] = wrap_shared_ptr(boost::make_shared<MyTemplate<A>>(MyTemplate<A>::Level(K)),"MyTemplateA", false);
+}
+
+void ForwardKinematicsFactor_collectorInsertAndMakeBase_51(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<ForwardKinematicsFactor> Shared;
@@ -475,7 +635,7 @@ void ForwardKinematicsFactor_collectorInsertAndMakeBase_35(int nargout, mxArray 
   *reinterpret_cast<SharedBase**>(mxGetData(out[0])) = new SharedBase(*self);
 }
 
-void ForwardKinematicsFactor_upcastFromVoid_36(int nargout, mxArray *out[], int nargin, const mxArray *in[]) {
+void ForwardKinematicsFactor_upcastFromVoid_52(int nargout, mxArray *out[], int nargin, const mxArray *in[]) {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<ForwardKinematicsFactor> Shared;
   boost::shared_ptr<void> *asVoid = *reinterpret_cast<boost::shared_ptr<void>**> (mxGetData(in[0]));
@@ -484,7 +644,7 @@ void ForwardKinematicsFactor_upcastFromVoid_36(int nargout, mxArray *out[], int 
   *reinterpret_cast<Shared**>(mxGetData(out[0])) = self;
 }
 
-void ForwardKinematicsFactor_deconstructor_37(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void ForwardKinematicsFactor_deconstructor_53(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<ForwardKinematicsFactor> Shared;
   checkArguments("delete_ForwardKinematicsFactor",nargout,nargin,1);
@@ -615,13 +775,61 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       MyTemplateMatrix_Level_34(nargout, out, nargin-1, in+1);
       break;
     case 35:
-      ForwardKinematicsFactor_collectorInsertAndMakeBase_35(nargout, out, nargin-1, in+1);
+      MyTemplateA_collectorInsertAndMakeBase_35(nargout, out, nargin-1, in+1);
       break;
     case 36:
-      ForwardKinematicsFactor_upcastFromVoid_36(nargout, out, nargin-1, in+1);
+      MyTemplateA_upcastFromVoid_36(nargout, out, nargin-1, in+1);
       break;
     case 37:
-      ForwardKinematicsFactor_deconstructor_37(nargout, out, nargin-1, in+1);
+      MyTemplateA_constructor_37(nargout, out, nargin-1, in+1);
+      break;
+    case 38:
+      MyTemplateA_deconstructor_38(nargout, out, nargin-1, in+1);
+      break;
+    case 39:
+      MyTemplateA_accept_T_39(nargout, out, nargin-1, in+1);
+      break;
+    case 40:
+      MyTemplateA_accept_Tptr_40(nargout, out, nargin-1, in+1);
+      break;
+    case 41:
+      MyTemplateA_create_MixedPtrs_41(nargout, out, nargin-1, in+1);
+      break;
+    case 42:
+      MyTemplateA_create_ptrs_42(nargout, out, nargin-1, in+1);
+      break;
+    case 43:
+      MyTemplateA_return_T_43(nargout, out, nargin-1, in+1);
+      break;
+    case 44:
+      MyTemplateA_return_Tptr_44(nargout, out, nargin-1, in+1);
+      break;
+    case 45:
+      MyTemplateA_return_ptrs_45(nargout, out, nargin-1, in+1);
+      break;
+    case 46:
+      MyTemplateA_templatedMethod_46(nargout, out, nargin-1, in+1);
+      break;
+    case 47:
+      MyTemplateA_templatedMethod_47(nargout, out, nargin-1, in+1);
+      break;
+    case 48:
+      MyTemplateA_templatedMethod_48(nargout, out, nargin-1, in+1);
+      break;
+    case 49:
+      MyTemplateA_templatedMethod_49(nargout, out, nargin-1, in+1);
+      break;
+    case 50:
+      MyTemplateA_Level_50(nargout, out, nargin-1, in+1);
+      break;
+    case 51:
+      ForwardKinematicsFactor_collectorInsertAndMakeBase_51(nargout, out, nargin-1, in+1);
+      break;
+    case 52:
+      ForwardKinematicsFactor_upcastFromVoid_52(nargout, out, nargin-1, in+1);
+      break;
+    case 53:
+      ForwardKinematicsFactor_deconstructor_53(nargout, out, nargin-1, in+1);
       break;
     }
   } catch(const std::exception& e) {

--- a/tests/expected/python/inheritance_pybind.cpp
+++ b/tests/expected/python/inheritance_pybind.cpp
@@ -54,6 +54,21 @@ PYBIND11_MODULE(inheritance_py, m_) {
         .def("return_ptrs",[](MyTemplate<gtsam::Matrix>* self, const std::shared_ptr<gtsam::Matrix> p1, const std::shared_ptr<gtsam::Matrix> p2){return self->return_ptrs(p1, p2);}, py::arg("p1"), py::arg("p2"))
         .def_static("Level",[](const gtsam::Matrix& K){return MyTemplate<gtsam::Matrix>::Level(K);}, py::arg("K"));
 
+    py::class_<MyTemplate<A>, MyBase, std::shared_ptr<MyTemplate<A>>>(m_, "MyTemplateA")
+        .def(py::init<>())
+        .def("templatedMethodPoint2",[](MyTemplate<A>* self, const gtsam::Point2& t){return self->templatedMethod<gtsam::Point2>(t);}, py::arg("t"))
+        .def("templatedMethodPoint3",[](MyTemplate<A>* self, const gtsam::Point3& t){return self->templatedMethod<gtsam::Point3>(t);}, py::arg("t"))
+        .def("templatedMethodVector",[](MyTemplate<A>* self, const gtsam::Vector& t){return self->templatedMethod<gtsam::Vector>(t);}, py::arg("t"))
+        .def("templatedMethodMatrix",[](MyTemplate<A>* self, const gtsam::Matrix& t){return self->templatedMethod<gtsam::Matrix>(t);}, py::arg("t"))
+        .def("accept_T",[](MyTemplate<A>* self, const A& value){ self->accept_T(value);}, py::arg("value"))
+        .def("accept_Tptr",[](MyTemplate<A>* self, std::shared_ptr<A> value){ self->accept_Tptr(value);}, py::arg("value"))
+        .def("return_Tptr",[](MyTemplate<A>* self, std::shared_ptr<A> value){return self->return_Tptr(value);}, py::arg("value"))
+        .def("return_T",[](MyTemplate<A>* self, A* value){return self->return_T(value);}, py::arg("value"))
+        .def("create_ptrs",[](MyTemplate<A>* self){return self->create_ptrs();})
+        .def("create_MixedPtrs",[](MyTemplate<A>* self){return self->create_MixedPtrs();})
+        .def("return_ptrs",[](MyTemplate<A>* self, std::shared_ptr<A> p1, std::shared_ptr<A> p2){return self->return_ptrs(p1, p2);}, py::arg("p1"), py::arg("p2"))
+        .def_static("Level",[](const A& K){return MyTemplate<A>::Level(K);}, py::arg("K"));
+
     py::class_<ForwardKinematicsFactor, gtsam::BetweenFactor<gtsam::Pose3>, std::shared_ptr<ForwardKinematicsFactor>>(m_, "ForwardKinematicsFactor");
 
 

--- a/tests/fixtures/inheritance.i
+++ b/tests/fixtures/inheritance.i
@@ -4,7 +4,7 @@ virtual class MyBase {
 };
 
 // A templated class
-template<T = {gtsam::Point2, Matrix}>
+template<T = {gtsam::Point2, Matrix, A}>
 virtual class MyTemplate : MyBase {
   MyTemplate();
 


### PR DESCRIPTION
The matlab wrapper was never updated to handle raw pointers (e.g. `func(Pose3@ pose);`) so this PR fixes that.

The main thing is the introduction of a new `unwrap_ptr` function in `matlab.h` that works similar to `unwrap_shared_ptr` but for a raw pointer.

cc @dellaert since this came up due to updates to discrete.i.