### PR TITLE
fix: guard size_t template specializations for Win64

### DIFF
--- a/matlab.h
+++ b/matlab.h
@@ -159,13 +159,15 @@ mxArray* wrap<bool>(const bool& value) {
   return result;
 }
 
-// specialization to size_t
+// specialization to size_t but skip Win64 size check & CUDACC check
+#if !defined(_WIN64) || defined(__CUDACC__)
 template<>
 mxArray* wrap<size_t>(const size_t& value) {
   mxArray *result = scalar(mxUINT32OR64_CLASS);
   *(size_t*)mxGetData(result) = value;
   return result;
 }
+#endif
 
 // specialization to int
 template<>
@@ -345,12 +347,14 @@ uint64_t unwrap<uint64_t>(const mxArray* array) {
   return myGetScalar<uint64_t>(array);
 }
 
-// specialization to size_t
+// specialization to size_t but skip Win64 size check (size_t == uint64_t) & CUDACC check
+#if !defined(_WIN64) || defined(__CUDACC__)
 template<>
 size_t unwrap<size_t>(const mxArray* array) {
   checkScalar(array, "unwrap<size_t>");
   return myGetScalar<size_t>(array);
 }
+#endif
 
 // specialization to double
 template<>

--- a/matlab.h
+++ b/matlab.h
@@ -347,7 +347,9 @@ uint64_t unwrap<uint64_t>(const mxArray* array) {
   return myGetScalar<uint64_t>(array);
 }
 
-// specialization to size_t but skip Win64 size check (size_t == uint64_t) & CUDACC check
+// specialization to size_t; omit it on Win64 because size_t is uint64_t there
+// and would duplicate unwrap<uint64_t>. The __CUDACC__ case intentionally
+// bypasses the Win64 guard when compiling with CUDA.
 #if !defined(_WIN64) || defined(__CUDACC__)
 template<>
 size_t unwrap<size_t>(const mxArray* array) {


### PR DESCRIPTION
On 64-bit Windows, size_t and uint64_t are the same underlying type, causing duplicate explicit template specialization errors when building the MATLAB wrapper. Guard both wrap<size_t> and unwrap<size_t> with #if !defined(_WIN64) || defined(__CUDACC__).

Successfully locally tested on win64 the change in gtsam/wrap/matlab.h. 

fixes borglab/gtsam#2505