### PR TITLE
Function template argument namespaces

### DIFF
--- a/gtwrap/template_instantiator/function.py
+++ b/gtwrap/template_instantiator/function.py
@@ -55,7 +55,8 @@ class InstantiatedGlobalFunction(parser.GlobalFunction):
         """Generate the C++ code for wrapping."""
         if self.original.template:
             instantiated_names = [
-                inst.instantiated_name() for inst in self.instantiations
+                "::".join(inst.namespaces + [inst.instantiated_name()])
+                for inst in self.instantiations
             ]
             ret = "{}<{}>".format(self.original.name,
                                   ",".join(instantiated_names))

--- a/tests/expected/python/functions_pybind.cpp
+++ b/tests/expected/python/functions_pybind.cpp
@@ -36,7 +36,7 @@ PYBIND11_MODULE(functions_py, m_) {
     m_.def("DefaultFuncZero",[](int a, int b, double c, int d, bool e){ ::DefaultFuncZero(a, b, c, d, e);}, py::arg("a"), py::arg("b"), py::arg("c") = 0.0, py::arg("d") = 0, py::arg("e") = false);
     m_.def("DefaultFuncVector",[](const std::vector<int>& i, const std::vector<string>& s){ ::DefaultFuncVector(i, s);}, py::arg("i") = {1, 2, 3}, py::arg("s") = {"borglab", "gtsam"});
     m_.def("setPose",[](const gtsam::Pose3& pose){ ::setPose(pose);}, py::arg("pose") = gtsam::Pose3());
-    m_.def("TemplatedFunctionRot3",[](const gtsam::Rot3& t){ ::TemplatedFunction<Rot3>(t);}, py::arg("t"));
+    m_.def("TemplatedFunctionRot3",[](const gtsam::Rot3& t){ ::TemplatedFunction<gtsam::Rot3>(t);}, py::arg("t"));
 
 #include "python/specializations.h"
 


### PR DESCRIPTION
Previously, the template argument for a function had its namespace stripped.  So for example,

```c++
template<T = {gtsam::Rot3}>
void TemplatedFunction();
```
would generate something like:
```c++
    m_.def("TemplatedFunctionRot3",[](){ ::TemplatedFunction<Rot3>();});
```
instead of
```c++
    m_.def("TemplatedFunctionRot3",[](){ ::TemplatedFunction<gtsam::Rot3>();});
```
(notice the `gtsam::Rot3`)

Fixed this in the unit test and code.