### PR TITLE
Remove Boost

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -15,8 +15,8 @@ The python wrapper supports keyword arguments for functions/methods. Hence, the 
     - Eigen types: `Matrix`, `Vector`.
     - C/C++ basic types: `string`, `bool`, `size_t`, `int`, `double`, `char`, `unsigned char`.
     - `void`
-    - Any class with which be copied with `boost::make_shared()`.
-    - `boost::shared_ptr` of any object type.
+    - Any class with which be copied with `std::make_shared()`.
+    - `std::shared_ptr` of any object type.
 
 - Constructors
     - Overloads are supported, but arguments of different types *have* to have different names.
@@ -37,8 +37,8 @@ The python wrapper supports keyword arguments for functions/methods. Hence, the 
     - Eigen types: `Matrix`, `Vector`.
     - Eigen types and classes as an optionally const reference.
     - C/C++ basic types: `string`, `bool`, `size_t`, `size_t`, `double`, `char`, `unsigned char`.
-    - Any class with which be copied with `boost::make_shared()` (except Eigen).
-    - `boost::shared_ptr` of any object type (except Eigen).
+    - Any class with which be copied with `std::make_shared()` (except Eigen).
+    - `std::shared_ptr` of any object type (except Eigen).
 
 - Properties or Variables
     - You can specify class variables in the interface file as long as they are in the `public` scope, e.g.
