### PR TITLE
Inheritance with parent class templated on template parameters

### DIFF
--- a/gtwrap/interface_parser/classes.py
+++ b/gtwrap/interface_parser/classes.py
@@ -299,7 +299,7 @@ class Class:
             # If the base class is a TemplatedType,
             # we want the instantiated Typename
             if isinstance(parent_class, TemplatedType):
-                parent_class = parent_class.typename  # type: ignore
+                pass  # Note: this must get handled in InstantiatedClass
 
             self.parent_class = parent_class
         else:

--- a/tests/expected/matlab/inheritance_wrapper.cpp
+++ b/tests/expected/matlab/inheritance_wrapper.cpp
@@ -10,6 +10,7 @@
 typedef MyTemplate<gtsam::Point2> MyTemplatePoint2;
 typedef MyTemplate<gtsam::Matrix> MyTemplateMatrix;
 typedef MyTemplate<A> MyTemplateA;
+typedef ParentHasTemplate<double> ParentHasTemplateDouble;
 
 typedef std::set<boost::shared_ptr<MyBase>*> Collector_MyBase;
 static Collector_MyBase collector_MyBase;
@@ -21,6 +22,8 @@ typedef std::set<boost::shared_ptr<MyTemplateA>*> Collector_MyTemplateA;
 static Collector_MyTemplateA collector_MyTemplateA;
 typedef std::set<boost::shared_ptr<ForwardKinematicsFactor>*> Collector_ForwardKinematicsFactor;
 static Collector_ForwardKinematicsFactor collector_ForwardKinematicsFactor;
+typedef std::set<boost::shared_ptr<ParentHasTemplateDouble>*> Collector_ParentHasTemplateDouble;
+static Collector_ParentHasTemplateDouble collector_ParentHasTemplateDouble;
 
 
 void _deleteAllObjects()
@@ -59,6 +62,12 @@ void _deleteAllObjects()
     collector_ForwardKinematicsFactor.erase(iter++);
     anyDeleted = true;
   } }
+  { for(Collector_ParentHasTemplateDouble::iterator iter = collector_ParentHasTemplateDouble.begin();
+      iter != collector_ParentHasTemplateDouble.end(); ) {
+    delete *iter;
+    collector_ParentHasTemplateDouble.erase(iter++);
+    anyDeleted = true;
+  } }
 
   if(anyDeleted)
     cout <<
