### PR TITLE
Fix MATLAB matrix view size check

### DIFF
--- a/matlab.h
+++ b/matlab.h
@@ -436,8 +436,10 @@ MatrixView unwrapMatrixView(const mxArray* array) {
   if (mxIsDouble(array)==false || mxIsComplex(array) || mxIsSparse(array))
     error("unwrapMatrixView: not a full real double matrix");
   const mwSize rows = mxGetM(array), cols = mxGetN(array);
-  if (rows > static_cast<mwSize>(std::numeric_limits<Eigen::Index>::max()) ||
-      cols > static_cast<mwSize>(std::numeric_limits<Eigen::Index>::max())) {
+  const auto maxIndex =
+      static_cast<unsigned long long>((std::numeric_limits<Eigen::Index>::max)());
+  if (static_cast<unsigned long long>(rows) > maxIndex ||
+      static_cast<unsigned long long>(cols) > maxIndex) {
     error("unwrapMatrixView: matrix dimensions exceed Eigen::Index");
   }
   const Eigen::Index m = static_cast<Eigen::Index>(rows);

--- a/tests/test_matlab_wrapper.py
+++ b/tests/test_matlab_wrapper.py
@@ -115,6 +115,7 @@ class TestWrap(unittest.TestCase):
         self.assertIn('unwrapMatrixView', header_content)
         self.assertIn('mxIsSparse(array)', header_content)
         self.assertIn('mwSize rows', header_content)
+        self.assertIn('static_cast<unsigned long long>(rows)', header_content)
         self.assertIn('Eigen::Index m', header_content)
         self.assertIn('Stride(m, 1)', header_content)
 


### PR DESCRIPTION
## Summary
- widen the MATLAB matrix-view dimension guard before comparing against Eigen::Index
- keep the no-copy ConstMatrixView unwrap path compatible with GTSAM builds that define MX_COMPAT_32
- add a generator test assertion for the widened rows comparison

## Validation
- conda run -n py312 python -m unittest tests.test_matlab_wrapper.TestWrap.test_matrix_view_arguments
- conda run -n py312 python -m unittest discover tests
