### PR TITLE
Add class property support to Matlab

### DIFF
--- a/gtwrap/matlab_wrapper/wrapper.py
+++ b/gtwrap/matlab_wrapper/wrapper.py
@@ -595,12 +595,13 @@ class MatlabWrapper(CheckMixin, FormatMixin):
         param_wrap += textwrap.indent(textwrap.dedent('''\
             else
               error('Arguments do not match any overload of function {func_name}');
-        ''').format(func_name=function_name),
+            end''').format(func_name=function_name),
                                       prefix='      ')
 
         global_function = textwrap.indent(textwrap.dedent('''\
             function varargout = {m_method}(varargin)
-            {statements}      end
+            {statements}
+            end
         ''').format(m_method=function_name, statements=param_wrap),
                                           prefix='')
 

--- a/gtwrap/matlab_wrapper/wrapper.py
+++ b/gtwrap/matlab_wrapper/wrapper.py
@@ -3,7 +3,7 @@ Code to use the parsed results and convert it to a format
 that Matlab's MEX compiler can use.
 """
 
-# pylint: disable=too-many-lines, no-self-use, too-many-arguments, too-many-branches, too-many-statements
+# pylint: disable=too-many-lines, no-self-use, too-many-arguments, too-many-branches, too-many-statements, consider-using-f-string, unspecified-encoding
 
 import copy
 import os

--- a/gtwrap/matlab_wrapper/wrapper.py
+++ b/gtwrap/matlab_wrapper/wrapper.py
@@ -17,6 +17,7 @@ import gtwrap.template_instantiator as instantiator
 from gtwrap.interface_parser.function import ArgumentList
 from gtwrap.matlab_wrapper.mixins import CheckMixin, FormatMixin
 from gtwrap.matlab_wrapper.templates import WrapperTemplate
+from gtwrap.template_instantiator.classes import InstantiatedClass
 
 
 class MatlabWrapper(CheckMixin, FormatMixin):
@@ -28,6 +29,7 @@ class MatlabWrapper(CheckMixin, FormatMixin):
         top_module_namespace: C++ namespace for the top module (default '')
         ignore_classes: A list of classes to ignore (default [])
     """
+
     def __init__(self,
                  module_name,
                  top_module_namespace='',
@@ -145,6 +147,7 @@ class MatlabWrapper(CheckMixin, FormatMixin):
         We create "overload" functions with fewer arguments, but since we have to "remember" what
         the default arguments are for later, we make a backup.
         """
+
         def args_copy(args):
             return ArgumentList([copy.copy(arg) for arg in args.list()])
 
@@ -452,6 +455,7 @@ class MatlabWrapper(CheckMixin, FormatMixin):
         """
         class_name = instantiated_class.name
         ctors = instantiated_class.ctors
+        properties = instantiated_class.properties
         methods = instantiated_class.methods
         static_methods = instantiated_class.static_methods
 
@@ -468,6 +472,12 @@ class MatlabWrapper(CheckMixin, FormatMixin):
             comment += '%{ctor_name}({args})\n'.format(ctor_name=ctor.name,
                                                        args=self._wrap_args(
                                                            ctor.args))
+
+        if len(properties) != 0:
+            comment += '%\n' \
+                       '%-------Properties-------\n'
+            for property in properties:
+                comment += '%{}\n'.format(property.name)
 
         if len(methods) != 0:
             comment += '%\n' \

--- a/gtwrap/template_instantiator/classes.py
+++ b/gtwrap/template_instantiator/classes.py
@@ -3,10 +3,10 @@
 import gtwrap.interface_parser as parser
 from gtwrap.template_instantiator.constructor import InstantiatedConstructor
 from gtwrap.template_instantiator.helpers import (InstantiationHelper,
-                                                  instantiate_type,
                                                   instantiate_args_list,
                                                   instantiate_name,
-                                                  instantiate_return_type)
+                                                  instantiate_return_type,
+                                                  instantiate_type)
 from gtwrap.template_instantiator.method import (InstantiatedMethod,
                                                  InstantiatedStaticMethod)
 
@@ -15,6 +15,7 @@ class InstantiatedClass(parser.Class):
     """
     Instantiate the class defined in the interface file.
     """
+
     def __init__(self, original: parser.Class, instantiations=(), new_name=''):
         """
         Template <T, U>
@@ -95,8 +96,9 @@ class InstantiatedClass(parser.Class):
         """
 
         if isinstance(self.original.parent_class, parser.type.TemplatedType):
-            return instantiate_type(self.original.parent_class, typenames, self.instantiations,
-                                    parser.Typename(self.namespaces())).typename
+            return instantiate_type(
+                self.original.parent_class, typenames, self.instantiations,
+                parser.Typename(self.namespaces())).typename
         else:
             return self.original.parent_class
 
@@ -195,12 +197,18 @@ class InstantiatedClass(parser.Class):
 
         Return: List of properties instantiated with provided template args.
         """
-        instantiated_properties = instantiate_args_list(
+        instantiated_ = instantiate_args_list(
             self.original.properties,
             typenames,
             self.instantiations,
             self.cpp_typename(),
         )
+        # Convert to type Variable
+        instantiated_properties = [
+            parser.Variable(ctype=[arg.ctype],
+                            name=arg.name,
+                            default=arg.default) for arg in instantiated_
+        ]
         return instantiated_properties
 
     def cpp_typename(self):

--- a/tests/expected/matlab/+gtsam/GeneralSFMFactorCal3Bundler.m
+++ b/tests/expected/matlab/+gtsam/GeneralSFMFactorCal3Bundler.m
@@ -9,7 +9,7 @@ classdef GeneralSFMFactorCal3Bundler < handle
     function obj = GeneralSFMFactorCal3Bundler(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        special_cases_wrapper(7, my_ptr);
+        special_cases_wrapper(9, my_ptr);
       else
         error('Arguments do not match any overload of gtsam.GeneralSFMFactorCal3Bundler constructor');
       end
@@ -17,7 +17,7 @@ classdef GeneralSFMFactorCal3Bundler < handle
     end
 
     function delete(obj)
-      special_cases_wrapper(8, obj.ptr_gtsamGeneralSFMFactorCal3Bundler);
+      special_cases_wrapper(10, obj.ptr_gtsamGeneralSFMFactorCal3Bundler);
     end
 
     function display(obj), obj.print(''); end

--- a/tests/expected/matlab/+gtsam/PinholeCameraCal3Bundler.m
+++ b/tests/expected/matlab/+gtsam/PinholeCameraCal3Bundler.m
@@ -9,7 +9,7 @@ classdef PinholeCameraCal3Bundler < handle
     function obj = PinholeCameraCal3Bundler(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        special_cases_wrapper(5, my_ptr);
+        special_cases_wrapper(7, my_ptr);
       else
         error('Arguments do not match any overload of gtsam.PinholeCameraCal3Bundler constructor');
       end
@@ -17,7 +17,7 @@ classdef PinholeCameraCal3Bundler < handle
     end
 
     function delete(obj)
-      special_cases_wrapper(6, obj.ptr_gtsamPinholeCameraCal3Bundler);
+      special_cases_wrapper(8, obj.ptr_gtsamPinholeCameraCal3Bundler);
     end
 
     function display(obj), obj.print(''); end

--- a/tests/expected/matlab/+gtsam/SfmTrack.m
+++ b/tests/expected/matlab/+gtsam/SfmTrack.m
@@ -1,6 +1,9 @@
 %class SfmTrack, see Doxygen page for details
 %at https://gtsam.org/doxygen/
 %
+%-------Properties-------
+%measurements
+%
 classdef SfmTrack < handle
   properties
     ptr_gtsamSfmTrack = 0

--- a/tests/expected/matlab/+gtsam/SfmTrack.m
+++ b/tests/expected/matlab/+gtsam/SfmTrack.m
@@ -7,6 +7,7 @@
 classdef SfmTrack < handle
   properties
     ptr_gtsamSfmTrack = 0
+    measurements
   end
   methods
     function obj = SfmTrack(varargin)
@@ -27,6 +28,16 @@ classdef SfmTrack < handle
     %DISPLAY Calls print on the object
     function disp(obj), obj.display; end
     %DISP Calls print on the object
+
+    function varargout = get.measurements(this)
+        varargout{1} = special_cases_wrapper(5, this);
+        this.measurements = varargout{1};
+    end
+
+    function set.measurements(this, value)
+        obj.measurements = value;
+        special_cases_wrapper(6, this, value);
+    end
   end
 
   methods(Static = true)

--- a/tests/expected/matlab/+ns1/aGlobalFunction.m
+++ b/tests/expected/matlab/+ns1/aGlobalFunction.m
@@ -4,3 +4,4 @@ function varargout = aGlobalFunction(varargin)
       else
         error('Arguments do not match any overload of function aGlobalFunction');
       end
+end

--- a/tests/expected/matlab/+ns2/aGlobalFunction.m
+++ b/tests/expected/matlab/+ns2/aGlobalFunction.m
@@ -4,3 +4,4 @@ function varargout = aGlobalFunction(varargin)
       else
         error('Arguments do not match any overload of function aGlobalFunction');
       end
+end

--- a/tests/expected/matlab/+ns2/overloadedGlobalFunction.m
+++ b/tests/expected/matlab/+ns2/overloadedGlobalFunction.m
@@ -6,3 +6,4 @@ function varargout = overloadedGlobalFunction(varargin)
       else
         error('Arguments do not match any overload of function overloadedGlobalFunction');
       end
+end

--- a/tests/expected/matlab/DefaultFuncInt.m
+++ b/tests/expected/matlab/DefaultFuncInt.m
@@ -8,3 +8,4 @@ function varargout = DefaultFuncInt(varargin)
       else
         error('Arguments do not match any overload of function DefaultFuncInt');
       end
+end

--- a/tests/expected/matlab/DefaultFuncObj.m
+++ b/tests/expected/matlab/DefaultFuncObj.m
@@ -6,3 +6,4 @@ function varargout = DefaultFuncObj(varargin)
       else
         error('Arguments do not match any overload of function DefaultFuncObj');
       end
+end

--- a/tests/expected/matlab/DefaultFuncString.m
+++ b/tests/expected/matlab/DefaultFuncString.m
@@ -8,3 +8,4 @@ function varargout = DefaultFuncString(varargin)
       else
         error('Arguments do not match any overload of function DefaultFuncString');
       end
+end

--- a/tests/expected/matlab/DefaultFuncVector.m
+++ b/tests/expected/matlab/DefaultFuncVector.m
@@ -8,3 +8,4 @@ function varargout = DefaultFuncVector(varargin)
       else
         error('Arguments do not match any overload of function DefaultFuncVector');
       end
+end

--- a/tests/expected/matlab/DefaultFuncZero.m
+++ b/tests/expected/matlab/DefaultFuncZero.m
@@ -10,3 +10,4 @@ function varargout = DefaultFuncZero(varargin)
       else
         error('Arguments do not match any overload of function DefaultFuncZero');
       end
+end

--- a/tests/expected/matlab/ForwardKinematics.m
+++ b/tests/expected/matlab/ForwardKinematics.m
@@ -12,11 +12,11 @@ classdef ForwardKinematics < handle
     function obj = ForwardKinematics(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(57, my_ptr);
+        class_wrapper(59, my_ptr);
       elseif nargin == 5 && isa(varargin{1},'gtdynamics.Robot') && isa(varargin{2},'char') && isa(varargin{3},'char') && isa(varargin{4},'gtsam.Values') && isa(varargin{5},'gtsam.Pose3')
-        my_ptr = class_wrapper(58, varargin{1}, varargin{2}, varargin{3}, varargin{4}, varargin{5});
+        my_ptr = class_wrapper(60, varargin{1}, varargin{2}, varargin{3}, varargin{4}, varargin{5});
       elseif nargin == 4 && isa(varargin{1},'gtdynamics.Robot') && isa(varargin{2},'char') && isa(varargin{3},'char') && isa(varargin{4},'gtsam.Values')
-        my_ptr = class_wrapper(59, varargin{1}, varargin{2}, varargin{3}, varargin{4});
+        my_ptr = class_wrapper(61, varargin{1}, varargin{2}, varargin{3}, varargin{4});
       else
         error('Arguments do not match any overload of ForwardKinematics constructor');
       end
@@ -24,7 +24,7 @@ classdef ForwardKinematics < handle
     end
 
     function delete(obj)
-      class_wrapper(60, obj.ptr_ForwardKinematics);
+      class_wrapper(62, obj.ptr_ForwardKinematics);
     end
 
     function display(obj), obj.print(''); end

--- a/tests/expected/matlab/MultiTemplatedFunctionDoubleSize_tDouble.m
+++ b/tests/expected/matlab/MultiTemplatedFunctionDoubleSize_tDouble.m
@@ -4,3 +4,4 @@ function varargout = MultiTemplatedFunctionDoubleSize_tDouble(varargin)
       else
         error('Arguments do not match any overload of function MultiTemplatedFunctionDoubleSize_tDouble');
       end
+end

--- a/tests/expected/matlab/MultiTemplatedFunctionStringSize_tDouble.m
+++ b/tests/expected/matlab/MultiTemplatedFunctionStringSize_tDouble.m
@@ -4,3 +4,4 @@ function varargout = MultiTemplatedFunctionStringSize_tDouble(varargin)
       else
         error('Arguments do not match any overload of function MultiTemplatedFunctionStringSize_tDouble');
       end
+end

--- a/tests/expected/matlab/MultipleTemplatesIntDouble.m
+++ b/tests/expected/matlab/MultipleTemplatesIntDouble.m
@@ -9,7 +9,7 @@ classdef MultipleTemplatesIntDouble < handle
     function obj = MultipleTemplatesIntDouble(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(53, my_ptr);
+        class_wrapper(55, my_ptr);
       else
         error('Arguments do not match any overload of MultipleTemplatesIntDouble constructor');
       end
@@ -17,7 +17,7 @@ classdef MultipleTemplatesIntDouble < handle
     end
 
     function delete(obj)
-      class_wrapper(54, obj.ptr_MultipleTemplatesIntDouble);
+      class_wrapper(56, obj.ptr_MultipleTemplatesIntDouble);
     end
 
     function display(obj), obj.print(''); end

--- a/tests/expected/matlab/MultipleTemplatesIntFloat.m
+++ b/tests/expected/matlab/MultipleTemplatesIntFloat.m
@@ -9,7 +9,7 @@ classdef MultipleTemplatesIntFloat < handle
     function obj = MultipleTemplatesIntFloat(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(55, my_ptr);
+        class_wrapper(57, my_ptr);
       else
         error('Arguments do not match any overload of MultipleTemplatesIntFloat constructor');
       end
@@ -17,7 +17,7 @@ classdef MultipleTemplatesIntFloat < handle
     end
 
     function delete(obj)
-      class_wrapper(56, obj.ptr_MultipleTemplatesIntFloat);
+      class_wrapper(58, obj.ptr_MultipleTemplatesIntFloat);
     end
 
     function display(obj), obj.print(''); end

--- a/tests/expected/matlab/MyFactorPosePoint2.m
+++ b/tests/expected/matlab/MyFactorPosePoint2.m
@@ -15,9 +15,9 @@ classdef MyFactorPosePoint2 < handle
     function obj = MyFactorPosePoint2(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(67, my_ptr);
+        class_wrapper(69, my_ptr);
       elseif nargin == 4 && isa(varargin{1},'numeric') && isa(varargin{2},'numeric') && isa(varargin{3},'double') && isa(varargin{4},'gtsam.noiseModel.Base')
-        my_ptr = class_wrapper(68, varargin{1}, varargin{2}, varargin{3}, varargin{4});
+        my_ptr = class_wrapper(70, varargin{1}, varargin{2}, varargin{3}, varargin{4});
       else
         error('Arguments do not match any overload of MyFactorPosePoint2 constructor');
       end
@@ -25,7 +25,7 @@ classdef MyFactorPosePoint2 < handle
     end
 
     function delete(obj)
-      class_wrapper(69, obj.ptr_MyFactorPosePoint2);
+      class_wrapper(71, obj.ptr_MyFactorPosePoint2);
     end
 
     function display(obj), obj.print(''); end
@@ -36,19 +36,19 @@ classdef MyFactorPosePoint2 < handle
       % PRINT usage: print(string s, KeyFormatter keyFormatter) : returns void
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 2 && isa(varargin{1},'char') && isa(varargin{2},'gtsam.KeyFormatter')
-        class_wrapper(70, this, varargin{:});
+        class_wrapper(72, this, varargin{:});
         return
       end
       % PRINT usage: print(string s) : returns void
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'char')
-        class_wrapper(71, this, varargin{:});
+        class_wrapper(73, this, varargin{:});
         return
       end
       % PRINT usage: print() : returns void
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 0
-        class_wrapper(72, this, varargin{:});
+        class_wrapper(74, this, varargin{:});
         return
       end
       error('Arguments do not match any overload of function MyFactorPosePoint2.print');

--- a/tests/expected/matlab/MyVector12.m
+++ b/tests/expected/matlab/MyVector12.m
@@ -12,9 +12,9 @@ classdef MyVector12 < handle
     function obj = MyVector12(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(50, my_ptr);
+        class_wrapper(52, my_ptr);
       elseif nargin == 0
-        my_ptr = class_wrapper(51);
+        my_ptr = class_wrapper(53);
       else
         error('Arguments do not match any overload of MyVector12 constructor');
       end
@@ -22,7 +22,7 @@ classdef MyVector12 < handle
     end
 
     function delete(obj)
-      class_wrapper(52, obj.ptr_MyVector12);
+      class_wrapper(54, obj.ptr_MyVector12);
     end
 
     function display(obj), obj.print(''); end

--- a/tests/expected/matlab/MyVector3.m
+++ b/tests/expected/matlab/MyVector3.m
@@ -12,9 +12,9 @@ classdef MyVector3 < handle
     function obj = MyVector3(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(47, my_ptr);
+        class_wrapper(49, my_ptr);
       elseif nargin == 0
-        my_ptr = class_wrapper(48);
+        my_ptr = class_wrapper(50);
       else
         error('Arguments do not match any overload of MyVector3 constructor');
       end
@@ -22,7 +22,7 @@ classdef MyVector3 < handle
     end
 
     function delete(obj)
-      class_wrapper(49, obj.ptr_MyVector3);
+      class_wrapper(51, obj.ptr_MyVector3);
     end
 
     function display(obj), obj.print(''); end

--- a/tests/expected/matlab/PrimitiveRefDouble.m
+++ b/tests/expected/matlab/PrimitiveRefDouble.m
@@ -19,9 +19,9 @@ classdef PrimitiveRefDouble < handle
     function obj = PrimitiveRefDouble(varargin)
       if nargin == 2 && isa(varargin{1}, 'uint64') && varargin{1} == uint64(5139824614673773682)
         my_ptr = varargin{2};
-        class_wrapper(43, my_ptr);
+        class_wrapper(45, my_ptr);
       elseif nargin == 0
-        my_ptr = class_wrapper(44);
+        my_ptr = class_wrapper(46);
       else
         error('Arguments do not match any overload of PrimitiveRefDouble constructor');
       end
@@ -29,7 +29,7 @@ classdef PrimitiveRefDouble < handle
     end
 
     function delete(obj)
-      class_wrapper(45, obj.ptr_PrimitiveRefDouble);
+      class_wrapper(47, obj.ptr_PrimitiveRefDouble);
     end
 
     function display(obj), obj.print(''); end
@@ -43,7 +43,7 @@ classdef PrimitiveRefDouble < handle
       % BRUTAL usage: Brutal(double t) : returns PrimitiveRefdouble
       % Doxygen can be found at https://gtsam.org/doxygen/
       if length(varargin) == 1 && isa(varargin{1},'double')
-        varargout{1} = class_wrapper(46, varargin{:});
+        varargout{1} = class_wrapper(48, varargin{:});
         return
       end
 

--- a/tests/expected/matlab/TemplatedFunctionRot3.m
+++ b/tests/expected/matlab/TemplatedFunctionRot3.m
@@ -4,3 +4,4 @@ function varargout = TemplatedFunctionRot3(varargin)
       else
         error('Arguments do not match any overload of function TemplatedFunctionRot3');
       end
+end

--- a/tests/expected/matlab/Test.m
+++ b/tests/expected/matlab/Test.m
@@ -39,6 +39,7 @@
 classdef Test < handle
   properties
     ptr_Test = 0
+    model_ptr
   end
   methods
     function obj = Test(varargin)
@@ -317,6 +318,16 @@ classdef Test < handle
       error('Arguments do not match any overload of function Test.set_container');
     end
 
+
+    function varargout = get.model_ptr(this)
+        varargout{1} = class_wrapper(43, this);
+        this.model_ptr = varargout{1};
+    end
+
+    function set.model_ptr(this, value)
+        obj.model_ptr = value;
+        class_wrapper(44, this, value);
+    end
   end
 
   methods(Static = true)

--- a/tests/expected/matlab/Test.m
+++ b/tests/expected/matlab/Test.m
@@ -5,6 +5,9 @@
 %Test()
 %Test(double a, Matrix b)
 %
+%-------Properties-------
+%model_ptr
+%
 %-------Methods-------
 %arg_EigenConstRef(Matrix value) : returns void
 %create_MixedPtrs() : returns pair< Test, Test >

--- a/tests/expected/matlab/aGlobalFunction.m
+++ b/tests/expected/matlab/aGlobalFunction.m
@@ -4,3 +4,4 @@ function varargout = aGlobalFunction(varargin)
       else
         error('Arguments do not match any overload of function aGlobalFunction');
       end
+end

--- a/tests/expected/matlab/class_wrapper.cpp
+++ b/tests/expected/matlab/class_wrapper.cpp
@@ -533,10 +533,17 @@ void Test_set_container_42(int nargout, mxArray *out[], int nargin, const mxArra
 
 void Test_get_model_ptr_43(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
+  checkArguments("model_ptr",nargout,nargin-1,0);
+  auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
+  out[0] = wrap_shared_ptr(obj->model_ptr,"gtsam.noiseModel.Base", false);
 }
 
 void Test_set_model_ptr_44(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
+  checkArguments("model_ptr",nargout,nargin-1,1);
+  auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
+  boost::shared_ptr<gtsam::noiseModel::Base> model_ptr = unwrap_shared_ptr< gtsam::noiseModel::Base >(in[1], "ptr_gtsamnoiseModelBase");
+  obj->model_ptr = *model_ptr;
 }
 
 void PrimitiveRefDouble_collectorInsertAndMakeBase_45(int nargout, mxArray *out[], int nargin, const mxArray *in[])

--- a/tests/expected/matlab/class_wrapper.cpp
+++ b/tests/expected/matlab/class_wrapper.cpp
@@ -531,7 +531,15 @@ void Test_set_container_42(int nargout, mxArray *out[], int nargin, const mxArra
   obj->set_container(*container);
 }
 
-void PrimitiveRefDouble_collectorInsertAndMakeBase_43(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void Test_get_model_ptr_43(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+}
+
+void Test_set_model_ptr_44(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+}
+
+void PrimitiveRefDouble_collectorInsertAndMakeBase_45(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<PrimitiveRef<double>> Shared;
@@ -540,7 +548,7 @@ void PrimitiveRefDouble_collectorInsertAndMakeBase_43(int nargout, mxArray *out[
   collector_PrimitiveRefDouble.insert(self);
 }
 
-void PrimitiveRefDouble_constructor_44(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void PrimitiveRefDouble_constructor_46(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<PrimitiveRef<double>> Shared;
@@ -551,7 +559,7 @@ void PrimitiveRefDouble_constructor_44(int nargout, mxArray *out[], int nargin, 
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void PrimitiveRefDouble_deconstructor_45(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void PrimitiveRefDouble_deconstructor_47(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<PrimitiveRef<double>> Shared;
   checkArguments("delete_PrimitiveRefDouble",nargout,nargin,1);
@@ -564,14 +572,14 @@ void PrimitiveRefDouble_deconstructor_45(int nargout, mxArray *out[], int nargin
   delete self;
 }
 
-void PrimitiveRefDouble_Brutal_46(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void PrimitiveRefDouble_Brutal_48(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("PrimitiveRef<double>.Brutal",nargout,nargin,1);
   double t = unwrap< double >(in[0]);
   out[0] = wrap_shared_ptr(boost::make_shared<PrimitiveRef<double>>(PrimitiveRef<double>::Brutal(t)),"PrimitiveRefdouble", false);
 }
 
-void MyVector3_collectorInsertAndMakeBase_47(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyVector3_collectorInsertAndMakeBase_49(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MyVector<3>> Shared;
@@ -580,7 +588,7 @@ void MyVector3_collectorInsertAndMakeBase_47(int nargout, mxArray *out[], int na
   collector_MyVector3.insert(self);
 }
 
-void MyVector3_constructor_48(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyVector3_constructor_50(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MyVector<3>> Shared;
@@ -591,7 +599,7 @@ void MyVector3_constructor_48(int nargout, mxArray *out[], int nargin, const mxA
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void MyVector3_deconstructor_49(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyVector3_deconstructor_51(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<MyVector<3>> Shared;
   checkArguments("delete_MyVector3",nargout,nargin,1);
@@ -604,7 +612,7 @@ void MyVector3_deconstructor_49(int nargout, mxArray *out[], int nargin, const m
   delete self;
 }
 
-void MyVector12_collectorInsertAndMakeBase_50(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyVector12_collectorInsertAndMakeBase_52(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MyVector<12>> Shared;
@@ -613,7 +621,7 @@ void MyVector12_collectorInsertAndMakeBase_50(int nargout, mxArray *out[], int n
   collector_MyVector12.insert(self);
 }
 
-void MyVector12_constructor_51(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyVector12_constructor_53(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MyVector<12>> Shared;
@@ -624,7 +632,7 @@ void MyVector12_constructor_51(int nargout, mxArray *out[], int nargin, const mx
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void MyVector12_deconstructor_52(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyVector12_deconstructor_54(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<MyVector<12>> Shared;
   checkArguments("delete_MyVector12",nargout,nargin,1);
@@ -637,7 +645,7 @@ void MyVector12_deconstructor_52(int nargout, mxArray *out[], int nargin, const 
   delete self;
 }
 
-void MultipleTemplatesIntDouble_collectorInsertAndMakeBase_53(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MultipleTemplatesIntDouble_collectorInsertAndMakeBase_55(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MultipleTemplates<int, double>> Shared;
@@ -646,7 +654,7 @@ void MultipleTemplatesIntDouble_collectorInsertAndMakeBase_53(int nargout, mxArr
   collector_MultipleTemplatesIntDouble.insert(self);
 }
 
-void MultipleTemplatesIntDouble_deconstructor_54(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MultipleTemplatesIntDouble_deconstructor_56(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<MultipleTemplates<int, double>> Shared;
   checkArguments("delete_MultipleTemplatesIntDouble",nargout,nargin,1);
@@ -659,7 +667,7 @@ void MultipleTemplatesIntDouble_deconstructor_54(int nargout, mxArray *out[], in
   delete self;
 }
 
-void MultipleTemplatesIntFloat_collectorInsertAndMakeBase_55(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MultipleTemplatesIntFloat_collectorInsertAndMakeBase_57(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MultipleTemplates<int, float>> Shared;
@@ -668,7 +676,7 @@ void MultipleTemplatesIntFloat_collectorInsertAndMakeBase_55(int nargout, mxArra
   collector_MultipleTemplatesIntFloat.insert(self);
 }
 
-void MultipleTemplatesIntFloat_deconstructor_56(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MultipleTemplatesIntFloat_deconstructor_58(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<MultipleTemplates<int, float>> Shared;
   checkArguments("delete_MultipleTemplatesIntFloat",nargout,nargin,1);
@@ -681,7 +689,7 @@ void MultipleTemplatesIntFloat_deconstructor_56(int nargout, mxArray *out[], int
   delete self;
 }
 
-void ForwardKinematics_collectorInsertAndMakeBase_57(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void ForwardKinematics_collectorInsertAndMakeBase_59(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<ForwardKinematics> Shared;
@@ -690,7 +698,7 @@ void ForwardKinematics_collectorInsertAndMakeBase_57(int nargout, mxArray *out[]
   collector_ForwardKinematics.insert(self);
 }
 
-void ForwardKinematics_constructor_58(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void ForwardKinematics_constructor_60(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<ForwardKinematics> Shared;
@@ -706,7 +714,7 @@ void ForwardKinematics_constructor_58(int nargout, mxArray *out[], int nargin, c
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void ForwardKinematics_constructor_59(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void ForwardKinematics_constructor_61(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<ForwardKinematics> Shared;
@@ -721,7 +729,7 @@ void ForwardKinematics_constructor_59(int nargout, mxArray *out[], int nargin, c
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void ForwardKinematics_deconstructor_60(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void ForwardKinematics_deconstructor_62(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<ForwardKinematics> Shared;
   checkArguments("delete_ForwardKinematics",nargout,nargin,1);
@@ -734,7 +742,7 @@ void ForwardKinematics_deconstructor_60(int nargout, mxArray *out[], int nargin,
   delete self;
 }
 
-void TemplatedConstructor_collectorInsertAndMakeBase_61(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void TemplatedConstructor_collectorInsertAndMakeBase_63(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<TemplatedConstructor> Shared;
@@ -743,7 +751,7 @@ void TemplatedConstructor_collectorInsertAndMakeBase_61(int nargout, mxArray *ou
   collector_TemplatedConstructor.insert(self);
 }
 
-void TemplatedConstructor_constructor_62(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void TemplatedConstructor_constructor_64(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<TemplatedConstructor> Shared;
@@ -754,7 +762,7 @@ void TemplatedConstructor_constructor_62(int nargout, mxArray *out[], int nargin
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void TemplatedConstructor_constructor_63(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void TemplatedConstructor_constructor_65(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<TemplatedConstructor> Shared;
@@ -766,7 +774,7 @@ void TemplatedConstructor_constructor_63(int nargout, mxArray *out[], int nargin
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void TemplatedConstructor_constructor_64(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void TemplatedConstructor_constructor_66(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<TemplatedConstructor> Shared;
@@ -778,7 +786,7 @@ void TemplatedConstructor_constructor_64(int nargout, mxArray *out[], int nargin
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void TemplatedConstructor_constructor_65(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void TemplatedConstructor_constructor_67(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<TemplatedConstructor> Shared;
@@ -790,7 +798,7 @@ void TemplatedConstructor_constructor_65(int nargout, mxArray *out[], int nargin
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void TemplatedConstructor_deconstructor_66(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void TemplatedConstructor_deconstructor_68(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<TemplatedConstructor> Shared;
   checkArguments("delete_TemplatedConstructor",nargout,nargin,1);
@@ -803,7 +811,7 @@ void TemplatedConstructor_deconstructor_66(int nargout, mxArray *out[], int narg
   delete self;
 }
 
-void MyFactorPosePoint2_collectorInsertAndMakeBase_67(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyFactorPosePoint2_collectorInsertAndMakeBase_69(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>> Shared;
@@ -812,7 +820,7 @@ void MyFactorPosePoint2_collectorInsertAndMakeBase_67(int nargout, mxArray *out[
   collector_MyFactorPosePoint2.insert(self);
 }
 
-void MyFactorPosePoint2_constructor_68(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyFactorPosePoint2_constructor_70(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>> Shared;
@@ -827,7 +835,7 @@ void MyFactorPosePoint2_constructor_68(int nargout, mxArray *out[], int nargin, 
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 }
 
-void MyFactorPosePoint2_deconstructor_69(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyFactorPosePoint2_deconstructor_71(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>> Shared;
   checkArguments("delete_MyFactorPosePoint2",nargout,nargin,1);
@@ -840,7 +848,7 @@ void MyFactorPosePoint2_deconstructor_69(int nargout, mxArray *out[], int nargin
   delete self;
 }
 
-void MyFactorPosePoint2_print_70(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyFactorPosePoint2_print_72(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("print",nargout,nargin-1,2);
   auto obj = unwrap_shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>>(in[0], "ptr_MyFactorPosePoint2");
@@ -849,7 +857,7 @@ void MyFactorPosePoint2_print_70(int nargout, mxArray *out[], int nargin, const 
   obj->print(s,keyFormatter);
 }
 
-void MyFactorPosePoint2_print_71(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyFactorPosePoint2_print_73(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("print",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>>(in[0], "ptr_MyFactorPosePoint2");
@@ -857,7 +865,7 @@ void MyFactorPosePoint2_print_71(int nargout, mxArray *out[], int nargin, const 
   obj->print(s,gtsam::DefaultKeyFormatter);
 }
 
-void MyFactorPosePoint2_print_72(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void MyFactorPosePoint2_print_74(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("print",nargout,nargin-1,0);
   auto obj = unwrap_shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>>(in[0], "ptr_MyFactorPosePoint2");
@@ -1006,67 +1014,67 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       Test_set_container_42(nargout, out, nargin-1, in+1);
       break;
     case 43:
-      PrimitiveRefDouble_collectorInsertAndMakeBase_43(nargout, out, nargin-1, in+1);
+      Test_get_model_ptr_43(nargout, out, nargin-1, in+1);
       break;
     case 44:
-      PrimitiveRefDouble_constructor_44(nargout, out, nargin-1, in+1);
+      Test_set_model_ptr_44(nargout, out, nargin-1, in+1);
       break;
     case 45:
-      PrimitiveRefDouble_deconstructor_45(nargout, out, nargin-1, in+1);
+      PrimitiveRefDouble_collectorInsertAndMakeBase_45(nargout, out, nargin-1, in+1);
       break;
     case 46:
-      PrimitiveRefDouble_Brutal_46(nargout, out, nargin-1, in+1);
+      PrimitiveRefDouble_constructor_46(nargout, out, nargin-1, in+1);
       break;
     case 47:
-      MyVector3_collectorInsertAndMakeBase_47(nargout, out, nargin-1, in+1);
+      PrimitiveRefDouble_deconstructor_47(nargout, out, nargin-1, in+1);
       break;
     case 48:
-      MyVector3_constructor_48(nargout, out, nargin-1, in+1);
+      PrimitiveRefDouble_Brutal_48(nargout, out, nargin-1, in+1);
       break;
     case 49:
-      MyVector3_deconstructor_49(nargout, out, nargin-1, in+1);
+      MyVector3_collectorInsertAndMakeBase_49(nargout, out, nargin-1, in+1);
       break;
     case 50:
-      MyVector12_collectorInsertAndMakeBase_50(nargout, out, nargin-1, in+1);
+      MyVector3_constructor_50(nargout, out, nargin-1, in+1);
       break;
     case 51:
-      MyVector12_constructor_51(nargout, out, nargin-1, in+1);
+      MyVector3_deconstructor_51(nargout, out, nargin-1, in+1);
       break;
     case 52:
-      MyVector12_deconstructor_52(nargout, out, nargin-1, in+1);
+      MyVector12_collectorInsertAndMakeBase_52(nargout, out, nargin-1, in+1);
       break;
     case 53:
-      MultipleTemplatesIntDouble_collectorInsertAndMakeBase_53(nargout, out, nargin-1, in+1);
+      MyVector12_constructor_53(nargout, out, nargin-1, in+1);
       break;
     case 54:
-      MultipleTemplatesIntDouble_deconstructor_54(nargout, out, nargin-1, in+1);
+      MyVector12_deconstructor_54(nargout, out, nargin-1, in+1);
       break;
     case 55:
-      MultipleTemplatesIntFloat_collectorInsertAndMakeBase_55(nargout, out, nargin-1, in+1);
+      MultipleTemplatesIntDouble_collectorInsertAndMakeBase_55(nargout, out, nargin-1, in+1);
       break;
     case 56:
-      MultipleTemplatesIntFloat_deconstructor_56(nargout, out, nargin-1, in+1);
+      MultipleTemplatesIntDouble_deconstructor_56(nargout, out, nargin-1, in+1);
       break;
     case 57:
-      ForwardKinematics_collectorInsertAndMakeBase_57(nargout, out, nargin-1, in+1);
+      MultipleTemplatesIntFloat_collectorInsertAndMakeBase_57(nargout, out, nargin-1, in+1);
       break;
     case 58:
-      ForwardKinematics_constructor_58(nargout, out, nargin-1, in+1);
+      MultipleTemplatesIntFloat_deconstructor_58(nargout, out, nargin-1, in+1);
       break;
     case 59:
-      ForwardKinematics_constructor_59(nargout, out, nargin-1, in+1);
+      ForwardKinematics_collectorInsertAndMakeBase_59(nargout, out, nargin-1, in+1);
       break;
     case 60:
-      ForwardKinematics_deconstructor_60(nargout, out, nargin-1, in+1);
+      ForwardKinematics_constructor_60(nargout, out, nargin-1, in+1);
       break;
     case 61:
-      TemplatedConstructor_collectorInsertAndMakeBase_61(nargout, out, nargin-1, in+1);
+      ForwardKinematics_constructor_61(nargout, out, nargin-1, in+1);
       break;
     case 62:
-      TemplatedConstructor_constructor_62(nargout, out, nargin-1, in+1);
+      ForwardKinematics_deconstructor_62(nargout, out, nargin-1, in+1);
       break;
     case 63:
-      TemplatedConstructor_constructor_63(nargout, out, nargin-1, in+1);
+      TemplatedConstructor_collectorInsertAndMakeBase_63(nargout, out, nargin-1, in+1);
       break;
     case 64:
       TemplatedConstructor_constructor_64(nargout, out, nargin-1, in+1);
@@ -1075,25 +1083,31 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       TemplatedConstructor_constructor_65(nargout, out, nargin-1, in+1);
       break;
     case 66:
-      TemplatedConstructor_deconstructor_66(nargout, out, nargin-1, in+1);
+      TemplatedConstructor_constructor_66(nargout, out, nargin-1, in+1);
       break;
     case 67:
-      MyFactorPosePoint2_collectorInsertAndMakeBase_67(nargout, out, nargin-1, in+1);
+      TemplatedConstructor_constructor_67(nargout, out, nargin-1, in+1);
       break;
     case 68:
-      MyFactorPosePoint2_constructor_68(nargout, out, nargin-1, in+1);
+      TemplatedConstructor_deconstructor_68(nargout, out, nargin-1, in+1);
       break;
     case 69:
-      MyFactorPosePoint2_deconstructor_69(nargout, out, nargin-1, in+1);
+      MyFactorPosePoint2_collectorInsertAndMakeBase_69(nargout, out, nargin-1, in+1);
       break;
     case 70:
-      MyFactorPosePoint2_print_70(nargout, out, nargin-1, in+1);
+      MyFactorPosePoint2_constructor_70(nargout, out, nargin-1, in+1);
       break;
     case 71:
-      MyFactorPosePoint2_print_71(nargout, out, nargin-1, in+1);
+      MyFactorPosePoint2_deconstructor_71(nargout, out, nargin-1, in+1);
       break;
     case 72:
       MyFactorPosePoint2_print_72(nargout, out, nargin-1, in+1);
+      break;
+    case 73:
+      MyFactorPosePoint2_print_73(nargout, out, nargin-1, in+1);
+      break;
+    case 74:
+      MyFactorPosePoint2_print_74(nargout, out, nargin-1, in+1);
       break;
     }
   } catch(const std::exception& e) {

--- a/tests/expected/matlab/load2D.m
+++ b/tests/expected/matlab/load2D.m
@@ -8,3 +8,4 @@ function varargout = load2D(varargin)
       else
         error('Arguments do not match any overload of function load2D');
       end
+end

--- a/tests/expected/matlab/overloadedGlobalFunction.m
+++ b/tests/expected/matlab/overloadedGlobalFunction.m
@@ -6,3 +6,4 @@ function varargout = overloadedGlobalFunction(varargin)
       else
         error('Arguments do not match any overload of function overloadedGlobalFunction');
       end
+end

--- a/tests/expected/matlab/setPose.m
+++ b/tests/expected/matlab/setPose.m
@@ -6,3 +6,4 @@ function varargout = setPose(varargin)
       else
         error('Arguments do not match any overload of function setPose');
       end
+end

--- a/tests/expected/matlab/special_cases_wrapper.cpp
+++ b/tests/expected/matlab/special_cases_wrapper.cpp
@@ -147,10 +147,17 @@ void gtsamSfmTrack_deconstructor_4(int nargout, mxArray *out[], int nargin, cons
 
 void gtsamSfmTrack_get_measurements_5(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
+  checkArguments("measurements",nargout,nargin-1,0);
+  auto obj = unwrap_shared_ptr<gtsam::SfmTrack>(in[0], "ptr_gtsamSfmTrack");
+  out[0] = wrap_shared_ptr(boost::make_shared<std::vector<std::pair<size_t,Point2>>>(obj->measurements),"std.vectorpairsize_tPoint2", false);
 }
 
 void gtsamSfmTrack_set_measurements_6(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
+  checkArguments("measurements",nargout,nargin-1,1);
+  auto obj = unwrap_shared_ptr<gtsam::SfmTrack>(in[0], "ptr_gtsamSfmTrack");
+  boost::shared_ptr<std::vector<std::pair<size_t,Point2>>> measurements = unwrap_shared_ptr< std::vector<std::pair<size_t,Point2>> >(in[1], "ptr_stdvectorpairsize_tPoint2");
+  obj->measurements = *measurements;
 }
 
 void gtsamPinholeCameraCal3Bundler_collectorInsertAndMakeBase_7(int nargout, mxArray *out[], int nargin, const mxArray *in[])

--- a/tests/expected/matlab/special_cases_wrapper.cpp
+++ b/tests/expected/matlab/special_cases_wrapper.cpp
@@ -145,7 +145,15 @@ void gtsamSfmTrack_deconstructor_4(int nargout, mxArray *out[], int nargin, cons
   delete self;
 }
 
-void gtsamPinholeCameraCal3Bundler_collectorInsertAndMakeBase_5(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void gtsamSfmTrack_get_measurements_5(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+}
+
+void gtsamSfmTrack_set_measurements_6(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+}
+
+void gtsamPinholeCameraCal3Bundler_collectorInsertAndMakeBase_7(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<gtsam::PinholeCamera<gtsam::Cal3Bundler>> Shared;
@@ -154,7 +162,7 @@ void gtsamPinholeCameraCal3Bundler_collectorInsertAndMakeBase_5(int nargout, mxA
   collector_gtsamPinholeCameraCal3Bundler.insert(self);
 }
 
-void gtsamPinholeCameraCal3Bundler_deconstructor_6(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void gtsamPinholeCameraCal3Bundler_deconstructor_8(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<gtsam::PinholeCamera<gtsam::Cal3Bundler>> Shared;
   checkArguments("delete_gtsamPinholeCameraCal3Bundler",nargout,nargin,1);
@@ -167,7 +175,7 @@ void gtsamPinholeCameraCal3Bundler_deconstructor_6(int nargout, mxArray *out[], 
   delete self;
 }
 
-void gtsamGeneralSFMFactorCal3Bundler_collectorInsertAndMakeBase_7(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void gtsamGeneralSFMFactorCal3Bundler_collectorInsertAndMakeBase_9(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
   typedef boost::shared_ptr<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>> Shared;
@@ -176,7 +184,7 @@ void gtsamGeneralSFMFactorCal3Bundler_collectorInsertAndMakeBase_7(int nargout, 
   collector_gtsamGeneralSFMFactorCal3Bundler.insert(self);
 }
 
-void gtsamGeneralSFMFactorCal3Bundler_deconstructor_8(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void gtsamGeneralSFMFactorCal3Bundler_deconstructor_10(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   typedef boost::shared_ptr<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>> Shared;
   checkArguments("delete_gtsamGeneralSFMFactorCal3Bundler",nargout,nargin,1);
@@ -217,16 +225,22 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       gtsamSfmTrack_deconstructor_4(nargout, out, nargin-1, in+1);
       break;
     case 5:
-      gtsamPinholeCameraCal3Bundler_collectorInsertAndMakeBase_5(nargout, out, nargin-1, in+1);
+      gtsamSfmTrack_get_measurements_5(nargout, out, nargin-1, in+1);
       break;
     case 6:
-      gtsamPinholeCameraCal3Bundler_deconstructor_6(nargout, out, nargin-1, in+1);
+      gtsamSfmTrack_set_measurements_6(nargout, out, nargin-1, in+1);
       break;
     case 7:
-      gtsamGeneralSFMFactorCal3Bundler_collectorInsertAndMakeBase_7(nargout, out, nargin-1, in+1);
+      gtsamPinholeCameraCal3Bundler_collectorInsertAndMakeBase_7(nargout, out, nargin-1, in+1);
       break;
     case 8:
-      gtsamGeneralSFMFactorCal3Bundler_deconstructor_8(nargout, out, nargin-1, in+1);
+      gtsamPinholeCameraCal3Bundler_deconstructor_8(nargout, out, nargin-1, in+1);
+      break;
+    case 9:
+      gtsamGeneralSFMFactorCal3Bundler_collectorInsertAndMakeBase_9(nargout, out, nargin-1, in+1);
+      break;
+    case 10:
+      gtsamGeneralSFMFactorCal3Bundler_deconstructor_10(nargout, out, nargin-1, in+1);
       break;
     }
   } catch(const std::exception& e) {


### PR DESCRIPTION
This PR adds
1. Support for accessing properties in Matlab similar to Python.
2. Some code refactor to reduce duplication.
3. Fixed a bug where global functions where not getting the `end` block correctly written.
4. Relevant unit tests.