@@ -78,6 +87,7 @@ void _inheritance_RTTIRegister() {
     types.insert(std::make_pair(typeid(MyTemplateMatrix).name(), "MyTemplateMatrix"));
     types.insert(std::make_pair(typeid(MyTemplateA).name(), "MyTemplateA"));
     types.insert(std::make_pair(typeid(ForwardKinematicsFactor).name(), "ForwardKinematicsFactor"));
+    types.insert(std::make_pair(typeid(ParentHasTemplateDouble).name(), "ParentHasTemplateDouble"));
 
 
     mxArray *registry = mexGetVariable("global", "gtsamwrap_rttiRegistry");
@@ -657,6 +667,41 @@ void ForwardKinematicsFactor_deconstructor_53(int nargout, mxArray *out[], int n
   delete self;
 }
 
+void ParentHasTemplateDouble_collectorInsertAndMakeBase_54(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  mexAtExit(&_deleteAllObjects);
+  typedef boost::shared_ptr<ParentHasTemplate<double>> Shared;
+
+  Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
+  collector_ParentHasTemplateDouble.insert(self);
+
+  typedef boost::shared_ptr<MyTemplate<double>> SharedBase;
+  out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
+  *reinterpret_cast<SharedBase**>(mxGetData(out[0])) = new SharedBase(*self);
+}
+
+void ParentHasTemplateDouble_upcastFromVoid_55(int nargout, mxArray *out[], int nargin, const mxArray *in[]) {
+  mexAtExit(&_deleteAllObjects);
+  typedef boost::shared_ptr<ParentHasTemplate<double>> Shared;
+  boost::shared_ptr<void> *asVoid = *reinterpret_cast<boost::shared_ptr<void>**> (mxGetData(in[0]));
+  out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
+  Shared *self = new Shared(boost::static_pointer_cast<ParentHasTemplate<double>>(*asVoid));
+  *reinterpret_cast<Shared**>(mxGetData(out[0])) = self;
+}
+
+void ParentHasTemplateDouble_deconstructor_56(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  typedef boost::shared_ptr<ParentHasTemplate<double>> Shared;
+  checkArguments("delete_ParentHasTemplateDouble",nargout,nargin,1);
+  Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
+  Collector_ParentHasTemplateDouble::iterator item;
+  item = collector_ParentHasTemplateDouble.find(self);
+  if(item != collector_ParentHasTemplateDouble.end()) {
+    collector_ParentHasTemplateDouble.erase(item);
+  }
+  delete self;
+}
+
 
 void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
@@ -830,6 +875,15 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       break;
     case 53:
       ForwardKinematicsFactor_deconstructor_53(nargout, out, nargin-1, in+1);
+      break;
+    case 54:
+      ParentHasTemplateDouble_collectorInsertAndMakeBase_54(nargout, out, nargin-1, in+1);
+      break;
+    case 55:
+      ParentHasTemplateDouble_upcastFromVoid_55(nargout, out, nargin-1, in+1);
+      break;
+    case 56:
+      ParentHasTemplateDouble_deconstructor_56(nargout, out, nargin-1, in+1);
       break;
     }
   } catch(const std::exception& e) {

--- a/tests/expected/python/inheritance_pybind.cpp
+++ b/tests/expected/python/inheritance_pybind.cpp
@@ -71,6 +71,8 @@ PYBIND11_MODULE(inheritance_py, m_) {
 
     py::class_<ForwardKinematicsFactor, gtsam::BetweenFactor<gtsam::Pose3>, std::shared_ptr<ForwardKinematicsFactor>>(m_, "ForwardKinematicsFactor");
 
+    py::class_<ParentHasTemplate<double>, MyTemplate<double>, std::shared_ptr<ParentHasTemplate<double>>>(m_, "ParentHasTemplateDouble");
+
 
 #include "python/specializations.h"
 

--- a/tests/fixtures/inheritance.i
+++ b/tests/fixtures/inheritance.i
@@ -24,3 +24,6 @@ virtual class MyTemplate : MyBase {
 
 
 virtual class ForwardKinematicsFactor : gtsam::BetweenFactor<gtsam::Pose3> {};
+
+template <T = {double}>
+virtual class ParentHasTemplate : MyTemplate<T> {};

--- a/tests/test_interface_parser.py
+++ b/tests/test_interface_parser.py
@@ -26,6 +26,8 @@ from gtwrap.interface_parser import (ArgumentList, Class, Constructor, Enum,
                                      TypedefTemplateInstantiation, Typename,
                                      Variable)
 
+from gtwrap.template_instantiator.classes import InstantiatedClass
+
 
 class TestInterfaceParser(unittest.TestCase):
     """Test driver for all classes in interface_parser.py."""
@@ -501,6 +503,7 @@ class TestInterfaceParser(unittest.TestCase):
         ret = Class.rule.parseString(
             "class ForwardKinematicsFactor : gtsam::BetweenFactor<gtsam::Pose3> {};"
         )[0]
+        ret = InstantiatedClass(ret, [])  # Needed to correctly parse parent class
         self.assertEqual("ForwardKinematicsFactor", ret.name)
         self.assertEqual("BetweenFactor", ret.parent_class.name)
         self.assertEqual(["gtsam"], ret.parent_class.namespaces)


### PR DESCRIPTION
In a case where the parent class is templated on the derived class's template parameters, e.g.

```c++
template <typename T>
class Derived : public Parent<T> { ... };
```

the current wrapper does not substitute the typename `T` properly.  I.e.

```c++
template <T = {double}>
class Derived : Parent<T> { ... };
```

results in a generated .cpp pybind:

```c++
py::class_<Derived<double>, Parent<T>, boost::shared_ptr<Derived<T>>>(m_, "DerivedDouble").def(...);
```
instead of:
```c++
py::class_<Derived<double>, Parent<double>, boost::shared_ptr<Derived<T>>>(m_, "DerivedDouble").def(...);
```

This PR fixes it.

Notable change:  previously in `Class`, if `parent_class` was a `TemplatedType` then it would get "instantiated" immediately to the generic type name.  I changed this behavior to delay instantiation until inside `InstantiatedClass` (since you can't know what to do until you check for template matches).  I don't think this should cause any problems since during parsing `Class`es are always converted to `InstantiatedClass` even for non-template classes, but if there's any case that a `Class` is /not/ converted to `InstantiatedClass` and it does have a templated parent class, then an error might get thrown in python.

(Currently rebuilding gtsam but I don't expect any issues) *edit, passed all tests on gtsam