### PR TITLE
Allow optional std:: for pair

### DIFF
--- a/gtwrap/interface_parser/function.py
+++ b/gtwrap/interface_parser/function.py
@@ -12,7 +12,8 @@ Author: Duy Nguyen Ta, Fan Jiang, Matthew Sklar, Varun Agrawal, and Frank Dellae
 
 from typing import Any, Iterable, List, Union
 
-from pyparsing import Optional, ParseResults, delimitedList  # type: ignore
+from pyparsing import (Literal, Optional, ParseResults,  # type: ignore
+                       delimitedList)
 
 from .template import Template
 from .tokens import (COMMA, DEFAULT_ARG, EQUAL, IDENT, LOPBRACK, LPAREN, PAIR,
@@ -105,8 +106,10 @@ class ReturnType:
 
     The return type can either be a single type or a pair such as <type1, type2>.
     """
+    # rule to parse optional std:: in front of `pair`
+    optional_std = Optional(Literal('std::')).suppress()
     _pair = (
-        PAIR.suppress()  #
+        optional_std + PAIR.suppress()  #
         + LOPBRACK  #
         + Type.rule("type1")  #
         + COMMA  #

--- a/tests/expected/matlab/TemplatedFunctionRot3.m
+++ b/tests/expected/matlab/TemplatedFunctionRot3.m
@@ -1,6 +1,6 @@
 function varargout = TemplatedFunctionRot3(varargin)
       if length(varargin) == 1 && isa(varargin{1},'gtsam.Rot3')
-        functions_wrapper(25, varargin{:});
+        functions_wrapper(26, varargin{:});
       else
         error('Arguments do not match any overload of function TemplatedFunctionRot3');
       end

--- a/tests/expected/matlab/functions_wrapper.cpp
+++ b/tests/expected/matlab/functions_wrapper.cpp
@@ -229,7 +229,16 @@ void setPose_24(int nargout, mxArray *out[], int nargin, const mxArray *in[])
   checkArguments("setPose",nargout,nargin,0);
   setPose(gtsam::Pose3());
 }
-void TemplatedFunctionRot3_25(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+void EliminateDiscrete_25(int nargout, mxArray *out[], int nargin, const mxArray *in[])
+{
+  checkArguments("EliminateDiscrete",nargout,nargin,2);
+  gtsam::DiscreteFactorGraph& factors = *unwrap_shared_ptr< gtsam::DiscreteFactorGraph >(in[0], "ptr_gtsamDiscreteFactorGraph");
+  gtsam::Ordering& frontalKeys = *unwrap_shared_ptr< gtsam::Ordering >(in[1], "ptr_gtsamOrdering");
+  auto pairResult = EliminateDiscrete(factors,frontalKeys);
+  out[0] = wrap_shared_ptr(pairResult.first,"gtsam.DiscreteConditional", false);
+  out[1] = wrap_shared_ptr(pairResult.second,"gtsam.DecisionTreeFactor", false);
+}
+void TemplatedFunctionRot3_26(int nargout, mxArray *out[], int nargin, const mxArray *in[])
 {
   checkArguments("TemplatedFunctionRot3",nargout,nargin,1);
   gtsam::Rot3& t = *unwrap_shared_ptr< gtsam::Rot3 >(in[0], "ptr_gtsamRot3");
@@ -323,7 +332,10 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       setPose_24(nargout, out, nargin-1, in+1);
       break;
     case 25:
-      TemplatedFunctionRot3_25(nargout, out, nargin-1, in+1);
+      EliminateDiscrete_25(nargout, out, nargin-1, in+1);
+      break;
+    case 26:
+      TemplatedFunctionRot3_26(nargout, out, nargin-1, in+1);
       break;
     }
   } catch(const std::exception& e) {

--- a/tests/expected/python/functions_pybind.cpp
+++ b/tests/expected/python/functions_pybind.cpp
@@ -30,6 +30,7 @@ PYBIND11_MODULE(functions_py, m_) {
     m_.def("DefaultFuncZero",[](int a, int b, double c, int d, bool e){ ::DefaultFuncZero(a, b, c, d, e);}, py::arg("a"), py::arg("b"), py::arg("c") = 0.0, py::arg("d") = 0, py::arg("e") = false);
     m_.def("DefaultFuncVector",[](const std::vector<int>& i, const std::vector<string>& s){ ::DefaultFuncVector(i, s);}, py::arg("i") = {1, 2, 3}, py::arg("s") = {"borglab", "gtsam"});
     m_.def("setPose",[](const gtsam::Pose3& pose){ ::setPose(pose);}, py::arg("pose") = gtsam::Pose3());
+    m_.def("EliminateDiscrete",[](const gtsam::DiscreteFactorGraph& factors, const gtsam::Ordering& frontalKeys){return ::EliminateDiscrete(factors, frontalKeys);}, py::arg("factors"), py::arg("frontalKeys"));
     m_.def("TemplatedFunctionRot3",[](const gtsam::Rot3& t){ ::TemplatedFunction<gtsam::Rot3>(t);}, py::arg("t"));
 
 #include "python/specializations.h"

--- a/tests/fixtures/functions.i
+++ b/tests/fixtures/functions.i
@@ -36,3 +36,7 @@ void DefaultFuncVector(const std::vector<int> &i = {1, 2, 3}, const std::vector<
 
 // Test for non-trivial default constructor
 void setPose(const gtsam::Pose3& pose = gtsam::Pose3());
+
+std::pair<gtsam::DiscreteConditional*, gtsam::DecisionTreeFactor*>
+EliminateDiscrete(const gtsam::DiscreteFactorGraph& factors,
+                  const gtsam::Ordering& frontalKeys);


### PR DESCRIPTION
This PR fixes the Matlab wrapper by allowing `std::` to be specified before STL containers as the return type in the .i file.