@@ -142,7 +142,7 @@ The python wrapper supports keyword arguments for functions/methods. Hence, the 
     - Signature of clone function - `clone()` will be called virtually, so must appear at least at the top of the inheritance tree
 
         ```cpp
-        virtual boost::shared_ptr<CLASS_NAME> clone() const;
+        virtual std::shared_ptr<CLASS_NAME> clone() const;
         ```
 
 - Templates

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pybind_wrap(${PROJECT_NAME}_py # target
             ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.tpl # the wrapping template file
             ${PROJECT_NAME} # libs
             "${PROJECT_NAME}" # dependencies
-            ON # use boost
+            ON # use boost serialization
             )
 ```
 

--- a/cmake/MatlabWrap.cmake
+++ b/cmake/MatlabWrap.cmake
@@ -63,11 +63,11 @@ endmacro()
 
 # Consistent and user-friendly wrap function
 function(matlab_wrap interfaceHeader moduleName linkLibraries
-         extraIncludeDirs extraMexFlags ignore_classes)
+         extraIncludeDirs extraMexFlags ignore_classes use_boost_serialization)
   find_and_configure_matlab()
   wrap_and_install_library("${interfaceHeader}" "${moduleName}" "${linkLibraries}"
                            "${extraIncludeDirs}" "${extraMexFlags}"
-                           "${ignore_classes}")
+                           "${ignore_classes}" "${use_boost_serialization}")
 endfunction()
 
 # Wrapping function.  Builds a mex module from the provided
@@ -86,16 +86,18 @@ endfunction()
 # extraMexFlags:    Any *additional* flags to pass to the compiler when building
 # the wrap code.  Normally, leave this empty.
 # ignore_classes:  List of classes to ignore in the wrapping.
+# use_boost_serialization: Flag indicating whether to provide Boost-based serialization.
 function(wrap_and_install_library interfaceHeader moduleName linkLibraries
-         extraIncludeDirs extraMexFlags ignore_classes)
+         extraIncludeDirs extraMexFlags ignore_classes use_boost_serialization)
   wrap_library_internal("${interfaceHeader}" "${moduleName}" "${linkLibraries}"
-                        "${extraIncludeDirs}" "${mexFlags}")
+                        "${extraIncludeDirs}" "${extraMexFlags}" "${ignore_classes}"
+                        "${use_boost_serialization}")
   install_wrapped_library_internal("${moduleName}")
 endfunction()
 
 # Internal function that wraps a library and compiles the wrapper
 function(wrap_library_internal interfaceHeader moduleName linkLibraries extraIncludeDirs
-         extraMexFlags)
+         extraMexFlags ignore_classes use_boost_serialization)
   if(UNIX AND NOT APPLE)
     if(CMAKE_SIZEOF_VOID_P EQUAL 8)
       set(mexModuleExt mexa64)
@@ -145,30 +147,6 @@ function(wrap_library_internal interfaceHeader moduleName linkLibraries extraInc
       endif()
     endif()
   endforeach()
-
-  # CHRIS: Temporary fix. On my system the get_target_property above returned
-  # Not-found for gtsam module This needs to be fixed!!
-  if(UNIX AND NOT APPLE)
-    list(
-      APPEND
-      automaticDependencies
-      ${Boost_SERIALIZATION_LIBRARY_RELEASE}
-      ${Boost_FILESYSTEM_LIBRARY_RELEASE}
-      ${Boost_SYSTEM_LIBRARY_RELEASE}
-      ${Boost_THREAD_LIBRARY_RELEASE}
-      ${Boost_DATE_TIME_LIBRARY_RELEASE})
-    # Only present in Boost >= 1.48.0
-    if(Boost_TIMER_LIBRARY_RELEASE)
-      list(APPEND automaticDependencies ${Boost_TIMER_LIBRARY_RELEASE}
-           ${Boost_CHRONO_LIBRARY_RELEASE})
-      if(WRAP_MEX_BUILD_STATIC_MODULE)
-        # list(APPEND automaticDependencies -Wl,--no-as-needed -lrt)
-      endif()
-    endif()
-  endif()
-
-  # message("AUTOMATIC DEPENDENCIES:  ${automaticDependencies}") CHRIS: End
-  # temporary fix
 
   # Separate dependencies
   set(correctedOtherLibraries "")
@@ -249,6 +227,13 @@ function(wrap_library_internal interfaceHeader moduleName linkLibraries extraInc
     set(GTWRAP_PATH_SEPARATOR ";")
   endif()
 
+  # Set boost serialization flag for the python script call below.
+  if(use_boost_serialization)
+    set(_BOOST_SERIALIZATION "--use-boost-serialization")
+  else(use_boost_serialization)
+    set(_BOOST_SERIALIZATION "")
+  endif(use_boost_serialization)
+
   add_custom_command(
     OUTPUT ${generated_cpp_file}
     DEPENDS ${interfaceHeader} ${module_library_target} ${otherLibraryTargets}
@@ -258,7 +243,7 @@ function(wrap_library_internal interfaceHeader moduleName linkLibraries extraInc
       "PYTHONPATH=${GTWRAP_PACKAGE_DIR}${GTWRAP_PATH_SEPARATOR}$ENV{PYTHONPATH}"
       ${PYTHON_EXECUTABLE} ${MATLAB_WRAP_SCRIPT} --src "${interfaceHeader}"
       --module_name ${moduleName} --out ${generated_files_path}
-      --top_module_namespaces ${moduleName} --ignore ${ignore_classes}
+      --top_module_namespaces ${moduleName} --ignore ${ignore_classes} ${_BOOST_SERIALIZATION}
     VERBATIM
     WORKING_DIRECTORY ${generated_files_path})
 

--- a/cmake/PybindWrap.cmake
+++ b/cmake/PybindWrap.cmake
@@ -29,7 +29,7 @@ set(PYBIND11_PYTHON_VERSION ${WRAP_PYTHON_VERSION})
 # module_template: The template file (.tpl) from which to generate the Pybind11 module.
 # libs: Libraries to link with.
 # dependencies: Dependencies which need to be built before the wrapper.
-# use_boost (optional): Flag indicating whether to include Boost.
+# use_boost_serialization (optional): Flag indicating whether to include Boost.
 function(
   pybind_wrap
   target
@@ -42,12 +42,12 @@ function(
   libs
   dependencies)
   set(ExtraMacroArgs ${ARGN})
-  list(GET ExtraMacroArgs 0 USE_BOOST)
-  if(USE_BOOST)
-    set(_WRAP_BOOST_ARG "--use-boost")
-  else(USE_BOOST)
+  list(GET ExtraMacroArgs 0 USE_BOOST_SERIALIZATION)
+  if(USE_BOOST_SERIALIZATION)
+    set(_WRAP_BOOST_ARG "--use-boost-serialization")
+  else(USE_BOOST_SERIALIZATION)
     set(_WRAP_BOOST_ARG "")
-  endif(USE_BOOST)
+  endif(USE_BOOST_SERIALIZATION)
 
   if(UNIX)
     set(GTWRAP_PATH_SEPARATOR ":")

--- a/gtwrap/interface_parser/function.py
+++ b/gtwrap/interface_parser/function.py
@@ -94,9 +94,9 @@ class ArgumentList:
         """Return a list of the names of all the arguments."""
         return self.args_list
 
-    def to_cpp(self, use_boost: bool) -> List[str]:
+    def to_cpp(self) -> List[str]:
         """Generate the C++ code for wrapping."""
-        return [arg.ctype.to_cpp(use_boost) for arg in self.args_list]
+        return [arg.ctype.to_cpp() for arg in self.args_list]
 
 
 class ReturnType:
@@ -135,7 +135,7 @@ class ReturnType:
         return "{}{}".format(
             self.type1, (', ' + self.type2.__repr__()) if self.type2 else '')
 
-    def to_cpp(self, use_boost: bool) -> str:
+    def to_cpp(self) -> str:
         """
         Generate the C++ code for wrapping.
 
@@ -144,10 +144,9 @@ class ReturnType:
         """
         if self.type2:
             return "std::pair<{type1},{type2}>".format(
-                type1=self.type1.to_cpp(use_boost),
-                type2=self.type2.to_cpp(use_boost))
+                type1=self.type1.to_cpp(), type2=self.type2.to_cpp())
         else:
-            return self.type1.to_cpp(use_boost)
+            return self.type1.to_cpp()
 
 
 class GlobalFunction:

--- a/gtwrap/interface_parser/type.py
+++ b/gtwrap/interface_parser/type.py
@@ -14,8 +14,8 @@ Author: Duy Nguyen Ta, Fan Jiang, Matthew Sklar, Varun Agrawal, and Frank Dellae
 
 from typing import List, Sequence, Union
 
-from pyparsing import (Forward, Optional, Or, ParseResults,  # type: ignore
-                       delimitedList)
+from pyparsing import ParseResults  # type: ignore
+from pyparsing import Forward, Optional, Or, delimitedList
 
 from .tokens import (BASIS_TYPES, CONST, IDENT, LOPBRACK, RAW_POINTER, REF,
                      ROPBRACK, SHARED_POINTER)
@@ -217,21 +217,17 @@ class Type:
             is_const="const " if self.is_const else "",
             is_ptr_or_ref=" " + is_ptr_or_ref if is_ptr_or_ref else "")
 
-    def to_cpp(self, use_boost: bool) -> str:
+    def to_cpp(self) -> str:
         """
         Generate the C++ code for wrapping.
 
         Treat all pointers as "const shared_ptr<T>&"
         Treat Matrix and Vector as "const Matrix&" and "const Vector&" resp.
-
-        Args:
-            use_boost: Flag indicating whether to use boost::shared_ptr or std::shared_ptr.
         """
-        shared_ptr_ns = "boost" if use_boost else "std"
 
         if self.is_shared_ptr:
-            typename = "{ns}::shared_ptr<{typename}>".format(
-                ns=shared_ptr_ns, typename=self.typename.to_cpp())
+            typename = "std::shared_ptr<{typename}>".format(
+                typename=self.typename.to_cpp())
         elif self.is_ptr:
             typename = "{typename}*".format(typename=self.typename.to_cpp())
         elif self.is_ref or self.typename.name in ["Matrix", "Vector"]:
@@ -249,6 +245,7 @@ class Type:
     def get_typename(self):
         """Convenience method to get the typename of this type."""
         return self.typename.name
+
 
 class TemplatedType:
     """
@@ -295,25 +292,19 @@ class TemplatedType:
         return "TemplatedType({typename.namespaces}::{typename.name})".format(
             typename=self.typename)
 
-    def to_cpp(self, use_boost: bool):
+    def to_cpp(self):
         """
         Generate the C++ code for wrapping.
-
-        Args:
-            use_boost: Flag indicating whether to use boost::shared_ptr or std::shared_ptr.
         """
         # Use Type.to_cpp to do the heavy lifting for the template parameters.
-        template_args = ", ".join(
-            [t.to_cpp(use_boost) for t in self.template_params])
+        template_args = ", ".join([t.to_cpp() for t in self.template_params])
 
         typename = "{typename}<{template_args}>".format(
             typename=self.typename.qualified_name(),
             template_args=template_args)
 
-        shared_ptr_ns = "boost" if use_boost else "std"
         if self.is_shared_ptr:
-            typename = "{ns}::shared_ptr<{typename}>".format(ns=shared_ptr_ns,
-                                                             typename=typename)
+            typename = f"std::shared_ptr<{typename}>"
         elif self.is_ptr:
             typename = "{typename}*".format(typename=typename)
         elif self.is_ref or self.typename.name in ["Matrix", "Vector"]:

--- a/gtwrap/matlab_wrapper/templates.py
+++ b/gtwrap/matlab_wrapper/templates.py
@@ -10,7 +10,7 @@ class WrapperTemplate:
         """)
 
     typdef_collectors = textwrap.dedent('''\
-                typedef std::set<boost::shared_ptr<{class_name_sep}>*> Collector_{class_name};
+                typedef std::set<std::shared_ptr<{class_name_sep}>*> Collector_{class_name};
                 static Collector_{class_name} collector_{class_name};
             ''')
 
@@ -77,10 +77,10 @@ class WrapperTemplate:
     collector_function_upcast_from_void = textwrap.dedent('''\
             void {class_name}_upcastFromVoid_{id}(int nargout, mxArray *out[], int nargin, const mxArray *in[]) {{
               mexAtExit(&_deleteAllObjects);
-              typedef boost::shared_ptr<{cpp_name}> Shared;
-              boost::shared_ptr<void> *asVoid = *reinterpret_cast<boost::shared_ptr<void>**> (mxGetData(in[0]));
+              typedef std::shared_ptr<{cpp_name}> Shared;
+              std::shared_ptr<void> *asVoid = *reinterpret_cast<std::shared_ptr<void>**> (mxGetData(in[0]));
               out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
-              Shared *self = new Shared(boost::static_pointer_cast<{cpp_name}>(*asVoid));
+              Shared *self = new Shared(std::static_pointer_cast<{cpp_name}>(*asVoid));
               *reinterpret_cast<Shared**>(mxGetData(out[0])) = self;
             }}\n
         ''')
@@ -102,7 +102,7 @@ class WrapperTemplate:
         ''')
 
     collector_function_serialize = textwrap.indent(textwrap.dedent("""\
-            typedef boost::shared_ptr<{full_name}> Shared;
+            typedef std::shared_ptr<{full_name}> Shared;
             checkArguments("string_serialize",nargout,nargin-1,0);
             Shared obj = unwrap_shared_ptr<{full_name}>(in[0], "ptr_{namespace}{class_name}");
             ostringstream out_archive_stream;
@@ -113,7 +113,7 @@ class WrapperTemplate:
                                                    prefix='  ')
 
     collector_function_deserialize = textwrap.indent(textwrap.dedent("""\
-            typedef boost::shared_ptr<{full_name}> Shared;
+            typedef std::shared_ptr<{full_name}> Shared;
             checkArguments("{namespace}{class_name}.string_deserialize",nargout,nargin,1);
             string serialized = unwrap< string >(in[0]);
             istringstream in_archive_stream(serialized);
@@ -143,7 +143,7 @@ class WrapperTemplate:
 
     collector_function_shared_return = textwrap.indent(textwrap.dedent('''\
             {{
-            boost::shared_ptr<{name}> shared({shared_obj});
+            std::shared_ptr<{name}> shared({shared_obj});
             out[{id}] = wrap_shared_ptr(shared,"{name}");
             }}{new_line}'''),
                                                        prefix='  ')

--- a/gtwrap/matlab_wrapper/wrapper.py
+++ b/gtwrap/matlab_wrapper/wrapper.py
@@ -33,13 +33,15 @@ class MatlabWrapper(CheckMixin, FormatMixin):
     def __init__(self,
                  module_name,
                  top_module_namespace='',
-                 ignore_classes=()):
+                 ignore_classes=(),
+                 use_boost_serialization=False):
         super().__init__()
 
         self.module_name = module_name
         self.top_module_namespace = top_module_namespace
         self.ignore_classes = ignore_classes
         self.verbose = False
+        self.use_boost_serialization = use_boost_serialization
 
         # Map the data type to its Matlab class.
         # Found in Argument.cpp in old wrapper
@@ -358,8 +360,7 @@ class MatlabWrapper(CheckMixin, FormatMixin):
         elif (self.is_shared_ptr(arg.ctype) or self.can_be_pointer(arg.ctype)) and \
                 arg.ctype.typename.name not in self.ignore_namespace:
 
-            arg_type = "{std_boost}::shared_ptr<{ctype_sep}>".format(
-                std_boost='boost' if constructor else 'boost',
+            arg_type = "std::shared_ptr<{ctype_sep}>".format(
                 ctype_sep=ctype_sep)
             unwrap = 'unwrap_shared_ptr< {ctype_sep} >(in[{id}], "ptr_{ctype}");'.format(
                 ctype_sep=ctype_sep, ctype=ctype_camel, id=arg_id)
@@ -762,13 +763,12 @@ class MatlabWrapper(CheckMixin, FormatMixin):
                 {varargout} = {wrapper}({num}, this);
                 this.{name} = {varargout};
             end
-            """.format(
-                name=propty.name,
-                varargout='varargout{1}',
-                wrapper=self._wrapper_name(),
-                num=self._update_wrapper_id(
-                    (namespace_name, inst_class, propty.name, propty),
-                    function_name=function_name))
+            """.format(name=propty.name,
+                       varargout='varargout{1}',
+                       wrapper=self._wrapper_name(),
+                       num=self._update_wrapper_id(
+                           (namespace_name, inst_class, propty.name, propty),
+                           function_name=function_name))
             properties.append(getter)
 
             # Setter doesn't need varargin since it needs just one input.
@@ -778,12 +778,11 @@ class MatlabWrapper(CheckMixin, FormatMixin):
                 obj.{name} = value;
                 {wrapper}({num}, this, value);
             end
-            """.format(
-                name=propty.name,
-                wrapper=self._wrapper_name(),
-                num=self._update_wrapper_id(
-                    (namespace_name, inst_class, propty.name, propty),
-                    function_name=function_name))
+            """.format(name=propty.name,
+                       wrapper=self._wrapper_name(),
+                       num=self._update_wrapper_id(
+                           (namespace_name, inst_class, propty.name, propty),
+                           function_name=function_name))
             properties.append(setter)
 
         return properties
@@ -860,9 +859,11 @@ class MatlabWrapper(CheckMixin, FormatMixin):
                 continue
 
             if method_name == 'serialize':
-                serialize[0] = True
-                method_text += self.wrap_class_serialize_method(
-                    namespace_name, inst_class)
+                if self.use_boost_serialization:
+                    serialize[0] = True
+                    method_text += self.wrap_class_serialize_method(
+                        namespace_name, inst_class)
+
             else:
                 # Generate method code
                 method_text += textwrap.indent(textwrap.dedent("""\
@@ -998,7 +999,7 @@ class MatlabWrapper(CheckMixin, FormatMixin):
                 """),
                                            prefix="  ")
 
-        if serialize:
+        if serialize and self.use_boost_serialization:
             method_text += WrapperTemplate.matlab_deserialize.format(
                 class_name=namespace_name + '.' + instantiated_class.name,
                 wrapper=self._wrapper_name(),
@@ -1192,7 +1193,7 @@ class MatlabWrapper(CheckMixin, FormatMixin):
             shared_obj = 'pairResult.' + pair_value
 
             if not (return_type.is_shared_ptr or return_type.is_ptr):
-                shared_obj = 'boost::make_shared<{name}>({shared_obj})' \
+                shared_obj = 'std::make_shared<{name}>({shared_obj})' \
                     .format(name=self._format_type_name(return_type.typename),
                             shared_obj='pairResult.' + pair_value)
 
@@ -1230,7 +1231,7 @@ class MatlabWrapper(CheckMixin, FormatMixin):
                     obj=obj, method_name_sep=sep_method_name('.'))
             else:
                 method_name_sep_dot = sep_method_name('.')
-                shared_obj_template = 'boost::make_shared<{method_name_sep_col}>({obj}),' \
+                shared_obj_template = 'std::make_shared<{method_name_sep_col}>({obj}),' \
                                         '"{method_name_sep_dot}"'
                 shared_obj = shared_obj_template \
                     .format(method_name_sep_col=sep_method_name(),
@@ -1351,7 +1352,7 @@ class MatlabWrapper(CheckMixin, FormatMixin):
             if collector_func[2] == 'collectorInsertAndMakeBase':
                 body += textwrap.indent(textwrap.dedent('''\
                     mexAtExit(&_deleteAllObjects);
-                    typedef boost::shared_ptr<{class_name_sep}> Shared;\n
+                    typedef std::shared_ptr<{class_name_sep}> Shared;\n
                     Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
                     collector_{class_name}.insert(self);
                 ''').format(class_name_sep=class_name_separated,
@@ -1360,7 +1361,7 @@ class MatlabWrapper(CheckMixin, FormatMixin):
 
                 if collector_func[1].parent_class:
                     body += textwrap.indent(textwrap.dedent('''
-                        typedef boost::shared_ptr<{}> SharedBase;
+                        typedef std::shared_ptr<{}> SharedBase;
                         out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
                         *reinterpret_cast<SharedBase**>(mxGetData(out[0])) = new SharedBase(*self);
                     ''').format(collector_func[1].parent_class),
@@ -1373,7 +1374,7 @@ class MatlabWrapper(CheckMixin, FormatMixin):
 
                 if collector_func[1].parent_class:
                     base += textwrap.indent(textwrap.dedent('''
-                        typedef boost::shared_ptr<{}> SharedBase;
+                        typedef std::shared_ptr<{}> SharedBase;
                         out[1] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
                         *reinterpret_cast<SharedBase**>(mxGetData(out[1])) = new SharedBase(*self);
                     ''').format(collector_func[1].parent_class),
@@ -1381,7 +1382,7 @@ class MatlabWrapper(CheckMixin, FormatMixin):
 
                 body += textwrap.dedent('''\
                       mexAtExit(&_deleteAllObjects);
-                      typedef boost::shared_ptr<{class_name_sep}> Shared;\n
+                      typedef std::shared_ptr<{class_name_sep}> Shared;\n
                     {body_args}  Shared *self = new Shared(new {class_name_sep}({params}));
                       collector_{class_name}.insert(self);
                       out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
@@ -1394,7 +1395,7 @@ class MatlabWrapper(CheckMixin, FormatMixin):
 
             elif collector_func[2] == 'deconstructor':
                 body += textwrap.indent(textwrap.dedent('''\
-                    typedef boost::shared_ptr<{class_name_sep}> Shared;
+                    typedef std::shared_ptr<{class_name_sep}> Shared;
                     checkArguments("delete_{class_name}",nargout,nargin,1);
                     Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
                     Collector_{class_name}::iterator item;
@@ -1408,16 +1409,18 @@ class MatlabWrapper(CheckMixin, FormatMixin):
                                         prefix='  ')
 
             elif extra == 'serialize':
-                body += self.wrap_collector_function_serialize(
-                    collector_func[1].name,
-                    full_name=collector_func[1].to_cpp(),
-                    namespace=collector_func[0])
+                if self.use_boost_serialization:
+                    body += self.wrap_collector_function_serialize(
+                        collector_func[1].name,
+                        full_name=collector_func[1].to_cpp(),
+                        namespace=collector_func[0])
 
             elif extra == 'deserialize':
-                body += self.wrap_collector_function_deserialize(
-                    collector_func[1].name,
-                    full_name=collector_func[1].to_cpp(),
-                    namespace=collector_func[0])
+                if self.use_boost_serialization:
+                    body += self.wrap_collector_function_deserialize(
+                        collector_func[1].name,
+                        full_name=collector_func[1].to_cpp(),
+                        namespace=collector_func[0])
 
             elif is_method or is_static_method:
                 method_name = ''
@@ -1610,7 +1613,8 @@ class MatlabWrapper(CheckMixin, FormatMixin):
                             class_name_sep=cls.name))
 
             # Get the Boost exports for serialization
-            if cls.original.namespaces() and self._has_serialization(cls):
+            if self.use_boost_serialization and \
+                cls.original.namespaces() and self._has_serialization(cls):
                 boost_class_export_guid += 'BOOST_CLASS_EXPORT_GUID({}, "{}");\n'.format(
                     class_name_sep, class_name)
 
@@ -1648,12 +1652,19 @@ class MatlabWrapper(CheckMixin, FormatMixin):
         # Generate the header includes
         includes_list = sorted(self.includes,
                                key=lambda include: include.header)
+
+        # If boost serialization is enabled, include serialization headers
+        if self.use_boost_serialization:
+            boost_headers = WrapperTemplate.boost_headers
+        else:
+            boost_headers = ""
+
         includes = textwrap.dedent("""\
             {wrapper_file_headers}
             {boost_headers}
             {includes_list}
         """).format(wrapper_file_headers=self.wrapper_file_headers.strip(),
-                    boost_headers=WrapperTemplate.boost_headers,
+                    boost_headers=boost_headers,
                     includes_list='\n'.join(map(str, includes_list)))
 
         preamble = self.generate_preamble()

--- a/gtwrap/matlab_wrapper/wrapper.py
+++ b/gtwrap/matlab_wrapper/wrapper.py
@@ -1231,6 +1231,17 @@ class MatlabWrapper(CheckMixin, FormatMixin):
                     obj=obj, method_name_sep=sep_method_name('.'))
             else:
                 method_name_sep_dot = sep_method_name('.')
+
+                # Specialize for std::optional so we access the underlying member
+                #TODO(Varun) How do we handle std::optional as a Mex type?
+                if isinstance(ctype, parser.TemplatedType) and \
+                    "std::optional" == str(ctype.typename)[:13]:
+                    obj = f"*{obj}"
+                    type_name = ctype.template_params[0].typename
+                    method_name_sep_dot = ".".join(
+                        type_name.namespaces) + f".{type_name.name}"
+
+
                 shared_obj_template = 'std::make_shared<{method_name_sep_col}>({obj}),' \
                                         '"{method_name_sep_dot}"'
                 shared_obj = shared_obj_template \

--- a/gtwrap/pybind_wrapper.py
+++ b/gtwrap/pybind_wrapper.py
@@ -10,7 +10,7 @@ Code generator for wrapping a C++ module with Pybind11
 Author: Duy Nguyen Ta, Fan Jiang, Matthew Sklar, Varun Agrawal, and Frank Dellaert
 """
 
-# pylint: disable=too-many-arguments, too-many-instance-attributes, no-self-use, no-else-return, too-many-arguments, unused-format-string-argument, line-too-long
+# pylint: disable=too-many-arguments, too-many-instance-attributes, no-self-use, no-else-return, too-many-arguments, unused-format-string-argument, line-too-long, consider-using-f-string
 
 import re
 from pathlib import Path
@@ -24,15 +24,16 @@ class PybindWrapper:
     """
     Class to generate binding code for Pybind11 specifically.
     """
+
     def __init__(self,
                  module_name,
                  top_module_namespaces='',
-                 use_boost=False,
+                 use_boost_serialization=False,
                  ignore_classes=(),
                  module_template=""):
         self.module_name = module_name
         self.top_module_namespaces = top_module_namespaces
-        self.use_boost = use_boost
+        self.use_boost_serialization = use_boost_serialization
         self.ignore_classes = ignore_classes
         self._serializing_classes = []
         self.module_template = module_template
@@ -71,7 +72,7 @@ class PybindWrapper:
 
     def _method_args_signature(self, args):
         """Generate the argument types and names as per the method signature."""
-        cpp_types = args.to_cpp(self.use_boost)
+        cpp_types = args.to_cpp()
         names = args.names()
         types_names = [
             "{} {}".format(ctype, name)
@@ -84,12 +85,11 @@ class PybindWrapper:
         """Wrap the constructors."""
         res = ""
         for ctor in my_class.ctors:
-            res += (
-                self.method_indent + '.def(py::init<{args_cpp_types}>()'
-                '{py_args_names})'.format(
-                    args_cpp_types=", ".join(ctor.args.to_cpp(self.use_boost)),
-                    py_args_names=self._py_args_names(ctor.args),
-                ))
+            res += (self.method_indent + '.def(py::init<{args_cpp_types}>()'
+                    '{py_args_names})'.format(
+                        args_cpp_types=", ".join(ctor.args.to_cpp()),
+                        py_args_names=self._py_args_names(ctor.args),
+                    ))
         return res
 
     def _wrap_serialization(self, cpp_class):
@@ -178,7 +178,10 @@ class PybindWrapper:
 
         # Special handling for the serialize/serializable method
         if cpp_method in ["serialize", "serializable"]:
-            return self._wrap_serialization(cpp_class)
+            if self.use_boost_serialization:
+                return self._wrap_serialization(cpp_class)
+            else:
+                return ""
 
         # Special handling of ipython specific methods
         # https://ipython.readthedocs.io/en/stable/config/integrating.html
@@ -246,7 +249,7 @@ class PybindWrapper:
             # To avoid type confusion for insert
             if method.name == 'insert' and cpp_class == 'gtsam::Values':
                 name_list = method.args.names()
-                type_list = method.args.to_cpp(self.use_boost)
+                type_list = method.args.to_cpp()
                 # inserting non-wrapped value types
                 if type_list[0].strip() == 'size_t':
                     method_suffix = '_' + name_list[1].strip()
@@ -372,10 +375,9 @@ class PybindWrapper:
             instance_name = instantiated_class.name.lower()
             class_declaration = (
                 '\n    py::class_<{cpp_class}, {class_parent}'
-                '{shared_ptr_type}::shared_ptr<{cpp_class}>> '
+                'std::shared_ptr<{cpp_class}>> '
                 '{instance_name}({module_var}, "{class_name}");'
                 '\n    {instance_name}').format(
-                    shared_ptr_type=('boost' if self.use_boost else 'std'),
                     cpp_class=cpp_class,
                     class_name=instantiated_class.name,
                     class_parent=class_parent,
@@ -386,9 +388,8 @@ class PybindWrapper:
         else:
             class_declaration = (
                 '\n    py::class_<{cpp_class}, {class_parent}'
-                '{shared_ptr_type}::shared_ptr<{cpp_class}>>({module_var}, "{class_name}")'
-            ).format(shared_ptr_type=('boost' if self.use_boost else 'std'),
-                     cpp_class=cpp_class,
+                'std::shared_ptr<{cpp_class}>>({module_var}, "{class_name}")'
+            ).format(cpp_class=cpp_class,
                      class_name=instantiated_class.name,
                      class_parent=class_parent,
                      module_var=module_var)
@@ -418,13 +419,11 @@ class PybindWrapper:
         if cpp_class in self.ignore_classes:
             return ""
 
-        res = (
-            '\n    py::class_<{cpp_class}, '
-            '{shared_ptr_type}::shared_ptr<{cpp_class}>>({module_var}, "{class_name}");'
-        ).format(shared_ptr_type=('boost' if self.use_boost else 'std'),
-                 cpp_class=cpp_class,
-                 class_name=instantiated_decl.name,
-                 module_var=module_var)
+        res = ('\n    py::class_<{cpp_class}, '
+               'std::shared_ptr<{cpp_class}>>({module_var}, "{class_name}");'
+               ).format(cpp_class=cpp_class,
+                        class_name=instantiated_decl.name,
+                        module_var=module_var)
         return res
 
     def wrap_stl_class(self, stl_class):
@@ -434,27 +433,25 @@ class PybindWrapper:
         if cpp_class in self.ignore_classes:
             return ""
 
-        return (
-            '\n    py::class_<{cpp_class}, {class_parent}'
-            '{shared_ptr_type}::shared_ptr<{cpp_class}>>({module_var}, "{class_name}")'
-            '{wrapped_ctors}'
-            '{wrapped_methods}'
-            '{wrapped_static_methods}'
-            '{wrapped_properties};\n'.format(
-                shared_ptr_type=('boost' if self.use_boost else 'std'),
-                cpp_class=cpp_class,
-                class_name=stl_class.name,
-                class_parent=str(stl_class.parent_class) +
-                (', ' if stl_class.parent_class else ''),
-                module_var=module_var,
-                wrapped_ctors=self.wrap_ctors(stl_class),
-                wrapped_methods=self.wrap_methods(stl_class.methods,
-                                                  cpp_class),
-                wrapped_static_methods=self.wrap_methods(
-                    stl_class.static_methods, cpp_class),
-                wrapped_properties=self.wrap_properties(
-                    stl_class.properties, cpp_class),
-            ))
+        return ('\n    py::class_<{cpp_class}, {class_parent}'
+                'std::shared_ptr<{cpp_class}>>({module_var}, "{class_name}")'
+                '{wrapped_ctors}'
+                '{wrapped_methods}'
+                '{wrapped_static_methods}'
+                '{wrapped_properties};\n'.format(
+                    cpp_class=cpp_class,
+                    class_name=stl_class.name,
+                    class_parent=str(stl_class.parent_class) +
+                    (', ' if stl_class.parent_class else ''),
+                    module_var=module_var,
+                    wrapped_ctors=self.wrap_ctors(stl_class),
+                    wrapped_methods=self.wrap_methods(stl_class.methods,
+                                                      cpp_class),
+                    wrapped_static_methods=self.wrap_methods(
+                        stl_class.static_methods, cpp_class),
+                    wrapped_properties=self.wrap_properties(
+                        stl_class.properties, cpp_class),
+                ))
 
     def wrap_functions(self,
                        functions,
@@ -643,10 +640,6 @@ class PybindWrapper:
         # Reset the serializing classes list
         self._serializing_classes = []
 
-        holder_type = "PYBIND11_DECLARE_HOLDER_TYPE(TYPE_PLACEHOLDER_DONOTUSE, " \
-                      "{shared_ptr_type}::shared_ptr<TYPE_PLACEHOLDER_DONOTUSE>);"
-        include_boost = "#include <boost/shared_ptr.hpp>" if self.use_boost else ""
-
         submodules_init = []
 
         if submodules is not None:
@@ -661,13 +654,9 @@ class PybindWrapper:
             submodules = []
 
         return self.module_template.format(
-            include_boost=include_boost,
             module_def=module_def,
             module_name=module_name,
             includes=includes,
-            holder_type=holder_type.format(
-                shared_ptr_type=('boost' if self.use_boost else 'std'))
-            if self.use_boost else "",
             wrapped_namespace=wrapped_namespace,
             boost_class_export=boost_class_export,
             submodules="\n".join(submodules),
@@ -690,13 +679,13 @@ class PybindWrapper:
         module_name = Path(source).stem
 
         # Read in the complete interface (.i) file
-        with open(source, "r") as f:
+        with open(source, "r", encoding="UTF-8") as f:
             content = f.read()
         # Wrap the read-in content
         cc_content = self.wrap_file(content, module_name=module_name)
 
         # Generate the C++ code which Pybind11 will use.
-        with open(filename.replace(".i", ".cpp"), "w") as f:
+        with open(filename.replace(".i", ".cpp"), "w", encoding="UTF-8") as f:
             f.write(cc_content)
 
     def wrap(self, sources, main_module_name):
@@ -716,12 +705,12 @@ class PybindWrapper:
             module_name = Path(source).stem
             submodules.append(module_name)
 
-        with open(main_module, "r") as f:
+        with open(main_module, "r", encoding="UTF-8") as f:
             content = f.read()
         cc_content = self.wrap_file(content,
                                     module_name=self.module_name,
                                     submodules=submodules)
 
         # Generate the C++ code which Pybind11 will use.
-        with open(main_module_name, "w") as f:
+        with open(main_module_name, "w", encoding="UTF-8") as f:
             f.write(cc_content)

--- a/matlab.h
+++ b/matlab.h
@@ -37,10 +37,6 @@ extern "C" {
 #include <mex.h>
 }
 
-#include <boost/cstdint.hpp>
-#include <boost/make_shared.hpp>
-#include <boost/shared_ptr.hpp>
-
 #include <list>
 #include <set>
 #include <sstream>
@@ -49,7 +45,6 @@ extern "C" {
 #include <typeinfo>
 
 using namespace std;
-using namespace boost; // not usual, but for conciseness of generated code
 
 // start GTSAM Specifics /////////////////////////////////////////////////
 // to enable Matrix and Vector constructor for SharedGaussian:
@@ -66,15 +61,15 @@ using namespace boost; // not usual, but for conciseness of generated code
 // "Unique" key to signal calling the matlab object constructor with a raw pointer
 // to a shared pointer of the same C++ object type as the MATLAB type.
 // Also present in utilities.h
-static const boost::uint64_t ptr_constructor_key =
-  (boost::uint64_t('G') << 56) |
-  (boost::uint64_t('T') << 48) |
-  (boost::uint64_t('S') << 40) |
-  (boost::uint64_t('A') << 32) |
-  (boost::uint64_t('M') << 24) |
-  (boost::uint64_t('p') << 16) |
-  (boost::uint64_t('t') << 8) |
-  (boost::uint64_t('r'));
+static const std::uint64_t ptr_constructor_key =
+  (std::uint64_t('G') << 56) |
+  (std::uint64_t('T') << 48) |
+  (std::uint64_t('S') << 40) |
+  (std::uint64_t('A') << 32) |
+  (std::uint64_t('M') << 24) |
+  (std::uint64_t('p') << 16) |
+  (std::uint64_t('t') << 8) |
+  (std::uint64_t('r'));
 
 //*****************************************************************************
 // Utilities
@@ -262,9 +257,9 @@ template <typename T>
 T myGetScalar(const mxArray* array) {
   switch (mxGetClassID(array)) {
     case mxINT64_CLASS:
-      return (T) *(boost::int64_t*) mxGetData(array);
+      return (T) *(std::int64_t*) mxGetData(array);
     case mxUINT64_CLASS:
-      return (T) *(boost::uint64_t*) mxGetData(array);
+      return (T) *(std::uint64_t*) mxGetData(array);
     default:
       // hope for the best!
       return (T) mxGetScalar(array);
@@ -402,7 +397,7 @@ mxArray* create_object(const std::string& classname, void *pointer, bool isVirtu
   int nargin = 2;
   // First input argument is pointer constructor key
   input[0] = mxCreateNumericMatrix(1, 1, mxUINT64_CLASS, mxREAL);
-  *reinterpret_cast<boost::uint64_t*>(mxGetData(input[0])) = ptr_constructor_key;
+  *reinterpret_cast<std::uint64_t*>(mxGetData(input[0])) = ptr_constructor_key;
   // Second input argument is the pointer
   input[1] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
   *reinterpret_cast<void**>(mxGetData(input[1])) = pointer;
@@ -453,28 +448,28 @@ mxArray* create_object(const std::string& classname, void *pointer, bool isVirtu
  class to matlab.
 */
 template <typename Class>
-mxArray* wrap_shared_ptr(boost::shared_ptr< Class > shared_ptr, const std::string& matlabName, bool isVirtual) {
+mxArray* wrap_shared_ptr(std::shared_ptr< Class > shared_ptr, const std::string& matlabName, bool isVirtual) {
   // Create actual class object from out pointer
   mxArray* result;
   if(isVirtual) {
-    boost::shared_ptr<void> void_ptr(shared_ptr);
+    std::shared_ptr<void> void_ptr(shared_ptr);
     result = create_object(matlabName, &void_ptr, isVirtual, typeid(*shared_ptr).name());
   } else {
-    boost::shared_ptr<Class> *heapPtr = new boost::shared_ptr<Class>(shared_ptr);
+    std::shared_ptr<Class> *heapPtr = new std::shared_ptr<Class>(shared_ptr);
     result = create_object(matlabName, heapPtr, isVirtual, "");
   }
   return result;
 }
 
 template <typename Class>
-boost::shared_ptr<Class> unwrap_shared_ptr(const mxArray* obj, const string& propertyName) {
+std::shared_ptr<Class> unwrap_shared_ptr(const mxArray* obj, const string& propertyName) {
 
   mxArray* mxh = mxGetProperty(obj,0, propertyName.c_str());
   if (mxGetClassID(mxh) != mxUINT32OR64_CLASS || mxIsComplex(mxh)
     || mxGetM(mxh) != 1 || mxGetN(mxh) != 1) error(
     "Parameter is not an Shared type.");
 
-  boost::shared_ptr<Class>* spp = *reinterpret_cast<boost::shared_ptr<Class>**> (mxGetData(mxh));
+  std::shared_ptr<Class>* spp = *reinterpret_cast<std::shared_ptr<Class>**> (mxGetData(mxh));
   return *spp;
 }
 

--- a/scripts/matlab_wrap.py
+++ b/scripts/matlab_wrap.py
@@ -43,16 +43,24 @@ if __name__ == "__main__":
         type=str,
         help="A space-separated list of classes to ignore. "
         "Class names must include their full namespaces.")
+    arg_parser.add_argument(
+        "--use-boost-serialization",
+        action="store_true",
+        help="Allow boost based serialization methods",
+    )
     args = arg_parser.parse_args()
 
     top_module_namespaces = args.top_module_namespaces.split("::")
     if top_module_namespaces[0]:
         top_module_namespaces = [''] + top_module_namespaces
 
-    print("[MatlabWrapper] Ignoring classes: {}".format(args.ignore), file=sys.stderr)
-    wrapper = MatlabWrapper(module_name=args.module_name,
-                            top_module_namespace=top_module_namespaces,
-                            ignore_classes=args.ignore)
+    print(f"[MatlabWrapper] Ignoring classes: {args.ignore}", file=sys.stderr)
+
+    wrapper = MatlabWrapper(
+        module_name=args.module_name,
+        top_module_namespace=top_module_namespaces,
+        ignore_classes=args.ignore,
+        use_boost_serialization=args.use_boost_serialization)
 
     sources = args.src.split(';')
     cc_content = wrapper.wrap(sources, path=args.out)

--- a/scripts/pybind_wrap.py
+++ b/scripts/pybind_wrap.py
@@ -34,9 +34,9 @@ def main():
         help="Name of the output pybind .cc file(s)",
     )
     arg_parser.add_argument(
-        "--use-boost",
+        "--use-boost-serialization",
         action="store_true",
-        help="using boost's shared_ptr instead of std's",
+        help="Allow boost based serialization methods",
     )
     arg_parser.add_argument(
         "--top_module_namespaces",
@@ -70,12 +70,12 @@ def main():
     if top_module_namespaces[0]:
         top_module_namespaces = [''] + top_module_namespaces
 
-    with open(args.template, "r") as f:
+    with open(args.template, "r", encoding="UTF-8") as f:
         template_content = f.read()
 
     wrapper = PybindWrapper(
         module_name=args.module_name,
-        use_boost=args.use_boost,
+        use_boost_serialization=args.use_boost_serialization,
         top_module_namespaces=top_module_namespaces,
         ignore_classes=args.ignore,
         module_template=template_content,

--- a/templates/pybind_wrapper.tpl.example
+++ b/templates/pybind_wrapper.tpl.example
@@ -8,7 +8,6 @@
 #include "gtsam/base/utilities.h"  // for RedirectCout.
 
 {includes}
-#include <boost/serialization/export.hpp>
 
 {boost_class_export}
 

--- a/templates/pybind_wrapper.tpl.example
+++ b/templates/pybind_wrapper.tpl.example
@@ -1,5 +1,3 @@
-{include_boost}
-
 #include <pybind11/eigen.h>
 #include <pybind11/stl_bind.h>
 #include <pybind11/pybind11.h>
@@ -13,8 +11,6 @@
 #include <boost/serialization/export.hpp>
 
 {boost_class_export}
-
-{holder_type}
 
 #include "python/preamble.h"
 

--- a/tests/expected/matlab/class_wrapper.cpp
+++ b/tests/expected/matlab/class_wrapper.cpp
@@ -1,10 +1,6 @@
 #include <gtwrap/matlab.h>
 #include <map>
 
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
-#include <boost/serialization/export.hpp>
-
 #include <folder/path/to/Test.h>
 
 typedef Fun<double> FunDouble;
@@ -15,27 +11,27 @@ typedef MultipleTemplates<int, double> MultipleTemplatesIntDouble;
 typedef MultipleTemplates<int, float> MultipleTemplatesIntFloat;
 typedef MyFactor<gtsam::Pose2, gtsam::Matrix> MyFactorPosePoint2;
 
-typedef std::set<boost::shared_ptr<FunRange>*> Collector_FunRange;
+typedef std::set<std::shared_ptr<FunRange>*> Collector_FunRange;
 static Collector_FunRange collector_FunRange;
-typedef std::set<boost::shared_ptr<FunDouble>*> Collector_FunDouble;
+typedef std::set<std::shared_ptr<FunDouble>*> Collector_FunDouble;
 static Collector_FunDouble collector_FunDouble;
-typedef std::set<boost::shared_ptr<Test>*> Collector_Test;
+typedef std::set<std::shared_ptr<Test>*> Collector_Test;
 static Collector_Test collector_Test;
-typedef std::set<boost::shared_ptr<PrimitiveRefDouble>*> Collector_PrimitiveRefDouble;
+typedef std::set<std::shared_ptr<PrimitiveRefDouble>*> Collector_PrimitiveRefDouble;
 static Collector_PrimitiveRefDouble collector_PrimitiveRefDouble;
-typedef std::set<boost::shared_ptr<MyVector3>*> Collector_MyVector3;
+typedef std::set<std::shared_ptr<MyVector3>*> Collector_MyVector3;
 static Collector_MyVector3 collector_MyVector3;
-typedef std::set<boost::shared_ptr<MyVector12>*> Collector_MyVector12;
+typedef std::set<std::shared_ptr<MyVector12>*> Collector_MyVector12;
 static Collector_MyVector12 collector_MyVector12;
-typedef std::set<boost::shared_ptr<MultipleTemplatesIntDouble>*> Collector_MultipleTemplatesIntDouble;
+typedef std::set<std::shared_ptr<MultipleTemplatesIntDouble>*> Collector_MultipleTemplatesIntDouble;
 static Collector_MultipleTemplatesIntDouble collector_MultipleTemplatesIntDouble;
-typedef std::set<boost::shared_ptr<MultipleTemplatesIntFloat>*> Collector_MultipleTemplatesIntFloat;
+typedef std::set<std::shared_ptr<MultipleTemplatesIntFloat>*> Collector_MultipleTemplatesIntFloat;
 static Collector_MultipleTemplatesIntFloat collector_MultipleTemplatesIntFloat;
-typedef std::set<boost::shared_ptr<ForwardKinematics>*> Collector_ForwardKinematics;
+typedef std::set<std::shared_ptr<ForwardKinematics>*> Collector_ForwardKinematics;
 static Collector_ForwardKinematics collector_ForwardKinematics;
-typedef std::set<boost::shared_ptr<TemplatedConstructor>*> Collector_TemplatedConstructor;
+typedef std::set<std::shared_ptr<TemplatedConstructor>*> Collector_TemplatedConstructor;
 static Collector_TemplatedConstructor collector_TemplatedConstructor;
-typedef std::set<boost::shared_ptr<MyFactorPosePoint2>*> Collector_MyFactorPosePoint2;
+typedef std::set<std::shared_ptr<MyFactorPosePoint2>*> Collector_MyFactorPosePoint2;
 static Collector_MyFactorPosePoint2 collector_MyFactorPosePoint2;
 
 
@@ -155,7 +151,7 @@ void _class_RTTIRegister() {
 void FunRange_collectorInsertAndMakeBase_0(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<FunRange> Shared;
+  typedef std::shared_ptr<FunRange> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_FunRange.insert(self);
@@ -164,7 +160,7 @@ void FunRange_collectorInsertAndMakeBase_0(int nargout, mxArray *out[], int narg
 void FunRange_constructor_1(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<FunRange> Shared;
+  typedef std::shared_ptr<FunRange> Shared;
 
   Shared *self = new Shared(new FunRange());
   collector_FunRange.insert(self);
@@ -174,7 +170,7 @@ void FunRange_constructor_1(int nargout, mxArray *out[], int nargin, const mxArr
 
 void FunRange_deconstructor_2(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<FunRange> Shared;
+  typedef std::shared_ptr<FunRange> Shared;
   checkArguments("delete_FunRange",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_FunRange::iterator item;
@@ -190,19 +186,19 @@ void FunRange_range_3(int nargout, mxArray *out[], int nargin, const mxArray *in
   checkArguments("range",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<FunRange>(in[0], "ptr_FunRange");
   double d = unwrap< double >(in[1]);
-  out[0] = wrap_shared_ptr(boost::make_shared<FunRange>(obj->range(d)),"FunRange", false);
+  out[0] = wrap_shared_ptr(std::make_shared<FunRange>(obj->range(d)),"FunRange", false);
 }
 
 void FunRange_create_4(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("FunRange.create",nargout,nargin,0);
-  out[0] = wrap_shared_ptr(boost::make_shared<FunRange>(FunRange::create()),"FunRange", false);
+  out[0] = wrap_shared_ptr(std::make_shared<FunRange>(FunRange::create()),"FunRange", false);
 }
 
 void FunDouble_collectorInsertAndMakeBase_5(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<Fun<double>> Shared;
+  typedef std::shared_ptr<Fun<double>> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_FunDouble.insert(self);
@@ -210,7 +206,7 @@ void FunDouble_collectorInsertAndMakeBase_5(int nargout, mxArray *out[], int nar
 
 void FunDouble_deconstructor_6(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<Fun<double>> Shared;
+  typedef std::shared_ptr<Fun<double>> Shared;
   checkArguments("delete_FunDouble",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_FunDouble::iterator item;
@@ -228,14 +224,14 @@ void FunDouble_multiTemplatedMethod_7(int nargout, mxArray *out[], int nargin, c
   double d = unwrap< double >(in[1]);
   string t = unwrap< string >(in[2]);
   size_t u = unwrap< size_t >(in[3]);
-  out[0] = wrap_shared_ptr(boost::make_shared<Fun<double>>(obj->multiTemplatedMethod<string,size_t>(d,t,u)),"Fun<double>", false);
+  out[0] = wrap_shared_ptr(std::make_shared<Fun<double>>(obj->multiTemplatedMethod<string,size_t>(d,t,u)),"Fun<double>", false);
 }
 
 void FunDouble_sets_8(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("sets",nargout,nargin-1,0);
   auto obj = unwrap_shared_ptr<Fun<double>>(in[0], "ptr_FunDouble");
-  out[0] = wrap_shared_ptr(boost::make_shared<std::map<double,Fun<double>::double>>(obj->sets()),"std.mapdoubledouble", false);
+  out[0] = wrap_shared_ptr(std::make_shared<std::map<double,Fun<double>::double>>(obj->sets()),"std.mapdoubledouble", false);
 }
 
 void FunDouble_templatedMethod_9(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -244,13 +240,13 @@ void FunDouble_templatedMethod_9(int nargout, mxArray *out[], int nargin, const 
   auto obj = unwrap_shared_ptr<Fun<double>>(in[0], "ptr_FunDouble");
   double d = unwrap< double >(in[1]);
   string t = unwrap< string >(in[2]);
-  out[0] = wrap_shared_ptr(boost::make_shared<Fun<double>>(obj->templatedMethod<string>(d,t)),"Fun<double>", false);
+  out[0] = wrap_shared_ptr(std::make_shared<Fun<double>>(obj->templatedMethod<string>(d,t)),"Fun<double>", false);
 }
 
 void FunDouble_staticMethodWithThis_10(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("Fun<double>.staticMethodWithThis",nargout,nargin,0);
-  out[0] = wrap_shared_ptr(boost::make_shared<Fun<double>>(Fun<double>::staticMethodWithThis()),"Fundouble", false);
+  out[0] = wrap_shared_ptr(std::make_shared<Fun<double>>(Fun<double>::staticMethodWithThis()),"Fundouble", false);
 }
 
 void FunDouble_templatedStaticMethodInt_11(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -263,7 +259,7 @@ void FunDouble_templatedStaticMethodInt_11(int nargout, mxArray *out[], int narg
 void Test_collectorInsertAndMakeBase_12(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<Test> Shared;
+  typedef std::shared_ptr<Test> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_Test.insert(self);
@@ -272,7 +268,7 @@ void Test_collectorInsertAndMakeBase_12(int nargout, mxArray *out[], int nargin,
 void Test_constructor_13(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<Test> Shared;
+  typedef std::shared_ptr<Test> Shared;
 
   Shared *self = new Shared(new Test());
   collector_Test.insert(self);
@@ -283,7 +279,7 @@ void Test_constructor_13(int nargout, mxArray *out[], int nargin, const mxArray 
 void Test_constructor_14(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<Test> Shared;
+  typedef std::shared_ptr<Test> Shared;
 
   double a = unwrap< double >(in[0]);
   Matrix b = unwrap< Matrix >(in[1]);
@@ -295,7 +291,7 @@ void Test_constructor_14(int nargout, mxArray *out[], int nargin, const mxArray 
 
 void Test_deconstructor_15(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<Test> Shared;
+  typedef std::shared_ptr<Test> Shared;
   checkArguments("delete_Test",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_Test::iterator item;
@@ -319,7 +315,7 @@ void Test_create_MixedPtrs_17(int nargout, mxArray *out[], int nargin, const mxA
   checkArguments("create_MixedPtrs",nargout,nargin-1,0);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
   auto pairResult = obj->create_MixedPtrs();
-  out[0] = wrap_shared_ptr(boost::make_shared<Test>(pairResult.first),"Test", false);
+  out[0] = wrap_shared_ptr(std::make_shared<Test>(pairResult.first),"Test", false);
   out[1] = wrap_shared_ptr(pairResult.second,"Test", false);
 }
 
@@ -336,7 +332,7 @@ void Test_get_container_19(int nargout, mxArray *out[], int nargin, const mxArra
 {
   checkArguments("get_container",nargout,nargin-1,0);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
-  out[0] = wrap_shared_ptr(boost::make_shared<std::vector<testing::Test>>(obj->get_container()),"std.vectorTest", false);
+  out[0] = wrap_shared_ptr(std::make_shared<std::vector<testing::Test>>(obj->get_container()),"std.vectorTest", false);
 }
 
 void Test_lambda_20(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -374,7 +370,7 @@ void Test_return_Point2Ptr_24(int nargout, mxArray *out[], int nargin, const mxA
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
   bool value = unwrap< bool >(in[1]);
   {
-  boost::shared_ptr<Point2> shared(obj->return_Point2Ptr(value));
+  std::shared_ptr<Point2> shared(obj->return_Point2Ptr(value));
   out[0] = wrap_shared_ptr(shared,"Point2");
   }
 }
@@ -383,15 +379,15 @@ void Test_return_Test_25(int nargout, mxArray *out[], int nargin, const mxArray 
 {
   checkArguments("return_Test",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
-  boost::shared_ptr<Test> value = unwrap_shared_ptr< Test >(in[1], "ptr_Test");
-  out[0] = wrap_shared_ptr(boost::make_shared<Test>(obj->return_Test(value)),"Test", false);
+  std::shared_ptr<Test> value = unwrap_shared_ptr< Test >(in[1], "ptr_Test");
+  out[0] = wrap_shared_ptr(std::make_shared<Test>(obj->return_Test(value)),"Test", false);
 }
 
 void Test_return_TestPtr_26(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_TestPtr",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
-  boost::shared_ptr<Test> value = unwrap_shared_ptr< Test >(in[1], "ptr_Test");
+  std::shared_ptr<Test> value = unwrap_shared_ptr< Test >(in[1], "ptr_Test");
   out[0] = wrap_shared_ptr(obj->return_TestPtr(value),"Test", false);
 }
 
@@ -468,8 +464,8 @@ void Test_return_ptrs_35(int nargout, mxArray *out[], int nargin, const mxArray 
 {
   checkArguments("return_ptrs",nargout,nargin-1,2);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
-  boost::shared_ptr<Test> p1 = unwrap_shared_ptr< Test >(in[1], "ptr_Test");
-  boost::shared_ptr<Test> p2 = unwrap_shared_ptr< Test >(in[2], "ptr_Test");
+  std::shared_ptr<Test> p1 = unwrap_shared_ptr< Test >(in[1], "ptr_Test");
+  std::shared_ptr<Test> p2 = unwrap_shared_ptr< Test >(in[2], "ptr_Test");
   auto pairResult = obj->return_ptrs(p1,p2);
   out[0] = wrap_shared_ptr(pairResult.first,"Test", false);
   out[1] = wrap_shared_ptr(pairResult.second,"Test", false);
@@ -511,7 +507,7 @@ void Test_set_container_40(int nargout, mxArray *out[], int nargin, const mxArra
 {
   checkArguments("set_container",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
-  boost::shared_ptr<std::vector<testing::Test>> container = unwrap_shared_ptr< std::vector<testing::Test> >(in[1], "ptr_stdvectorTest");
+  std::shared_ptr<std::vector<testing::Test>> container = unwrap_shared_ptr< std::vector<testing::Test> >(in[1], "ptr_stdvectorTest");
   obj->set_container(*container);
 }
 
@@ -519,7 +515,7 @@ void Test_set_container_41(int nargout, mxArray *out[], int nargin, const mxArra
 {
   checkArguments("set_container",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
-  boost::shared_ptr<std::vector<testing::Test>> container = unwrap_shared_ptr< std::vector<testing::Test> >(in[1], "ptr_stdvectorTest");
+  std::shared_ptr<std::vector<testing::Test>> container = unwrap_shared_ptr< std::vector<testing::Test> >(in[1], "ptr_stdvectorTest");
   obj->set_container(*container);
 }
 
@@ -527,7 +523,7 @@ void Test_set_container_42(int nargout, mxArray *out[], int nargin, const mxArra
 {
   checkArguments("set_container",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
-  boost::shared_ptr<std::vector<testing::Test>> container = unwrap_shared_ptr< std::vector<testing::Test> >(in[1], "ptr_stdvectorTest");
+  std::shared_ptr<std::vector<testing::Test>> container = unwrap_shared_ptr< std::vector<testing::Test> >(in[1], "ptr_stdvectorTest");
   obj->set_container(*container);
 }
 
@@ -542,7 +538,7 @@ void Test_set_model_ptr_44(int nargout, mxArray *out[], int nargin, const mxArra
 {
   checkArguments("model_ptr",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
-  boost::shared_ptr<gtsam::noiseModel::Base> model_ptr = unwrap_shared_ptr< gtsam::noiseModel::Base >(in[1], "ptr_gtsamnoiseModelBase");
+  std::shared_ptr<gtsam::noiseModel::Base> model_ptr = unwrap_shared_ptr< gtsam::noiseModel::Base >(in[1], "ptr_gtsamnoiseModelBase");
   obj->model_ptr = *model_ptr;
 }
 
@@ -579,7 +575,7 @@ void Test_set_name_48(int nargout, mxArray *out[], int nargin, const mxArray *in
 void PrimitiveRefDouble_collectorInsertAndMakeBase_49(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<PrimitiveRef<double>> Shared;
+  typedef std::shared_ptr<PrimitiveRef<double>> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_PrimitiveRefDouble.insert(self);
@@ -588,7 +584,7 @@ void PrimitiveRefDouble_collectorInsertAndMakeBase_49(int nargout, mxArray *out[
 void PrimitiveRefDouble_constructor_50(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<PrimitiveRef<double>> Shared;
+  typedef std::shared_ptr<PrimitiveRef<double>> Shared;
 
   Shared *self = new Shared(new PrimitiveRef<double>());
   collector_PrimitiveRefDouble.insert(self);
@@ -598,7 +594,7 @@ void PrimitiveRefDouble_constructor_50(int nargout, mxArray *out[], int nargin, 
 
 void PrimitiveRefDouble_deconstructor_51(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<PrimitiveRef<double>> Shared;
+  typedef std::shared_ptr<PrimitiveRef<double>> Shared;
   checkArguments("delete_PrimitiveRefDouble",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_PrimitiveRefDouble::iterator item;
@@ -613,13 +609,13 @@ void PrimitiveRefDouble_Brutal_52(int nargout, mxArray *out[], int nargin, const
 {
   checkArguments("PrimitiveRef<double>.Brutal",nargout,nargin,1);
   double t = unwrap< double >(in[0]);
-  out[0] = wrap_shared_ptr(boost::make_shared<PrimitiveRef<double>>(PrimitiveRef<double>::Brutal(t)),"PrimitiveRefdouble", false);
+  out[0] = wrap_shared_ptr(std::make_shared<PrimitiveRef<double>>(PrimitiveRef<double>::Brutal(t)),"PrimitiveRefdouble", false);
 }
 
 void MyVector3_collectorInsertAndMakeBase_53(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<MyVector<3>> Shared;
+  typedef std::shared_ptr<MyVector<3>> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_MyVector3.insert(self);
@@ -628,7 +624,7 @@ void MyVector3_collectorInsertAndMakeBase_53(int nargout, mxArray *out[], int na
 void MyVector3_constructor_54(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<MyVector<3>> Shared;
+  typedef std::shared_ptr<MyVector<3>> Shared;
 
   Shared *self = new Shared(new MyVector<3>());
   collector_MyVector3.insert(self);
@@ -638,7 +634,7 @@ void MyVector3_constructor_54(int nargout, mxArray *out[], int nargin, const mxA
 
 void MyVector3_deconstructor_55(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<MyVector<3>> Shared;
+  typedef std::shared_ptr<MyVector<3>> Shared;
   checkArguments("delete_MyVector3",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_MyVector3::iterator item;
@@ -652,7 +648,7 @@ void MyVector3_deconstructor_55(int nargout, mxArray *out[], int nargin, const m
 void MyVector12_collectorInsertAndMakeBase_56(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<MyVector<12>> Shared;
+  typedef std::shared_ptr<MyVector<12>> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_MyVector12.insert(self);
@@ -661,7 +657,7 @@ void MyVector12_collectorInsertAndMakeBase_56(int nargout, mxArray *out[], int n
 void MyVector12_constructor_57(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<MyVector<12>> Shared;
+  typedef std::shared_ptr<MyVector<12>> Shared;
 
   Shared *self = new Shared(new MyVector<12>());
   collector_MyVector12.insert(self);
@@ -671,7 +667,7 @@ void MyVector12_constructor_57(int nargout, mxArray *out[], int nargin, const mx
 
 void MyVector12_deconstructor_58(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<MyVector<12>> Shared;
+  typedef std::shared_ptr<MyVector<12>> Shared;
   checkArguments("delete_MyVector12",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_MyVector12::iterator item;
@@ -685,7 +681,7 @@ void MyVector12_deconstructor_58(int nargout, mxArray *out[], int nargin, const 
 void MultipleTemplatesIntDouble_collectorInsertAndMakeBase_59(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<MultipleTemplates<int, double>> Shared;
+  typedef std::shared_ptr<MultipleTemplates<int, double>> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_MultipleTemplatesIntDouble.insert(self);
@@ -693,7 +689,7 @@ void MultipleTemplatesIntDouble_collectorInsertAndMakeBase_59(int nargout, mxArr
 
 void MultipleTemplatesIntDouble_deconstructor_60(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<MultipleTemplates<int, double>> Shared;
+  typedef std::shared_ptr<MultipleTemplates<int, double>> Shared;
   checkArguments("delete_MultipleTemplatesIntDouble",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_MultipleTemplatesIntDouble::iterator item;
@@ -707,7 +703,7 @@ void MultipleTemplatesIntDouble_deconstructor_60(int nargout, mxArray *out[], in
 void MultipleTemplatesIntFloat_collectorInsertAndMakeBase_61(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<MultipleTemplates<int, float>> Shared;
+  typedef std::shared_ptr<MultipleTemplates<int, float>> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_MultipleTemplatesIntFloat.insert(self);
@@ -715,7 +711,7 @@ void MultipleTemplatesIntFloat_collectorInsertAndMakeBase_61(int nargout, mxArra
 
 void MultipleTemplatesIntFloat_deconstructor_62(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<MultipleTemplates<int, float>> Shared;
+  typedef std::shared_ptr<MultipleTemplates<int, float>> Shared;
   checkArguments("delete_MultipleTemplatesIntFloat",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_MultipleTemplatesIntFloat::iterator item;
@@ -729,7 +725,7 @@ void MultipleTemplatesIntFloat_deconstructor_62(int nargout, mxArray *out[], int
 void ForwardKinematics_collectorInsertAndMakeBase_63(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<ForwardKinematics> Shared;
+  typedef std::shared_ptr<ForwardKinematics> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_ForwardKinematics.insert(self);
@@ -738,7 +734,7 @@ void ForwardKinematics_collectorInsertAndMakeBase_63(int nargout, mxArray *out[]
 void ForwardKinematics_constructor_64(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<ForwardKinematics> Shared;
+  typedef std::shared_ptr<ForwardKinematics> Shared;
 
   gtdynamics::Robot& robot = *unwrap_shared_ptr< gtdynamics::Robot >(in[0], "ptr_gtdynamicsRobot");
   string& start_link_name = *unwrap_shared_ptr< string >(in[1], "ptr_string");
@@ -754,7 +750,7 @@ void ForwardKinematics_constructor_64(int nargout, mxArray *out[], int nargin, c
 void ForwardKinematics_constructor_65(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<ForwardKinematics> Shared;
+  typedef std::shared_ptr<ForwardKinematics> Shared;
 
   gtdynamics::Robot& robot = *unwrap_shared_ptr< gtdynamics::Robot >(in[0], "ptr_gtdynamicsRobot");
   string& start_link_name = *unwrap_shared_ptr< string >(in[1], "ptr_string");
@@ -768,7 +764,7 @@ void ForwardKinematics_constructor_65(int nargout, mxArray *out[], int nargin, c
 
 void ForwardKinematics_deconstructor_66(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<ForwardKinematics> Shared;
+  typedef std::shared_ptr<ForwardKinematics> Shared;
   checkArguments("delete_ForwardKinematics",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_ForwardKinematics::iterator item;
@@ -782,7 +778,7 @@ void ForwardKinematics_deconstructor_66(int nargout, mxArray *out[], int nargin,
 void TemplatedConstructor_collectorInsertAndMakeBase_67(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<TemplatedConstructor> Shared;
+  typedef std::shared_ptr<TemplatedConstructor> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_TemplatedConstructor.insert(self);
@@ -791,7 +787,7 @@ void TemplatedConstructor_collectorInsertAndMakeBase_67(int nargout, mxArray *ou
 void TemplatedConstructor_constructor_68(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<TemplatedConstructor> Shared;
+  typedef std::shared_ptr<TemplatedConstructor> Shared;
 
   Shared *self = new Shared(new TemplatedConstructor());
   collector_TemplatedConstructor.insert(self);
@@ -802,7 +798,7 @@ void TemplatedConstructor_constructor_68(int nargout, mxArray *out[], int nargin
 void TemplatedConstructor_constructor_69(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<TemplatedConstructor> Shared;
+  typedef std::shared_ptr<TemplatedConstructor> Shared;
 
   string& arg = *unwrap_shared_ptr< string >(in[0], "ptr_string");
   Shared *self = new Shared(new TemplatedConstructor(arg));
@@ -814,7 +810,7 @@ void TemplatedConstructor_constructor_69(int nargout, mxArray *out[], int nargin
 void TemplatedConstructor_constructor_70(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<TemplatedConstructor> Shared;
+  typedef std::shared_ptr<TemplatedConstructor> Shared;
 
   int arg = unwrap< int >(in[0]);
   Shared *self = new Shared(new TemplatedConstructor(arg));
@@ -826,7 +822,7 @@ void TemplatedConstructor_constructor_70(int nargout, mxArray *out[], int nargin
 void TemplatedConstructor_constructor_71(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<TemplatedConstructor> Shared;
+  typedef std::shared_ptr<TemplatedConstructor> Shared;
 
   double arg = unwrap< double >(in[0]);
   Shared *self = new Shared(new TemplatedConstructor(arg));
@@ -837,7 +833,7 @@ void TemplatedConstructor_constructor_71(int nargout, mxArray *out[], int nargin
 
 void TemplatedConstructor_deconstructor_72(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<TemplatedConstructor> Shared;
+  typedef std::shared_ptr<TemplatedConstructor> Shared;
   checkArguments("delete_TemplatedConstructor",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_TemplatedConstructor::iterator item;
@@ -851,7 +847,7 @@ void TemplatedConstructor_deconstructor_72(int nargout, mxArray *out[], int narg
 void MyFactorPosePoint2_collectorInsertAndMakeBase_73(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>> Shared;
+  typedef std::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_MyFactorPosePoint2.insert(self);
@@ -860,12 +856,12 @@ void MyFactorPosePoint2_collectorInsertAndMakeBase_73(int nargout, mxArray *out[
 void MyFactorPosePoint2_constructor_74(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>> Shared;
+  typedef std::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>> Shared;
 
   size_t key1 = unwrap< size_t >(in[0]);
   size_t key2 = unwrap< size_t >(in[1]);
   double measured = unwrap< double >(in[2]);
-  boost::shared_ptr<gtsam::noiseModel::Base> noiseModel = unwrap_shared_ptr< gtsam::noiseModel::Base >(in[3], "ptr_gtsamnoiseModelBase");
+  std::shared_ptr<gtsam::noiseModel::Base> noiseModel = unwrap_shared_ptr< gtsam::noiseModel::Base >(in[3], "ptr_gtsamnoiseModelBase");
   Shared *self = new Shared(new MyFactor<gtsam::Pose2, gtsam::Matrix>(key1,key2,measured,noiseModel));
   collector_MyFactorPosePoint2.insert(self);
   out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
@@ -874,7 +870,7 @@ void MyFactorPosePoint2_constructor_74(int nargout, mxArray *out[], int nargin, 
 
 void MyFactorPosePoint2_deconstructor_75(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>> Shared;
+  typedef std::shared_ptr<MyFactor<gtsam::Pose2, gtsam::Matrix>> Shared;
   checkArguments("delete_MyFactorPosePoint2",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_MyFactorPosePoint2::iterator item;

--- a/tests/expected/matlab/functions_wrapper.cpp
+++ b/tests/expected/matlab/functions_wrapper.cpp
@@ -1,10 +1,6 @@
 #include <gtwrap/matlab.h>
 #include <map>
 
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
-#include <boost/serialization/export.hpp>
-
 
 
 
@@ -62,7 +58,7 @@ void load2D_0(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("load2D",nargout,nargin,5);
   string filename = unwrap< string >(in[0]);
-  boost::shared_ptr<Test> model = unwrap_shared_ptr< Test >(in[1], "ptr_Test");
+  std::shared_ptr<Test> model = unwrap_shared_ptr< Test >(in[1], "ptr_Test");
   int maxID = unwrap< int >(in[2]);
   bool addNoise = unwrap< bool >(in[3]);
   bool smart = unwrap< bool >(in[4]);
@@ -74,7 +70,7 @@ void load2D_1(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("load2D",nargout,nargin,5);
   string filename = unwrap< string >(in[0]);
-  boost::shared_ptr<gtsam::noiseModel::Diagonal> model = unwrap_shared_ptr< gtsam::noiseModel::Diagonal >(in[1], "ptr_gtsamnoiseModelDiagonal");
+  std::shared_ptr<gtsam::noiseModel::Diagonal> model = unwrap_shared_ptr< gtsam::noiseModel::Diagonal >(in[1], "ptr_gtsamnoiseModelDiagonal");
   int maxID = unwrap< int >(in[2]);
   bool addNoise = unwrap< bool >(in[3]);
   bool smart = unwrap< bool >(in[4]);

--- a/tests/expected/matlab/geometry_wrapper.cpp
+++ b/tests/expected/matlab/geometry_wrapper.cpp
@@ -12,9 +12,9 @@
 BOOST_CLASS_EXPORT_GUID(gtsam::Point2, "gtsamPoint2");
 BOOST_CLASS_EXPORT_GUID(gtsam::Point3, "gtsamPoint3");
 
-typedef std::set<boost::shared_ptr<gtsam::Point2>*> Collector_gtsamPoint2;
+typedef std::set<std::shared_ptr<gtsam::Point2>*> Collector_gtsamPoint2;
 static Collector_gtsamPoint2 collector_gtsamPoint2;
-typedef std::set<boost::shared_ptr<gtsam::Point3>*> Collector_gtsamPoint3;
+typedef std::set<std::shared_ptr<gtsam::Point3>*> Collector_gtsamPoint3;
 static Collector_gtsamPoint3 collector_gtsamPoint3;
 
 
@@ -80,7 +80,7 @@ void _geometry_RTTIRegister() {
 void gtsamPoint2_collectorInsertAndMakeBase_0(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<gtsam::Point2> Shared;
+  typedef std::shared_ptr<gtsam::Point2> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_gtsamPoint2.insert(self);
@@ -89,7 +89,7 @@ void gtsamPoint2_collectorInsertAndMakeBase_0(int nargout, mxArray *out[], int n
 void gtsamPoint2_constructor_1(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<gtsam::Point2> Shared;
+  typedef std::shared_ptr<gtsam::Point2> Shared;
 
   Shared *self = new Shared(new gtsam::Point2());
   collector_gtsamPoint2.insert(self);
@@ -100,7 +100,7 @@ void gtsamPoint2_constructor_1(int nargout, mxArray *out[], int nargin, const mx
 void gtsamPoint2_constructor_2(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<gtsam::Point2> Shared;
+  typedef std::shared_ptr<gtsam::Point2> Shared;
 
   double x = unwrap< double >(in[0]);
   double y = unwrap< double >(in[1]);
@@ -112,7 +112,7 @@ void gtsamPoint2_constructor_2(int nargout, mxArray *out[], int nargin, const mx
 
 void gtsamPoint2_deconstructor_3(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<gtsam::Point2> Shared;
+  typedef std::shared_ptr<gtsam::Point2> Shared;
   checkArguments("delete_gtsamPoint2",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_gtsamPoint2::iterator item;
@@ -135,7 +135,7 @@ void gtsamPoint2_argChar_5(int nargout, mxArray *out[], int nargin, const mxArra
 {
   checkArguments("argChar",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<gtsam::Point2>(in[0], "ptr_gtsamPoint2");
-  boost::shared_ptr<char> a = unwrap_shared_ptr< char >(in[1], "ptr_char");
+  std::shared_ptr<char> a = unwrap_shared_ptr< char >(in[1], "ptr_char");
   obj->argChar(a);
 }
 
@@ -159,7 +159,7 @@ void gtsamPoint2_argChar_8(int nargout, mxArray *out[], int nargin, const mxArra
 {
   checkArguments("argChar",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<gtsam::Point2>(in[0], "ptr_gtsamPoint2");
-  boost::shared_ptr<char> a = unwrap_shared_ptr< char >(in[1], "ptr_char");
+  std::shared_ptr<char> a = unwrap_shared_ptr< char >(in[1], "ptr_char");
   obj->argChar(a);
 }
 
@@ -214,7 +214,7 @@ void gtsamPoint2_vectorConfusion_15(int nargout, mxArray *out[], int nargin, con
 {
   checkArguments("vectorConfusion",nargout,nargin-1,0);
   auto obj = unwrap_shared_ptr<gtsam::Point2>(in[0], "ptr_gtsamPoint2");
-  out[0] = wrap_shared_ptr(boost::make_shared<VectorNotEigen>(obj->vectorConfusion()),"VectorNotEigen", false);
+  out[0] = wrap_shared_ptr(std::make_shared<VectorNotEigen>(obj->vectorConfusion()),"VectorNotEigen", false);
 }
 
 void gtsamPoint2_x_16(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -234,7 +234,7 @@ void gtsamPoint2_y_17(int nargout, mxArray *out[], int nargin, const mxArray *in
 void gtsamPoint3_collectorInsertAndMakeBase_18(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<gtsam::Point3> Shared;
+  typedef std::shared_ptr<gtsam::Point3> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_gtsamPoint3.insert(self);
@@ -243,7 +243,7 @@ void gtsamPoint3_collectorInsertAndMakeBase_18(int nargout, mxArray *out[], int 
 void gtsamPoint3_constructor_19(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<gtsam::Point3> Shared;
+  typedef std::shared_ptr<gtsam::Point3> Shared;
 
   double x = unwrap< double >(in[0]);
   double y = unwrap< double >(in[1]);
@@ -256,7 +256,7 @@ void gtsamPoint3_constructor_19(int nargout, mxArray *out[], int nargin, const m
 
 void gtsamPoint3_deconstructor_20(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<gtsam::Point3> Shared;
+  typedef std::shared_ptr<gtsam::Point3> Shared;
   checkArguments("delete_gtsamPoint3",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_gtsamPoint3::iterator item;
@@ -276,7 +276,7 @@ void gtsamPoint3_norm_21(int nargout, mxArray *out[], int nargin, const mxArray 
 
 void gtsamPoint3_string_serialize_22(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<gtsam::Point3> Shared;
+  typedef std::shared_ptr<gtsam::Point3> Shared;
   checkArguments("string_serialize",nargout,nargin-1,0);
   Shared obj = unwrap_shared_ptr<gtsam::Point3>(in[0], "ptr_gtsamPoint3");
   ostringstream out_archive_stream;
@@ -299,7 +299,7 @@ void gtsamPoint3_staticFunction_24(int nargout, mxArray *out[], int nargin, cons
 
 void gtsamPoint3_string_deserialize_25(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<gtsam::Point3> Shared;
+  typedef std::shared_ptr<gtsam::Point3> Shared;
   checkArguments("gtsamPoint3.string_deserialize",nargout,nargin,1);
   string serialized = unwrap< string >(in[0]);
   istringstream in_archive_stream(serialized);

--- a/tests/expected/matlab/inheritance_wrapper.cpp
+++ b/tests/expected/matlab/inheritance_wrapper.cpp
@@ -1,10 +1,6 @@
 #include <gtwrap/matlab.h>
 #include <map>
 
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
-#include <boost/serialization/export.hpp>
-
 
 
 typedef MyTemplate<gtsam::Point2> MyTemplatePoint2;
@@ -12,17 +8,17 @@ typedef MyTemplate<gtsam::Matrix> MyTemplateMatrix;
 typedef MyTemplate<A> MyTemplateA;
 typedef ParentHasTemplate<double> ParentHasTemplateDouble;
 
-typedef std::set<boost::shared_ptr<MyBase>*> Collector_MyBase;
+typedef std::set<std::shared_ptr<MyBase>*> Collector_MyBase;
 static Collector_MyBase collector_MyBase;
-typedef std::set<boost::shared_ptr<MyTemplatePoint2>*> Collector_MyTemplatePoint2;
+typedef std::set<std::shared_ptr<MyTemplatePoint2>*> Collector_MyTemplatePoint2;
 static Collector_MyTemplatePoint2 collector_MyTemplatePoint2;
-typedef std::set<boost::shared_ptr<MyTemplateMatrix>*> Collector_MyTemplateMatrix;
+typedef std::set<std::shared_ptr<MyTemplateMatrix>*> Collector_MyTemplateMatrix;
 static Collector_MyTemplateMatrix collector_MyTemplateMatrix;
-typedef std::set<boost::shared_ptr<MyTemplateA>*> Collector_MyTemplateA;
+typedef std::set<std::shared_ptr<MyTemplateA>*> Collector_MyTemplateA;
 static Collector_MyTemplateA collector_MyTemplateA;
-typedef std::set<boost::shared_ptr<ForwardKinematicsFactor>*> Collector_ForwardKinematicsFactor;
+typedef std::set<std::shared_ptr<ForwardKinematicsFactor>*> Collector_ForwardKinematicsFactor;
 static Collector_ForwardKinematicsFactor collector_ForwardKinematicsFactor;
-typedef std::set<boost::shared_ptr<ParentHasTemplateDouble>*> Collector_ParentHasTemplateDouble;
+typedef std::set<std::shared_ptr<ParentHasTemplateDouble>*> Collector_ParentHasTemplateDouble;
 static Collector_ParentHasTemplateDouble collector_ParentHasTemplateDouble;
 
 
@@ -118,7 +114,7 @@ void _inheritance_RTTIRegister() {
 void MyBase_collectorInsertAndMakeBase_0(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<MyBase> Shared;
+  typedef std::shared_ptr<MyBase> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_MyBase.insert(self);
@@ -126,16 +122,16 @@ void MyBase_collectorInsertAndMakeBase_0(int nargout, mxArray *out[], int nargin
 
 void MyBase_upcastFromVoid_1(int nargout, mxArray *out[], int nargin, const mxArray *in[]) {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<MyBase> Shared;
-  boost::shared_ptr<void> *asVoid = *reinterpret_cast<boost::shared_ptr<void>**> (mxGetData(in[0]));
+  typedef std::shared_ptr<MyBase> Shared;
+  std::shared_ptr<void> *asVoid = *reinterpret_cast<std::shared_ptr<void>**> (mxGetData(in[0]));
   out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
-  Shared *self = new Shared(boost::static_pointer_cast<MyBase>(*asVoid));
+  Shared *self = new Shared(std::static_pointer_cast<MyBase>(*asVoid));
   *reinterpret_cast<Shared**>(mxGetData(out[0])) = self;
 }
 
 void MyBase_deconstructor_2(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<MyBase> Shared;
+  typedef std::shared_ptr<MyBase> Shared;
   checkArguments("delete_MyBase",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_MyBase::iterator item;
@@ -149,43 +145,43 @@ void MyBase_deconstructor_2(int nargout, mxArray *out[], int nargin, const mxArr
 void MyTemplatePoint2_collectorInsertAndMakeBase_3(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<MyTemplate<gtsam::Point2>> Shared;
+  typedef std::shared_ptr<MyTemplate<gtsam::Point2>> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_MyTemplatePoint2.insert(self);
 
-  typedef boost::shared_ptr<MyBase> SharedBase;
+  typedef std::shared_ptr<MyBase> SharedBase;
   out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
   *reinterpret_cast<SharedBase**>(mxGetData(out[0])) = new SharedBase(*self);
 }
 
 void MyTemplatePoint2_upcastFromVoid_4(int nargout, mxArray *out[], int nargin, const mxArray *in[]) {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<MyTemplate<gtsam::Point2>> Shared;
-  boost::shared_ptr<void> *asVoid = *reinterpret_cast<boost::shared_ptr<void>**> (mxGetData(in[0]));
+  typedef std::shared_ptr<MyTemplate<gtsam::Point2>> Shared;
+  std::shared_ptr<void> *asVoid = *reinterpret_cast<std::shared_ptr<void>**> (mxGetData(in[0]));
   out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
-  Shared *self = new Shared(boost::static_pointer_cast<MyTemplate<gtsam::Point2>>(*asVoid));
+  Shared *self = new Shared(std::static_pointer_cast<MyTemplate<gtsam::Point2>>(*asVoid));
   *reinterpret_cast<Shared**>(mxGetData(out[0])) = self;
 }
 
 void MyTemplatePoint2_constructor_5(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<MyTemplate<gtsam::Point2>> Shared;
+  typedef std::shared_ptr<MyTemplate<gtsam::Point2>> Shared;
 
   Shared *self = new Shared(new MyTemplate<gtsam::Point2>());
   collector_MyTemplatePoint2.insert(self);
   out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 
-  typedef boost::shared_ptr<MyBase> SharedBase;
+  typedef std::shared_ptr<MyBase> SharedBase;
   out[1] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
   *reinterpret_cast<SharedBase**>(mxGetData(out[1])) = new SharedBase(*self);
 }
 
 void MyTemplatePoint2_deconstructor_6(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<MyTemplate<gtsam::Point2>> Shared;
+  typedef std::shared_ptr<MyTemplate<gtsam::Point2>> Shared;
   checkArguments("delete_MyTemplatePoint2",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_MyTemplatePoint2::iterator item;
@@ -219,7 +215,7 @@ void MyTemplatePoint2_create_MixedPtrs_9(int nargout, mxArray *out[], int nargin
   auto pairResult = obj->create_MixedPtrs();
   out[0] = wrap< Point2 >(pairResult.first);
   {
-  boost::shared_ptr<Point2> shared(pairResult.second);
+  std::shared_ptr<Point2> shared(pairResult.second);
   out[1] = wrap_shared_ptr(shared,"Point2");
   }
 }
@@ -230,11 +226,11 @@ void MyTemplatePoint2_create_ptrs_10(int nargout, mxArray *out[], int nargin, co
   auto obj = unwrap_shared_ptr<MyTemplate<gtsam::Point2>>(in[0], "ptr_MyTemplatePoint2");
   auto pairResult = obj->create_ptrs();
   {
-  boost::shared_ptr<Point2> shared(pairResult.first);
+  std::shared_ptr<Point2> shared(pairResult.first);
   out[0] = wrap_shared_ptr(shared,"Point2");
   }
   {
-  boost::shared_ptr<Point2> shared(pairResult.second);
+  std::shared_ptr<Point2> shared(pairResult.second);
   out[1] = wrap_shared_ptr(shared,"Point2");
   }
 }
@@ -253,7 +249,7 @@ void MyTemplatePoint2_return_Tptr_12(int nargout, mxArray *out[], int nargin, co
   auto obj = unwrap_shared_ptr<MyTemplate<gtsam::Point2>>(in[0], "ptr_MyTemplatePoint2");
   Point2 value = unwrap< Point2 >(in[1]);
   {
-  boost::shared_ptr<Point2> shared(obj->return_Tptr(value));
+  std::shared_ptr<Point2> shared(obj->return_Tptr(value));
   out[0] = wrap_shared_ptr(shared,"Point2");
   }
 }
@@ -266,11 +262,11 @@ void MyTemplatePoint2_return_ptrs_13(int nargout, mxArray *out[], int nargin, co
   Point2 p2 = unwrap< Point2 >(in[2]);
   auto pairResult = obj->return_ptrs(p1,p2);
   {
-  boost::shared_ptr<Point2> shared(pairResult.first);
+  std::shared_ptr<Point2> shared(pairResult.first);
   out[0] = wrap_shared_ptr(shared,"Point2");
   }
   {
-  boost::shared_ptr<Point2> shared(pairResult.second);
+  std::shared_ptr<Point2> shared(pairResult.second);
   out[1] = wrap_shared_ptr(shared,"Point2");
   }
 }
@@ -311,49 +307,49 @@ void MyTemplatePoint2_Level_18(int nargout, mxArray *out[], int nargin, const mx
 {
   checkArguments("MyTemplate<gtsam::Point2>.Level",nargout,nargin,1);
   Point2 K = unwrap< Point2 >(in[0]);
-  out[0] = wrap_shared_ptr(boost::make_shared<MyTemplate<Point2>>(MyTemplate<gtsam::Point2>::Level(K)),"MyTemplatePoint2", false);
+  out[0] = wrap_shared_ptr(std::make_shared<MyTemplate<Point2>>(MyTemplate<gtsam::Point2>::Level(K)),"MyTemplatePoint2", false);
 }
 
 void MyTemplateMatrix_collectorInsertAndMakeBase_19(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<MyTemplate<gtsam::Matrix>> Shared;
+  typedef std::shared_ptr<MyTemplate<gtsam::Matrix>> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_MyTemplateMatrix.insert(self);
 
-  typedef boost::shared_ptr<MyBase> SharedBase;
+  typedef std::shared_ptr<MyBase> SharedBase;
   out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
   *reinterpret_cast<SharedBase**>(mxGetData(out[0])) = new SharedBase(*self);
 }
 
 void MyTemplateMatrix_upcastFromVoid_20(int nargout, mxArray *out[], int nargin, const mxArray *in[]) {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<MyTemplate<gtsam::Matrix>> Shared;
-  boost::shared_ptr<void> *asVoid = *reinterpret_cast<boost::shared_ptr<void>**> (mxGetData(in[0]));
+  typedef std::shared_ptr<MyTemplate<gtsam::Matrix>> Shared;
+  std::shared_ptr<void> *asVoid = *reinterpret_cast<std::shared_ptr<void>**> (mxGetData(in[0]));
   out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
-  Shared *self = new Shared(boost::static_pointer_cast<MyTemplate<gtsam::Matrix>>(*asVoid));
+  Shared *self = new Shared(std::static_pointer_cast<MyTemplate<gtsam::Matrix>>(*asVoid));
   *reinterpret_cast<Shared**>(mxGetData(out[0])) = self;
 }
 
 void MyTemplateMatrix_constructor_21(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<MyTemplate<gtsam::Matrix>> Shared;
+  typedef std::shared_ptr<MyTemplate<gtsam::Matrix>> Shared;
 
   Shared *self = new Shared(new MyTemplate<gtsam::Matrix>());
   collector_MyTemplateMatrix.insert(self);
   out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 
-  typedef boost::shared_ptr<MyBase> SharedBase;
+  typedef std::shared_ptr<MyBase> SharedBase;
   out[1] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
   *reinterpret_cast<SharedBase**>(mxGetData(out[1])) = new SharedBase(*self);
 }
 
 void MyTemplateMatrix_deconstructor_22(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<MyTemplate<gtsam::Matrix>> Shared;
+  typedef std::shared_ptr<MyTemplate<gtsam::Matrix>> Shared;
   checkArguments("delete_MyTemplateMatrix",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_MyTemplateMatrix::iterator item;
@@ -387,7 +383,7 @@ void MyTemplateMatrix_create_MixedPtrs_25(int nargout, mxArray *out[], int nargi
   auto pairResult = obj->create_MixedPtrs();
   out[0] = wrap< Matrix >(pairResult.first);
   {
-  boost::shared_ptr<Matrix> shared(pairResult.second);
+  std::shared_ptr<Matrix> shared(pairResult.second);
   out[1] = wrap_shared_ptr(shared,"Matrix");
   }
 }
@@ -398,11 +394,11 @@ void MyTemplateMatrix_create_ptrs_26(int nargout, mxArray *out[], int nargin, co
   auto obj = unwrap_shared_ptr<MyTemplate<gtsam::Matrix>>(in[0], "ptr_MyTemplateMatrix");
   auto pairResult = obj->create_ptrs();
   {
-  boost::shared_ptr<Matrix> shared(pairResult.first);
+  std::shared_ptr<Matrix> shared(pairResult.first);
   out[0] = wrap_shared_ptr(shared,"Matrix");
   }
   {
-  boost::shared_ptr<Matrix> shared(pairResult.second);
+  std::shared_ptr<Matrix> shared(pairResult.second);
   out[1] = wrap_shared_ptr(shared,"Matrix");
   }
 }
@@ -421,7 +417,7 @@ void MyTemplateMatrix_return_Tptr_28(int nargout, mxArray *out[], int nargin, co
   auto obj = unwrap_shared_ptr<MyTemplate<gtsam::Matrix>>(in[0], "ptr_MyTemplateMatrix");
   Matrix value = unwrap< Matrix >(in[1]);
   {
-  boost::shared_ptr<Matrix> shared(obj->return_Tptr(value));
+  std::shared_ptr<Matrix> shared(obj->return_Tptr(value));
   out[0] = wrap_shared_ptr(shared,"Matrix");
   }
 }
@@ -434,11 +430,11 @@ void MyTemplateMatrix_return_ptrs_29(int nargout, mxArray *out[], int nargin, co
   Matrix p2 = unwrap< Matrix >(in[2]);
   auto pairResult = obj->return_ptrs(p1,p2);
   {
-  boost::shared_ptr<Matrix> shared(pairResult.first);
+  std::shared_ptr<Matrix> shared(pairResult.first);
   out[0] = wrap_shared_ptr(shared,"Matrix");
   }
   {
-  boost::shared_ptr<Matrix> shared(pairResult.second);
+  std::shared_ptr<Matrix> shared(pairResult.second);
   out[1] = wrap_shared_ptr(shared,"Matrix");
   }
 }
@@ -479,49 +475,49 @@ void MyTemplateMatrix_Level_34(int nargout, mxArray *out[], int nargin, const mx
 {
   checkArguments("MyTemplate<gtsam::Matrix>.Level",nargout,nargin,1);
   Matrix K = unwrap< Matrix >(in[0]);
-  out[0] = wrap_shared_ptr(boost::make_shared<MyTemplate<Matrix>>(MyTemplate<gtsam::Matrix>::Level(K)),"MyTemplateMatrix", false);
+  out[0] = wrap_shared_ptr(std::make_shared<MyTemplate<Matrix>>(MyTemplate<gtsam::Matrix>::Level(K)),"MyTemplateMatrix", false);
 }
 
 void MyTemplateA_collectorInsertAndMakeBase_35(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<MyTemplate<A>> Shared;
+  typedef std::shared_ptr<MyTemplate<A>> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_MyTemplateA.insert(self);
 
-  typedef boost::shared_ptr<MyBase> SharedBase;
+  typedef std::shared_ptr<MyBase> SharedBase;
   out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
   *reinterpret_cast<SharedBase**>(mxGetData(out[0])) = new SharedBase(*self);
 }
 
 void MyTemplateA_upcastFromVoid_36(int nargout, mxArray *out[], int nargin, const mxArray *in[]) {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<MyTemplate<A>> Shared;
-  boost::shared_ptr<void> *asVoid = *reinterpret_cast<boost::shared_ptr<void>**> (mxGetData(in[0]));
+  typedef std::shared_ptr<MyTemplate<A>> Shared;
+  std::shared_ptr<void> *asVoid = *reinterpret_cast<std::shared_ptr<void>**> (mxGetData(in[0]));
   out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
-  Shared *self = new Shared(boost::static_pointer_cast<MyTemplate<A>>(*asVoid));
+  Shared *self = new Shared(std::static_pointer_cast<MyTemplate<A>>(*asVoid));
   *reinterpret_cast<Shared**>(mxGetData(out[0])) = self;
 }
 
 void MyTemplateA_constructor_37(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<MyTemplate<A>> Shared;
+  typedef std::shared_ptr<MyTemplate<A>> Shared;
 
   Shared *self = new Shared(new MyTemplate<A>());
   collector_MyTemplateA.insert(self);
   out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
   *reinterpret_cast<Shared**> (mxGetData(out[0])) = self;
 
-  typedef boost::shared_ptr<MyBase> SharedBase;
+  typedef std::shared_ptr<MyBase> SharedBase;
   out[1] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
   *reinterpret_cast<SharedBase**>(mxGetData(out[1])) = new SharedBase(*self);
 }
 
 void MyTemplateA_deconstructor_38(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<MyTemplate<A>> Shared;
+  typedef std::shared_ptr<MyTemplate<A>> Shared;
   checkArguments("delete_MyTemplateA",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_MyTemplateA::iterator item;
@@ -544,7 +540,7 @@ void MyTemplateA_accept_Tptr_40(int nargout, mxArray *out[], int nargin, const m
 {
   checkArguments("accept_Tptr",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<MyTemplate<A>>(in[0], "ptr_MyTemplateA");
-  boost::shared_ptr<A> value = unwrap_shared_ptr< A >(in[1], "ptr_A");
+  std::shared_ptr<A> value = unwrap_shared_ptr< A >(in[1], "ptr_A");
   obj->accept_Tptr(value);
 }
 
@@ -553,7 +549,7 @@ void MyTemplateA_create_MixedPtrs_41(int nargout, mxArray *out[], int nargin, co
   checkArguments("create_MixedPtrs",nargout,nargin-1,0);
   auto obj = unwrap_shared_ptr<MyTemplate<A>>(in[0], "ptr_MyTemplateA");
   auto pairResult = obj->create_MixedPtrs();
-  out[0] = wrap_shared_ptr(boost::make_shared<A>(pairResult.first),"A", false);
+  out[0] = wrap_shared_ptr(std::make_shared<A>(pairResult.first),"A", false);
   out[1] = wrap_shared_ptr(pairResult.second,"A", false);
 }
 
@@ -571,14 +567,14 @@ void MyTemplateA_return_T_43(int nargout, mxArray *out[], int nargin, const mxAr
   checkArguments("return_T",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<MyTemplate<A>>(in[0], "ptr_MyTemplateA");
   A* value = unwrap_ptr< A >(in[1], "ptr_A");
-  out[0] = wrap_shared_ptr(boost::make_shared<A>(obj->return_T(value)),"A", false);
+  out[0] = wrap_shared_ptr(std::make_shared<A>(obj->return_T(value)),"A", false);
 }
 
 void MyTemplateA_return_Tptr_44(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("return_Tptr",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<MyTemplate<A>>(in[0], "ptr_MyTemplateA");
-  boost::shared_ptr<A> value = unwrap_shared_ptr< A >(in[1], "ptr_A");
+  std::shared_ptr<A> value = unwrap_shared_ptr< A >(in[1], "ptr_A");
   out[0] = wrap_shared_ptr(obj->return_Tptr(value),"A", false);
 }
 
@@ -586,8 +582,8 @@ void MyTemplateA_return_ptrs_45(int nargout, mxArray *out[], int nargin, const m
 {
   checkArguments("return_ptrs",nargout,nargin-1,2);
   auto obj = unwrap_shared_ptr<MyTemplate<A>>(in[0], "ptr_MyTemplateA");
-  boost::shared_ptr<A> p1 = unwrap_shared_ptr< A >(in[1], "ptr_A");
-  boost::shared_ptr<A> p2 = unwrap_shared_ptr< A >(in[2], "ptr_A");
+  std::shared_ptr<A> p1 = unwrap_shared_ptr< A >(in[1], "ptr_A");
+  std::shared_ptr<A> p2 = unwrap_shared_ptr< A >(in[2], "ptr_A");
   auto pairResult = obj->return_ptrs(p1,p2);
   out[0] = wrap_shared_ptr(pairResult.first,"A", false);
   out[1] = wrap_shared_ptr(pairResult.second,"A", false);
@@ -629,34 +625,34 @@ void MyTemplateA_Level_50(int nargout, mxArray *out[], int nargin, const mxArray
 {
   checkArguments("MyTemplate<A>.Level",nargout,nargin,1);
   A& K = *unwrap_shared_ptr< A >(in[0], "ptr_A");
-  out[0] = wrap_shared_ptr(boost::make_shared<MyTemplate<A>>(MyTemplate<A>::Level(K)),"MyTemplateA", false);
+  out[0] = wrap_shared_ptr(std::make_shared<MyTemplate<A>>(MyTemplate<A>::Level(K)),"MyTemplateA", false);
 }
 
 void ForwardKinematicsFactor_collectorInsertAndMakeBase_51(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<ForwardKinematicsFactor> Shared;
+  typedef std::shared_ptr<ForwardKinematicsFactor> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_ForwardKinematicsFactor.insert(self);
 
-  typedef boost::shared_ptr<gtsam::BetweenFactor<gtsam::Pose3>> SharedBase;
+  typedef std::shared_ptr<gtsam::BetweenFactor<gtsam::Pose3>> SharedBase;
   out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
   *reinterpret_cast<SharedBase**>(mxGetData(out[0])) = new SharedBase(*self);
 }
 
 void ForwardKinematicsFactor_upcastFromVoid_52(int nargout, mxArray *out[], int nargin, const mxArray *in[]) {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<ForwardKinematicsFactor> Shared;
-  boost::shared_ptr<void> *asVoid = *reinterpret_cast<boost::shared_ptr<void>**> (mxGetData(in[0]));
+  typedef std::shared_ptr<ForwardKinematicsFactor> Shared;
+  std::shared_ptr<void> *asVoid = *reinterpret_cast<std::shared_ptr<void>**> (mxGetData(in[0]));
   out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
-  Shared *self = new Shared(boost::static_pointer_cast<ForwardKinematicsFactor>(*asVoid));
+  Shared *self = new Shared(std::static_pointer_cast<ForwardKinematicsFactor>(*asVoid));
   *reinterpret_cast<Shared**>(mxGetData(out[0])) = self;
 }
 
 void ForwardKinematicsFactor_deconstructor_53(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<ForwardKinematicsFactor> Shared;
+  typedef std::shared_ptr<ForwardKinematicsFactor> Shared;
   checkArguments("delete_ForwardKinematicsFactor",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_ForwardKinematicsFactor::iterator item;
@@ -670,28 +666,28 @@ void ForwardKinematicsFactor_deconstructor_53(int nargout, mxArray *out[], int n
 void ParentHasTemplateDouble_collectorInsertAndMakeBase_54(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<ParentHasTemplate<double>> Shared;
+  typedef std::shared_ptr<ParentHasTemplate<double>> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_ParentHasTemplateDouble.insert(self);
 
-  typedef boost::shared_ptr<MyTemplate<double>> SharedBase;
+  typedef std::shared_ptr<MyTemplate<double>> SharedBase;
   out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
   *reinterpret_cast<SharedBase**>(mxGetData(out[0])) = new SharedBase(*self);
 }
 
 void ParentHasTemplateDouble_upcastFromVoid_55(int nargout, mxArray *out[], int nargin, const mxArray *in[]) {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<ParentHasTemplate<double>> Shared;
-  boost::shared_ptr<void> *asVoid = *reinterpret_cast<boost::shared_ptr<void>**> (mxGetData(in[0]));
+  typedef std::shared_ptr<ParentHasTemplate<double>> Shared;
+  std::shared_ptr<void> *asVoid = *reinterpret_cast<std::shared_ptr<void>**> (mxGetData(in[0]));
   out[0] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
-  Shared *self = new Shared(boost::static_pointer_cast<ParentHasTemplate<double>>(*asVoid));
+  Shared *self = new Shared(std::static_pointer_cast<ParentHasTemplate<double>>(*asVoid));
   *reinterpret_cast<Shared**>(mxGetData(out[0])) = self;
 }
 
 void ParentHasTemplateDouble_deconstructor_56(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<ParentHasTemplate<double>> Shared;
+  typedef std::shared_ptr<ParentHasTemplate<double>> Shared;
   checkArguments("delete_ParentHasTemplateDouble",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_ParentHasTemplateDouble::iterator item;

--- a/tests/expected/matlab/multiple_files_wrapper.cpp
+++ b/tests/expected/matlab/multiple_files_wrapper.cpp
@@ -1,19 +1,15 @@
 #include <gtwrap/matlab.h>
 #include <map>
 
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
-#include <boost/serialization/export.hpp>
 
 
 
 
-
-typedef std::set<boost::shared_ptr<gtsam::Class1>*> Collector_gtsamClass1;
+typedef std::set<std::shared_ptr<gtsam::Class1>*> Collector_gtsamClass1;
 static Collector_gtsamClass1 collector_gtsamClass1;
-typedef std::set<boost::shared_ptr<gtsam::Class2>*> Collector_gtsamClass2;
+typedef std::set<std::shared_ptr<gtsam::Class2>*> Collector_gtsamClass2;
 static Collector_gtsamClass2 collector_gtsamClass2;
-typedef std::set<boost::shared_ptr<gtsam::ClassA>*> Collector_gtsamClassA;
+typedef std::set<std::shared_ptr<gtsam::ClassA>*> Collector_gtsamClassA;
 static Collector_gtsamClassA collector_gtsamClassA;
 
 
@@ -85,7 +81,7 @@ void _multiple_files_RTTIRegister() {
 void gtsamClass1_collectorInsertAndMakeBase_0(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<gtsam::Class1> Shared;
+  typedef std::shared_ptr<gtsam::Class1> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_gtsamClass1.insert(self);
@@ -94,7 +90,7 @@ void gtsamClass1_collectorInsertAndMakeBase_0(int nargout, mxArray *out[], int n
 void gtsamClass1_constructor_1(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<gtsam::Class1> Shared;
+  typedef std::shared_ptr<gtsam::Class1> Shared;
 
   Shared *self = new Shared(new gtsam::Class1());
   collector_gtsamClass1.insert(self);
@@ -104,7 +100,7 @@ void gtsamClass1_constructor_1(int nargout, mxArray *out[], int nargin, const mx
 
 void gtsamClass1_deconstructor_2(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<gtsam::Class1> Shared;
+  typedef std::shared_ptr<gtsam::Class1> Shared;
   checkArguments("delete_gtsamClass1",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_gtsamClass1::iterator item;
@@ -118,7 +114,7 @@ void gtsamClass1_deconstructor_2(int nargout, mxArray *out[], int nargin, const 
 void gtsamClass2_collectorInsertAndMakeBase_3(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<gtsam::Class2> Shared;
+  typedef std::shared_ptr<gtsam::Class2> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_gtsamClass2.insert(self);
@@ -127,7 +123,7 @@ void gtsamClass2_collectorInsertAndMakeBase_3(int nargout, mxArray *out[], int n
 void gtsamClass2_constructor_4(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<gtsam::Class2> Shared;
+  typedef std::shared_ptr<gtsam::Class2> Shared;
 
   Shared *self = new Shared(new gtsam::Class2());
   collector_gtsamClass2.insert(self);
@@ -137,7 +133,7 @@ void gtsamClass2_constructor_4(int nargout, mxArray *out[], int nargin, const mx
 
 void gtsamClass2_deconstructor_5(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<gtsam::Class2> Shared;
+  typedef std::shared_ptr<gtsam::Class2> Shared;
   checkArguments("delete_gtsamClass2",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_gtsamClass2::iterator item;
@@ -151,7 +147,7 @@ void gtsamClass2_deconstructor_5(int nargout, mxArray *out[], int nargin, const 
 void gtsamClassA_collectorInsertAndMakeBase_6(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<gtsam::ClassA> Shared;
+  typedef std::shared_ptr<gtsam::ClassA> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_gtsamClassA.insert(self);
@@ -160,7 +156,7 @@ void gtsamClassA_collectorInsertAndMakeBase_6(int nargout, mxArray *out[], int n
 void gtsamClassA_constructor_7(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<gtsam::ClassA> Shared;
+  typedef std::shared_ptr<gtsam::ClassA> Shared;
 
   Shared *self = new Shared(new gtsam::ClassA());
   collector_gtsamClassA.insert(self);
@@ -170,7 +166,7 @@ void gtsamClassA_constructor_7(int nargout, mxArray *out[], int nargin, const mx
 
 void gtsamClassA_deconstructor_8(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<gtsam::ClassA> Shared;
+  typedef std::shared_ptr<gtsam::ClassA> Shared;
   checkArguments("delete_gtsamClassA",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_gtsamClassA::iterator item;

--- a/tests/expected/matlab/namespaces_wrapper.cpp
+++ b/tests/expected/matlab/namespaces_wrapper.cpp
@@ -1,10 +1,6 @@
 #include <gtwrap/matlab.h>
 #include <map>
 
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
-#include <boost/serialization/export.hpp>
-
 #include <gtsam/nonlinear/Values.h>
 #include <path/to/ns1.h>
 #include <path/to/ns1/ClassB.h>
@@ -14,19 +10,19 @@
 
 
 
-typedef std::set<boost::shared_ptr<ns1::ClassA>*> Collector_ns1ClassA;
+typedef std::set<std::shared_ptr<ns1::ClassA>*> Collector_ns1ClassA;
 static Collector_ns1ClassA collector_ns1ClassA;
-typedef std::set<boost::shared_ptr<ns1::ClassB>*> Collector_ns1ClassB;
+typedef std::set<std::shared_ptr<ns1::ClassB>*> Collector_ns1ClassB;
 static Collector_ns1ClassB collector_ns1ClassB;
-typedef std::set<boost::shared_ptr<ns2::ClassA>*> Collector_ns2ClassA;
+typedef std::set<std::shared_ptr<ns2::ClassA>*> Collector_ns2ClassA;
 static Collector_ns2ClassA collector_ns2ClassA;
-typedef std::set<boost::shared_ptr<ns2::ns3::ClassB>*> Collector_ns2ns3ClassB;
+typedef std::set<std::shared_ptr<ns2::ns3::ClassB>*> Collector_ns2ns3ClassB;
 static Collector_ns2ns3ClassB collector_ns2ns3ClassB;
-typedef std::set<boost::shared_ptr<ns2::ClassC>*> Collector_ns2ClassC;
+typedef std::set<std::shared_ptr<ns2::ClassC>*> Collector_ns2ClassC;
 static Collector_ns2ClassC collector_ns2ClassC;
-typedef std::set<boost::shared_ptr<ClassD>*> Collector_ClassD;
+typedef std::set<std::shared_ptr<ClassD>*> Collector_ClassD;
 static Collector_ClassD collector_ClassD;
-typedef std::set<boost::shared_ptr<gtsam::Values>*> Collector_gtsamValues;
+typedef std::set<std::shared_ptr<gtsam::Values>*> Collector_gtsamValues;
 static Collector_gtsamValues collector_gtsamValues;
 
 
@@ -122,7 +118,7 @@ void _namespaces_RTTIRegister() {
 void ns1ClassA_collectorInsertAndMakeBase_0(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<ns1::ClassA> Shared;
+  typedef std::shared_ptr<ns1::ClassA> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_ns1ClassA.insert(self);
@@ -131,7 +127,7 @@ void ns1ClassA_collectorInsertAndMakeBase_0(int nargout, mxArray *out[], int nar
 void ns1ClassA_constructor_1(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<ns1::ClassA> Shared;
+  typedef std::shared_ptr<ns1::ClassA> Shared;
 
   Shared *self = new Shared(new ns1::ClassA());
   collector_ns1ClassA.insert(self);
@@ -141,7 +137,7 @@ void ns1ClassA_constructor_1(int nargout, mxArray *out[], int nargin, const mxAr
 
 void ns1ClassA_deconstructor_2(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<ns1::ClassA> Shared;
+  typedef std::shared_ptr<ns1::ClassA> Shared;
   checkArguments("delete_ns1ClassA",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_ns1ClassA::iterator item;
@@ -155,7 +151,7 @@ void ns1ClassA_deconstructor_2(int nargout, mxArray *out[], int nargin, const mx
 void ns1ClassB_collectorInsertAndMakeBase_3(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<ns1::ClassB> Shared;
+  typedef std::shared_ptr<ns1::ClassB> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_ns1ClassB.insert(self);
@@ -164,7 +160,7 @@ void ns1ClassB_collectorInsertAndMakeBase_3(int nargout, mxArray *out[], int nar
 void ns1ClassB_constructor_4(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<ns1::ClassB> Shared;
+  typedef std::shared_ptr<ns1::ClassB> Shared;
 
   Shared *self = new Shared(new ns1::ClassB());
   collector_ns1ClassB.insert(self);
@@ -174,7 +170,7 @@ void ns1ClassB_constructor_4(int nargout, mxArray *out[], int nargin, const mxAr
 
 void ns1ClassB_deconstructor_5(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<ns1::ClassB> Shared;
+  typedef std::shared_ptr<ns1::ClassB> Shared;
   checkArguments("delete_ns1ClassB",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_ns1ClassB::iterator item;
@@ -193,7 +189,7 @@ void aGlobalFunction_6(int nargout, mxArray *out[], int nargin, const mxArray *i
 void ns2ClassA_collectorInsertAndMakeBase_7(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<ns2::ClassA> Shared;
+  typedef std::shared_ptr<ns2::ClassA> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_ns2ClassA.insert(self);
@@ -202,7 +198,7 @@ void ns2ClassA_collectorInsertAndMakeBase_7(int nargout, mxArray *out[], int nar
 void ns2ClassA_constructor_8(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<ns2::ClassA> Shared;
+  typedef std::shared_ptr<ns2::ClassA> Shared;
 
   Shared *self = new Shared(new ns2::ClassA());
   collector_ns2ClassA.insert(self);
@@ -212,7 +208,7 @@ void ns2ClassA_constructor_8(int nargout, mxArray *out[], int nargin, const mxAr
 
 void ns2ClassA_deconstructor_9(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<ns2::ClassA> Shared;
+  typedef std::shared_ptr<ns2::ClassA> Shared;
   checkArguments("delete_ns2ClassA",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_ns2ClassA::iterator item;
@@ -243,7 +239,7 @@ void ns2ClassA_nsReturn_12(int nargout, mxArray *out[], int nargin, const mxArra
   checkArguments("nsReturn",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<ns2::ClassA>(in[0], "ptr_ns2ClassA");
   double q = unwrap< double >(in[1]);
-  out[0] = wrap_shared_ptr(boost::make_shared<ns2::ns3::ClassB>(obj->nsReturn(q)),"ns2.ns3.ClassB", false);
+  out[0] = wrap_shared_ptr(std::make_shared<ns2::ns3::ClassB>(obj->nsReturn(q)),"ns2.ns3.ClassB", false);
 }
 
 void ns2ClassA_afunction_13(int nargout, mxArray *out[], int nargin, const mxArray *in[])
@@ -255,7 +251,7 @@ void ns2ClassA_afunction_13(int nargout, mxArray *out[], int nargin, const mxArr
 void ns2ns3ClassB_collectorInsertAndMakeBase_14(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<ns2::ns3::ClassB> Shared;
+  typedef std::shared_ptr<ns2::ns3::ClassB> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_ns2ns3ClassB.insert(self);
@@ -264,7 +260,7 @@ void ns2ns3ClassB_collectorInsertAndMakeBase_14(int nargout, mxArray *out[], int
 void ns2ns3ClassB_constructor_15(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<ns2::ns3::ClassB> Shared;
+  typedef std::shared_ptr<ns2::ns3::ClassB> Shared;
 
   Shared *self = new Shared(new ns2::ns3::ClassB());
   collector_ns2ns3ClassB.insert(self);
@@ -274,7 +270,7 @@ void ns2ns3ClassB_constructor_15(int nargout, mxArray *out[], int nargin, const 
 
 void ns2ns3ClassB_deconstructor_16(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<ns2::ns3::ClassB> Shared;
+  typedef std::shared_ptr<ns2::ns3::ClassB> Shared;
   checkArguments("delete_ns2ns3ClassB",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_ns2ns3ClassB::iterator item;
@@ -288,7 +284,7 @@ void ns2ns3ClassB_deconstructor_16(int nargout, mxArray *out[], int nargin, cons
 void ns2ClassC_collectorInsertAndMakeBase_17(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<ns2::ClassC> Shared;
+  typedef std::shared_ptr<ns2::ClassC> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_ns2ClassC.insert(self);
@@ -297,7 +293,7 @@ void ns2ClassC_collectorInsertAndMakeBase_17(int nargout, mxArray *out[], int na
 void ns2ClassC_constructor_18(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<ns2::ClassC> Shared;
+  typedef std::shared_ptr<ns2::ClassC> Shared;
 
   Shared *self = new Shared(new ns2::ClassC());
   collector_ns2ClassC.insert(self);
@@ -307,7 +303,7 @@ void ns2ClassC_constructor_18(int nargout, mxArray *out[], int nargin, const mxA
 
 void ns2ClassC_deconstructor_19(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<ns2::ClassC> Shared;
+  typedef std::shared_ptr<ns2::ClassC> Shared;
   checkArguments("delete_ns2ClassC",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_ns2ClassC::iterator item;
@@ -327,19 +323,19 @@ void overloadedGlobalFunction_21(int nargout, mxArray *out[], int nargin, const 
 {
   checkArguments("overloadedGlobalFunction",nargout,nargin,1);
   ns1::ClassA& a = *unwrap_shared_ptr< ns1::ClassA >(in[0], "ptr_ns1ClassA");
-  out[0] = wrap_shared_ptr(boost::make_shared<ns1::ClassA>(ns2::overloadedGlobalFunction(a)),"ns1.ClassA", false);
+  out[0] = wrap_shared_ptr(std::make_shared<ns1::ClassA>(ns2::overloadedGlobalFunction(a)),"ns1.ClassA", false);
 }
 void overloadedGlobalFunction_22(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("overloadedGlobalFunction",nargout,nargin,2);
   ns1::ClassA& a = *unwrap_shared_ptr< ns1::ClassA >(in[0], "ptr_ns1ClassA");
   double b = unwrap< double >(in[1]);
-  out[0] = wrap_shared_ptr(boost::make_shared<ns1::ClassA>(ns2::overloadedGlobalFunction(a,b)),"ns1.ClassA", false);
+  out[0] = wrap_shared_ptr(std::make_shared<ns1::ClassA>(ns2::overloadedGlobalFunction(a,b)),"ns1.ClassA", false);
 }
 void ClassD_collectorInsertAndMakeBase_23(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<ClassD> Shared;
+  typedef std::shared_ptr<ClassD> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_ClassD.insert(self);
@@ -348,7 +344,7 @@ void ClassD_collectorInsertAndMakeBase_23(int nargout, mxArray *out[], int nargi
 void ClassD_constructor_24(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<ClassD> Shared;
+  typedef std::shared_ptr<ClassD> Shared;
 
   Shared *self = new Shared(new ClassD());
   collector_ClassD.insert(self);
@@ -358,7 +354,7 @@ void ClassD_constructor_24(int nargout, mxArray *out[], int nargin, const mxArra
 
 void ClassD_deconstructor_25(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<ClassD> Shared;
+  typedef std::shared_ptr<ClassD> Shared;
   checkArguments("delete_ClassD",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_ClassD::iterator item;
@@ -372,7 +368,7 @@ void ClassD_deconstructor_25(int nargout, mxArray *out[], int nargin, const mxAr
 void gtsamValues_collectorInsertAndMakeBase_26(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<gtsam::Values> Shared;
+  typedef std::shared_ptr<gtsam::Values> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_gtsamValues.insert(self);
@@ -381,7 +377,7 @@ void gtsamValues_collectorInsertAndMakeBase_26(int nargout, mxArray *out[], int 
 void gtsamValues_constructor_27(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<gtsam::Values> Shared;
+  typedef std::shared_ptr<gtsam::Values> Shared;
 
   Shared *self = new Shared(new gtsam::Values());
   collector_gtsamValues.insert(self);
@@ -392,7 +388,7 @@ void gtsamValues_constructor_27(int nargout, mxArray *out[], int nargin, const m
 void gtsamValues_constructor_28(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<gtsam::Values> Shared;
+  typedef std::shared_ptr<gtsam::Values> Shared;
 
   gtsam::Values& other = *unwrap_shared_ptr< gtsam::Values >(in[0], "ptr_gtsamValues");
   Shared *self = new Shared(new gtsam::Values(other));
@@ -403,7 +399,7 @@ void gtsamValues_constructor_28(int nargout, mxArray *out[], int nargin, const m
 
 void gtsamValues_deconstructor_29(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<gtsam::Values> Shared;
+  typedef std::shared_ptr<gtsam::Values> Shared;
   checkArguments("delete_gtsamValues",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_gtsamValues::iterator item;

--- a/tests/expected/matlab/special_cases_wrapper.cpp
+++ b/tests/expected/matlab/special_cases_wrapper.cpp
@@ -1,22 +1,18 @@
 #include <gtwrap/matlab.h>
 #include <map>
 
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
-#include <boost/serialization/export.hpp>
-
 #include <gtsam/geometry/Cal3Bundler.h>
 
 typedef gtsam::PinholeCamera<gtsam::Cal3Bundler> PinholeCameraCal3Bundler;
 typedef gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3> GeneralSFMFactorCal3Bundler;
 
-typedef std::set<boost::shared_ptr<gtsam::NonlinearFactorGraph>*> Collector_gtsamNonlinearFactorGraph;
+typedef std::set<std::shared_ptr<gtsam::NonlinearFactorGraph>*> Collector_gtsamNonlinearFactorGraph;
 static Collector_gtsamNonlinearFactorGraph collector_gtsamNonlinearFactorGraph;
-typedef std::set<boost::shared_ptr<gtsam::SfmTrack>*> Collector_gtsamSfmTrack;
+typedef std::set<std::shared_ptr<gtsam::SfmTrack>*> Collector_gtsamSfmTrack;
 static Collector_gtsamSfmTrack collector_gtsamSfmTrack;
-typedef std::set<boost::shared_ptr<PinholeCameraCal3Bundler>*> Collector_gtsamPinholeCameraCal3Bundler;
+typedef std::set<std::shared_ptr<PinholeCameraCal3Bundler>*> Collector_gtsamPinholeCameraCal3Bundler;
 static Collector_gtsamPinholeCameraCal3Bundler collector_gtsamPinholeCameraCal3Bundler;
-typedef std::set<boost::shared_ptr<GeneralSFMFactorCal3Bundler>*> Collector_gtsamGeneralSFMFactorCal3Bundler;
+typedef std::set<std::shared_ptr<GeneralSFMFactorCal3Bundler>*> Collector_gtsamGeneralSFMFactorCal3Bundler;
 static Collector_gtsamGeneralSFMFactorCal3Bundler collector_gtsamGeneralSFMFactorCal3Bundler;
 
 
@@ -94,7 +90,7 @@ void _special_cases_RTTIRegister() {
 void gtsamNonlinearFactorGraph_collectorInsertAndMakeBase_0(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<gtsam::NonlinearFactorGraph> Shared;
+  typedef std::shared_ptr<gtsam::NonlinearFactorGraph> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_gtsamNonlinearFactorGraph.insert(self);
@@ -102,7 +98,7 @@ void gtsamNonlinearFactorGraph_collectorInsertAndMakeBase_0(int nargout, mxArray
 
 void gtsamNonlinearFactorGraph_deconstructor_1(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<gtsam::NonlinearFactorGraph> Shared;
+  typedef std::shared_ptr<gtsam::NonlinearFactorGraph> Shared;
   checkArguments("delete_gtsamNonlinearFactorGraph",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_gtsamNonlinearFactorGraph::iterator item;
@@ -119,14 +115,14 @@ void gtsamNonlinearFactorGraph_addPrior_2(int nargout, mxArray *out[], int nargi
   auto obj = unwrap_shared_ptr<gtsam::NonlinearFactorGraph>(in[0], "ptr_gtsamNonlinearFactorGraph");
   size_t key = unwrap< size_t >(in[1]);
   gtsam::PinholeCamera<gtsam::Cal3Bundler>& prior = *unwrap_shared_ptr< gtsam::PinholeCamera<gtsam::Cal3Bundler> >(in[2], "ptr_gtsamPinholeCameraCal3Bundler");
-  boost::shared_ptr<gtsam::noiseModel::Base> noiseModel = unwrap_shared_ptr< gtsam::noiseModel::Base >(in[3], "ptr_gtsamnoiseModelBase");
+  std::shared_ptr<gtsam::noiseModel::Base> noiseModel = unwrap_shared_ptr< gtsam::noiseModel::Base >(in[3], "ptr_gtsamnoiseModelBase");
   obj->addPrior<gtsam::PinholeCamera<gtsam::Cal3Bundler>>(key,prior,noiseModel);
 }
 
 void gtsamSfmTrack_collectorInsertAndMakeBase_3(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<gtsam::SfmTrack> Shared;
+  typedef std::shared_ptr<gtsam::SfmTrack> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_gtsamSfmTrack.insert(self);
@@ -134,7 +130,7 @@ void gtsamSfmTrack_collectorInsertAndMakeBase_3(int nargout, mxArray *out[], int
 
 void gtsamSfmTrack_deconstructor_4(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<gtsam::SfmTrack> Shared;
+  typedef std::shared_ptr<gtsam::SfmTrack> Shared;
   checkArguments("delete_gtsamSfmTrack",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_gtsamSfmTrack::iterator item;
@@ -149,21 +145,21 @@ void gtsamSfmTrack_get_measurements_5(int nargout, mxArray *out[], int nargin, c
 {
   checkArguments("measurements",nargout,nargin-1,0);
   auto obj = unwrap_shared_ptr<gtsam::SfmTrack>(in[0], "ptr_gtsamSfmTrack");
-  out[0] = wrap_shared_ptr(boost::make_shared<std::vector<std::pair<size_t,Point2>>>(obj->measurements),"std.vectorpairsize_tPoint2", false);
+  out[0] = wrap_shared_ptr(std::make_shared<std::vector<std::pair<size_t,Point2>>>(obj->measurements),"std.vectorpairsize_tPoint2", false);
 }
 
 void gtsamSfmTrack_set_measurements_6(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("measurements",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<gtsam::SfmTrack>(in[0], "ptr_gtsamSfmTrack");
-  boost::shared_ptr<std::vector<std::pair<size_t,Point2>>> measurements = unwrap_shared_ptr< std::vector<std::pair<size_t,Point2>> >(in[1], "ptr_stdvectorpairsize_tPoint2");
+  std::shared_ptr<std::vector<std::pair<size_t,Point2>>> measurements = unwrap_shared_ptr< std::vector<std::pair<size_t,Point2>> >(in[1], "ptr_stdvectorpairsize_tPoint2");
   obj->measurements = *measurements;
 }
 
 void gtsamPinholeCameraCal3Bundler_collectorInsertAndMakeBase_7(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<gtsam::PinholeCamera<gtsam::Cal3Bundler>> Shared;
+  typedef std::shared_ptr<gtsam::PinholeCamera<gtsam::Cal3Bundler>> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_gtsamPinholeCameraCal3Bundler.insert(self);
@@ -171,7 +167,7 @@ void gtsamPinholeCameraCal3Bundler_collectorInsertAndMakeBase_7(int nargout, mxA
 
 void gtsamPinholeCameraCal3Bundler_deconstructor_8(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<gtsam::PinholeCamera<gtsam::Cal3Bundler>> Shared;
+  typedef std::shared_ptr<gtsam::PinholeCamera<gtsam::Cal3Bundler>> Shared;
   checkArguments("delete_gtsamPinholeCameraCal3Bundler",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_gtsamPinholeCameraCal3Bundler::iterator item;
@@ -185,7 +181,7 @@ void gtsamPinholeCameraCal3Bundler_deconstructor_8(int nargout, mxArray *out[], 
 void gtsamGeneralSFMFactorCal3Bundler_collectorInsertAndMakeBase_9(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>> Shared;
+  typedef std::shared_ptr<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_gtsamGeneralSFMFactorCal3Bundler.insert(self);
@@ -193,7 +189,7 @@ void gtsamGeneralSFMFactorCal3Bundler_collectorInsertAndMakeBase_9(int nargout, 
 
 void gtsamGeneralSFMFactorCal3Bundler_deconstructor_10(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>> Shared;
+  typedef std::shared_ptr<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>> Shared;
   checkArguments("delete_gtsamGeneralSFMFactorCal3Bundler",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_gtsamGeneralSFMFactorCal3Bundler::iterator item;
@@ -208,14 +204,14 @@ void gtsamGeneralSFMFactorCal3Bundler_get_verbosity_11(int nargout, mxArray *out
 {
   checkArguments("verbosity",nargout,nargin-1,0);
   auto obj = unwrap_shared_ptr<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>>(in[0], "ptr_gtsamGeneralSFMFactorCal3Bundler");
-  out[0] = wrap_shared_ptr(boost::make_shared<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>::Verbosity>(obj->verbosity),"gtsam.GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>.Verbosity", false);
+  out[0] = wrap_shared_ptr(std::make_shared<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>::Verbosity>(obj->verbosity),"gtsam.GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>.Verbosity", false);
 }
 
 void gtsamGeneralSFMFactorCal3Bundler_set_verbosity_12(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("verbosity",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>>(in[0], "ptr_gtsamGeneralSFMFactorCal3Bundler");
-  boost::shared_ptr<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>::Verbosity> verbosity = unwrap_shared_ptr< gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>::Verbosity >(in[1], "ptr_gtsamGeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>Verbosity");
+  std::shared_ptr<gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>::Verbosity> verbosity = unwrap_shared_ptr< gtsam::GeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>::Verbosity >(in[1], "ptr_gtsamGeneralSFMFactor<gtsam::PinholeCamera<gtsam::Cal3Bundler>, gtsam::Point3>Verbosity");
   obj->verbosity = *verbosity;
 }
 

--- a/tests/expected/matlab/template_wrapper.cpp
+++ b/tests/expected/matlab/template_wrapper.cpp
@@ -1,17 +1,13 @@
 #include <gtwrap/matlab.h>
 #include <map>
 
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
-#include <boost/serialization/export.hpp>
-
 
 
 typedef ScopedTemplate<Result> ScopedTemplateResult;
 
-typedef std::set<boost::shared_ptr<TemplatedConstructor>*> Collector_TemplatedConstructor;
+typedef std::set<std::shared_ptr<TemplatedConstructor>*> Collector_TemplatedConstructor;
 static Collector_TemplatedConstructor collector_TemplatedConstructor;
-typedef std::set<boost::shared_ptr<ScopedTemplateResult>*> Collector_ScopedTemplateResult;
+typedef std::set<std::shared_ptr<ScopedTemplateResult>*> Collector_ScopedTemplateResult;
 static Collector_ScopedTemplateResult collector_ScopedTemplateResult;
 
 
@@ -77,7 +73,7 @@ void _template_RTTIRegister() {
 void TemplatedConstructor_collectorInsertAndMakeBase_0(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<TemplatedConstructor> Shared;
+  typedef std::shared_ptr<TemplatedConstructor> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_TemplatedConstructor.insert(self);
@@ -86,7 +82,7 @@ void TemplatedConstructor_collectorInsertAndMakeBase_0(int nargout, mxArray *out
 void TemplatedConstructor_constructor_1(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<TemplatedConstructor> Shared;
+  typedef std::shared_ptr<TemplatedConstructor> Shared;
 
   Shared *self = new Shared(new TemplatedConstructor());
   collector_TemplatedConstructor.insert(self);
@@ -97,7 +93,7 @@ void TemplatedConstructor_constructor_1(int nargout, mxArray *out[], int nargin,
 void TemplatedConstructor_constructor_2(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<TemplatedConstructor> Shared;
+  typedef std::shared_ptr<TemplatedConstructor> Shared;
 
   string& arg = *unwrap_shared_ptr< string >(in[0], "ptr_string");
   Shared *self = new Shared(new TemplatedConstructor(arg));
@@ -109,7 +105,7 @@ void TemplatedConstructor_constructor_2(int nargout, mxArray *out[], int nargin,
 void TemplatedConstructor_constructor_3(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<TemplatedConstructor> Shared;
+  typedef std::shared_ptr<TemplatedConstructor> Shared;
 
   int arg = unwrap< int >(in[0]);
   Shared *self = new Shared(new TemplatedConstructor(arg));
@@ -121,7 +117,7 @@ void TemplatedConstructor_constructor_3(int nargout, mxArray *out[], int nargin,
 void TemplatedConstructor_constructor_4(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<TemplatedConstructor> Shared;
+  typedef std::shared_ptr<TemplatedConstructor> Shared;
 
   double arg = unwrap< double >(in[0]);
   Shared *self = new Shared(new TemplatedConstructor(arg));
@@ -132,7 +128,7 @@ void TemplatedConstructor_constructor_4(int nargout, mxArray *out[], int nargin,
 
 void TemplatedConstructor_deconstructor_5(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<TemplatedConstructor> Shared;
+  typedef std::shared_ptr<TemplatedConstructor> Shared;
   checkArguments("delete_TemplatedConstructor",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_TemplatedConstructor::iterator item;
@@ -146,7 +142,7 @@ void TemplatedConstructor_deconstructor_5(int nargout, mxArray *out[], int nargi
 void ScopedTemplateResult_collectorInsertAndMakeBase_6(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<ScopedTemplate<Result>> Shared;
+  typedef std::shared_ptr<ScopedTemplate<Result>> Shared;
 
   Shared *self = *reinterpret_cast<Shared**> (mxGetData(in[0]));
   collector_ScopedTemplateResult.insert(self);
@@ -155,7 +151,7 @@ void ScopedTemplateResult_collectorInsertAndMakeBase_6(int nargout, mxArray *out
 void ScopedTemplateResult_constructor_7(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   mexAtExit(&_deleteAllObjects);
-  typedef boost::shared_ptr<ScopedTemplate<Result>> Shared;
+  typedef std::shared_ptr<ScopedTemplate<Result>> Shared;
 
   Result::Value& arg = *unwrap_shared_ptr< Result::Value >(in[0], "ptr_Result::Value");
   Shared *self = new Shared(new ScopedTemplate<Result>(arg));
@@ -166,7 +162,7 @@ void ScopedTemplateResult_constructor_7(int nargout, mxArray *out[], int nargin,
 
 void ScopedTemplateResult_deconstructor_8(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
-  typedef boost::shared_ptr<ScopedTemplate<Result>> Shared;
+  typedef std::shared_ptr<ScopedTemplate<Result>> Shared;
   checkArguments("delete_ScopedTemplateResult",nargout,nargin,1);
   Shared *self = *reinterpret_cast<Shared**>(mxGetData(in[0]));
   Collector_ScopedTemplateResult::iterator item;

--- a/tests/expected/python/class_pybind.cpp
+++ b/tests/expected/python/class_pybind.cpp
@@ -1,5 +1,3 @@
-
-
 #include <pybind11/eigen.h>
 #include <pybind11/stl_bind.h>
 #include <pybind11/pybind11.h>
@@ -10,8 +8,6 @@
 
 #include "wrap/serialization.h"
 #include <boost/serialization/export.hpp>
-
-
 
 
 

--- a/tests/expected/python/class_pybind.cpp
+++ b/tests/expected/python/class_pybind.cpp
@@ -6,8 +6,6 @@
 
 #include "folder/path/to/Test.h"
 
-#include "wrap/serialization.h"
-#include <boost/serialization/export.hpp>
 
 
 

--- a/tests/expected/python/enum_pybind.cpp
+++ b/tests/expected/python/enum_pybind.cpp
@@ -5,8 +5,6 @@
 #include "gtsam/nonlinear/utilities.h"  // for RedirectCout.
 
 
-#include "wrap/serialization.h"
-#include <boost/serialization/export.hpp>
 
 
 

--- a/tests/expected/python/enum_pybind.cpp
+++ b/tests/expected/python/enum_pybind.cpp
@@ -1,5 +1,3 @@
-
-
 #include <pybind11/eigen.h>
 #include <pybind11/stl_bind.h>
 #include <pybind11/pybind11.h>
@@ -9,8 +7,6 @@
 
 #include "wrap/serialization.h"
 #include <boost/serialization/export.hpp>
-
-
 
 
 

--- a/tests/expected/python/functions_pybind.cpp
+++ b/tests/expected/python/functions_pybind.cpp
@@ -5,8 +5,6 @@
 #include "gtsam/nonlinear/utilities.h"  // for RedirectCout.
 
 
-#include "wrap/serialization.h"
-#include <boost/serialization/export.hpp>
 
 
 

--- a/tests/expected/python/functions_pybind.cpp
+++ b/tests/expected/python/functions_pybind.cpp
@@ -1,5 +1,3 @@
-
-
 #include <pybind11/eigen.h>
 #include <pybind11/stl_bind.h>
 #include <pybind11/pybind11.h>
@@ -9,8 +7,6 @@
 
 #include "wrap/serialization.h"
 #include <boost/serialization/export.hpp>
-
-
 
 
 

--- a/tests/expected/python/geometry_pybind.cpp
+++ b/tests/expected/python/geometry_pybind.cpp
@@ -1,5 +1,3 @@
-
-
 #include <pybind11/eigen.h>
 #include <pybind11/stl_bind.h>
 #include <pybind11/pybind11.h>
@@ -14,8 +12,6 @@
 
 BOOST_CLASS_EXPORT(gtsam::Point2)
 BOOST_CLASS_EXPORT(gtsam::Point3)
-
-
 
 
 using namespace std;

--- a/tests/expected/python/geometry_pybind.cpp
+++ b/tests/expected/python/geometry_pybind.cpp
@@ -6,8 +6,6 @@
 
 #include "gtsam/geometry/Point2.h"
 #include "gtsam/geometry/Point3.h"
-
-#include "wrap/serialization.h"
 #include <boost/serialization/export.hpp>
 
 BOOST_CLASS_EXPORT(gtsam::Point2)

--- a/tests/expected/python/inheritance_pybind.cpp
+++ b/tests/expected/python/inheritance_pybind.cpp
@@ -5,8 +5,6 @@
 #include "gtsam/nonlinear/utilities.h"  // for RedirectCout.
 
 
-#include "wrap/serialization.h"
-#include <boost/serialization/export.hpp>
 
 
 

--- a/tests/expected/python/inheritance_pybind.cpp
+++ b/tests/expected/python/inheritance_pybind.cpp
@@ -1,5 +1,3 @@
-
-
 #include <pybind11/eigen.h>
 #include <pybind11/stl_bind.h>
 #include <pybind11/pybind11.h>
@@ -9,8 +7,6 @@
 
 #include "wrap/serialization.h"
 #include <boost/serialization/export.hpp>
-
-
 
 
 

--- a/tests/expected/python/namespaces_pybind.cpp
+++ b/tests/expected/python/namespaces_pybind.cpp
@@ -11,8 +11,6 @@
 #include "path/to/ns3.h"
 #include "gtsam/nonlinear/Values.h"
 
-#include "wrap/serialization.h"
-#include <boost/serialization/export.hpp>
 
 
 

--- a/tests/expected/python/namespaces_pybind.cpp
+++ b/tests/expected/python/namespaces_pybind.cpp
@@ -1,5 +1,3 @@
-
-
 #include <pybind11/eigen.h>
 #include <pybind11/stl_bind.h>
 #include <pybind11/pybind11.h>
@@ -15,8 +13,6 @@
 
 #include "wrap/serialization.h"
 #include <boost/serialization/export.hpp>
-
-
 
 
 

--- a/tests/expected/python/operator_pybind.cpp
+++ b/tests/expected/python/operator_pybind.cpp
@@ -1,5 +1,3 @@
-
-
 #include <pybind11/eigen.h>
 #include <pybind11/stl_bind.h>
 #include <pybind11/pybind11.h>
@@ -10,8 +8,6 @@
 
 #include "wrap/serialization.h"
 #include <boost/serialization/export.hpp>
-
-
 
 
 

--- a/tests/expected/python/operator_pybind.cpp
+++ b/tests/expected/python/operator_pybind.cpp
@@ -6,8 +6,6 @@
 
 #include "gtsam/geometry/Pose3.h"
 
-#include "wrap/serialization.h"
-#include <boost/serialization/export.hpp>
 
 
 

--- a/tests/expected/python/special_cases_pybind.cpp
+++ b/tests/expected/python/special_cases_pybind.cpp
@@ -1,5 +1,3 @@
-
-
 #include <pybind11/eigen.h>
 #include <pybind11/stl_bind.h>
 #include <pybind11/pybind11.h>
@@ -10,8 +8,6 @@
 
 #include "wrap/serialization.h"
 #include <boost/serialization/export.hpp>
-
-
 
 
 

--- a/tests/expected/python/special_cases_pybind.cpp
+++ b/tests/expected/python/special_cases_pybind.cpp
@@ -6,8 +6,6 @@
 
 #include "gtsam/geometry/Cal3Bundler.h"
 
-#include "wrap/serialization.h"
-#include <boost/serialization/export.hpp>
 
 
 

--- a/tests/expected/python/templates_pybind.cpp
+++ b/tests/expected/python/templates_pybind.cpp
@@ -5,8 +5,6 @@
 #include "gtsam/nonlinear/utilities.h"  // for RedirectCout.
 
 
-#include "wrap/serialization.h"
-#include <boost/serialization/export.hpp>
 
 
 

--- a/tests/expected/python/templates_pybind.cpp
+++ b/tests/expected/python/templates_pybind.cpp
@@ -1,5 +1,3 @@
-
-
 #include <pybind11/eigen.h>
 #include <pybind11/stl_bind.h>
 #include <pybind11/pybind11.h>
@@ -9,8 +7,6 @@
 
 #include "wrap/serialization.h"
 #include <boost/serialization/export.hpp>
-
-
 
 
 

--- a/tests/fixtures/class.i
+++ b/tests/fixtures/class.i
@@ -3,6 +3,8 @@ class FunRange {
   This range(double d);
 
   static This create();
+
+  void serialize() const;
 };
 
 template<M={double}>

--- a/tests/pybind_wrapper.tpl
+++ b/tests/pybind_wrapper.tpl
@@ -1,5 +1,3 @@
-{include_boost}
-
 #include <pybind11/eigen.h>
 #include <pybind11/stl_bind.h>
 #include <pybind11/pybind11.h>
@@ -11,8 +9,6 @@
 #include <boost/serialization/export.hpp>
 
 {boost_class_export}
-
-{holder_type}
 
 using namespace std;
 

--- a/tests/pybind_wrapper.tpl
+++ b/tests/pybind_wrapper.tpl
@@ -5,8 +5,6 @@
 #include "gtsam/nonlinear/utilities.h"  // for RedirectCout.
 
 {includes}
-#include "wrap/serialization.h"
-#include <boost/serialization/export.hpp>
 
 {boost_class_export}
 

--- a/tests/test_interface_parser.py
+++ b/tests/test_interface_parser.py
@@ -25,12 +25,12 @@ from gtwrap.interface_parser import (ArgumentList, Class, Constructor, Enum,
                                      StaticMethod, TemplatedType, Type,
                                      TypedefTemplateInstantiation, Typename,
                                      Variable)
-
 from gtwrap.template_instantiator.classes import InstantiatedClass
 
 
 class TestInterfaceParser(unittest.TestCase):
     """Test driver for all classes in interface_parser.py."""
+
     def test_typename(self):
         """Test parsing of Typename."""
         typename = Typename.rule.parseString("size_t")[0]
@@ -89,10 +89,7 @@ class TestInterfaceParser(unittest.TestCase):
         self.assertEqual("Pose3", t.typename.name)
         self.assertEqual(["gtsam"], t.typename.namespaces)
         self.assertTrue(t.is_shared_ptr)
-        self.assertEqual("std::shared_ptr<gtsam::Pose3>",
-                         t.to_cpp(use_boost=False))
-        self.assertEqual("boost::shared_ptr<gtsam::Pose3>",
-                         t.to_cpp(use_boost=True))
+        self.assertEqual("std::shared_ptr<gtsam::Pose3>", t.to_cpp())
 
         # Check raw pointer
         t = Type.rule.parseString("gtsam::Pose3@ x")[0]
@@ -176,11 +173,9 @@ class TestInterfaceParser(unittest.TestCase):
         args_list = args.list()
         self.assertEqual(2, len(args_list))
         self.assertEqual("std::pair<string, double>",
-                         args_list[0].ctype.to_cpp(False))
+                         args_list[0].ctype.to_cpp())
         self.assertEqual("vector<std::shared_ptr<T>>",
-                         args_list[1].ctype.to_cpp(False))
-        self.assertEqual("vector<boost::shared_ptr<T>>",
-                         args_list[1].ctype.to_cpp(True))
+                         args_list[1].ctype.to_cpp())
 
     def test_default_arguments(self):
         """Tests any expression that is a valid default argument"""
@@ -503,7 +498,8 @@ class TestInterfaceParser(unittest.TestCase):
         ret = Class.rule.parseString(
             "class ForwardKinematicsFactor : gtsam::BetweenFactor<gtsam::Pose3> {};"
         )[0]
-        ret = InstantiatedClass(ret, [])  # Needed to correctly parse parent class
+        ret = InstantiatedClass(ret,
+                                [])  # Needed to correctly parse parent class
         self.assertEqual("ForwardKinematicsFactor", ret.name)
         self.assertEqual("BetweenFactor", ret.parent_class.name)
         self.assertEqual(["gtsam"], ret.parent_class.namespaces)

--- a/tests/test_matlab_wrapper.py
+++ b/tests/test_matlab_wrapper.py
@@ -20,6 +20,7 @@ class TestWrap(unittest.TestCase):
     """
     Test the Matlab wrapper
     """
+
     def setUp(self) -> None:
         super().setUp()
 
@@ -36,7 +37,7 @@ class TestWrap(unittest.TestCase):
         template_file = osp.join(self.TEST_DIR, "..", "gtwrap",
                                  "matlab_wrapper", "matlab_wrapper.tpl")
         if not osp.exists(template_file):
-            with open(template_file, 'w') as tpl:
+            with open(template_file, 'w', encoding="UTF-8") as tpl:
                 tpl.write("#include <gtwrap/matlab.h>\n#include <map>\n")
 
         # Create the `actual/matlab` directory
@@ -51,8 +52,8 @@ class TestWrap(unittest.TestCase):
         success = filecmp.cmp(actual, expected)
 
         if not success:
-            os.system("diff {} {}".format(actual, expected))
-        self.assertTrue(success, "Mismatch for file {0}".format(file))
+            os.system(f"diff {actual} {expected}")
+        self.assertTrue(success, f"Mismatch for file {file}")
 
     def test_geometry(self):
         """
@@ -63,11 +64,10 @@ class TestWrap(unittest.TestCase):
         file = osp.join(self.INTERFACE_DIR, 'geometry.i')
 
         # Create MATLAB wrapper instance
-        wrapper = MatlabWrapper(
-            module_name='geometry',
-            top_module_namespace=['gtsam'],
-            ignore_classes=[''],
-        )
+        wrapper = MatlabWrapper(module_name='geometry',
+                                top_module_namespace=['gtsam'],
+                                ignore_classes=[''],
+                                use_boost_serialization=True)
 
         wrapper.wrap([file], path=self.MATLAB_ACTUAL_DIR)
 

--- a/tests/test_pybind_wrapper.py
+++ b/tests/test_pybind_wrapper.py
@@ -31,20 +31,25 @@ class TestWrap(unittest.TestCase):
     # Create the `actual/python` directory
     os.makedirs(PYTHON_ACTUAL_DIR, exist_ok=True)
 
-    def wrap_content(self, sources, module_name, output_dir):
+    def wrap_content(self,
+                     sources,
+                     module_name,
+                     output_dir,
+                     use_boost_serialization=False):
         """
         Common function to wrap content in `sources`.
         """
-        with open(osp.join(self.TEST_DIR,
-                           "pybind_wrapper.tpl")) as template_file:
+        with open(osp.join(self.TEST_DIR, "pybind_wrapper.tpl"),
+                  encoding="UTF-8") as template_file:
             module_template = template_file.read()
 
         # Create Pybind wrapper instance
-        wrapper = PybindWrapper(module_name=module_name,
-                                use_boost=False,
-                                top_module_namespaces=[''],
-                                ignore_classes=[''],
-                                module_template=module_template)
+        wrapper = PybindWrapper(
+            module_name=module_name,
+            top_module_namespaces=[''],
+            ignore_classes=[''],
+            module_template=module_template,
+            use_boost_serialization=use_boost_serialization)
 
         output = osp.join(self.TEST_DIR, output_dir, module_name + ".cpp")
 
@@ -64,8 +69,8 @@ class TestWrap(unittest.TestCase):
         success = filecmp.cmp(actual, expected)
 
         if not success:
-            os.system("diff {} {}".format(actual, expected))
-        self.assertTrue(success, "Mismatch for file {0}".format(file))
+            os.system(f"diff {actual} {expected}")
+        self.assertTrue(success, f"Mismatch for file {file}")
 
     def test_geometry(self):
         """
@@ -74,8 +79,10 @@ class TestWrap(unittest.TestCase):
             geometry_py --out output/geometry_py.cc
         """
         source = osp.join(self.INTERFACE_DIR, 'geometry.i')
-        output = self.wrap_content([source], 'geometry_py',
-                                   self.PYTHON_ACTUAL_DIR)
+        output = self.wrap_content([source],
+                                   'geometry_py',
+                                   self.PYTHON_ACTUAL_DIR,
+                                   use_boost_serialization=True)
 
         self.compare_and_diff('geometry_pybind.cpp', output)
 


### PR DESCRIPTION
This PR upgrades the wrapper to remove Boost everywhere except for in serialization.

I repurposed the `USE_BOOST` flag to instead specify `BOOST_SERIALIZATION` so that we can use flags like `GTSAM_ENABLE_BOOST_SERIALIZATION` directly.