### PR TITLE
Fix some errors in the `xml_parser` script

### DIFF
--- a/gtwrap/xml_parser/xml_parser.py
+++ b/gtwrap/xml_parser/xml_parser.py
@@ -58,7 +58,7 @@ class XMLDocParser:
 
         # Extract the docs for the function that matches cpp_class.cpp_method(*method_args_names).
         return self.get_formatted_docstring(member_defs[documenting_index],
-                                            ignored_params)
+                                            ignored_params) if member_defs else ""
 
     def get_member_defs(self, xml_folder: str, cpp_class: str,
                         cpp_method: str):
@@ -95,7 +95,7 @@ class XMLDocParser:
             return ""
 
         # Create the path to the file with the documentation for cpp_class.
-        xml_class_file = xml_folder_path / class_index.attrib['refid'] + '.xml'
+        xml_class_file = xml_folder_path / f"{class_index.attrib['refid']}.xml"
 
         # Parse the class file
         class_tree = self.parse_xml(xml_class_file)


### PR DESCRIPTION
During work to integrate docstring generation into our `cibuildwheel` workflow, we found some issues with the `xml_parser.py` script that results in errors being thrown if a specific interface _does not_ have any associated Doxygen comments. When this is true, the `member_defs` variable will be an empty list, and indexing into it throws an out-of-bounds error. This is fixed with a simple ternary check. We also found an error with the concatenation of a `PosixPath` type with a string. This is fixed using Python format strings. 

@p-zach please sanity check these fixes! Also tagging @dellaert for visibility.