### PR TITLE
fix: guard size_t template specializations for 64-bit Unix (__LP64__)

### DIFF
--- a/matlab.h
+++ b/matlab.h
@@ -161,7 +161,7 @@ mxArray* wrap<bool>(const bool& value) {
 }
 
 // specialization to size_t but skip Win64 size check & CUDACC check
-#if !defined(_WIN64) || defined(__CUDACC__)
+#if (!defined(_WIN64) && !defined(__LP64__)) || defined(__CUDACC__)
 template<>
 mxArray* wrap<size_t>(const size_t& value) {
   mxArray *result = scalar(mxUINT32OR64_CLASS);
@@ -351,7 +351,7 @@ uint64_t unwrap<uint64_t>(const mxArray* array) {
 // specialization to size_t; omit it on Win64 because size_t is uint64_t there
 // and would duplicate unwrap<uint64_t>. The __CUDACC__ case intentionally
 // bypasses the Win64 guard when compiling with CUDA.
-#if !defined(_WIN64) || defined(__CUDACC__)
+#if (!defined(_WIN64) && !defined(__LP64__)) || defined(__CUDACC__)
 template<>
 size_t unwrap<size_t>(const mxArray* array) {
   checkScalar(array, "unwrap<size_t>");


### PR DESCRIPTION
This PR extends the fix introduced in #183.

PR #183 successfully guarded the size_t template specializations for Windows (_WIN64) to prevent duplicate explicit template specialization errors with uint64_t. However, on 64-bit Linux, size_t and uint64_t also resolve to the same underlying type, which causes the MATLAB 2024a MEX build to fail on Ubuntu with GCC 11.4.

I have updated the preprocessor guards to #if (!defined(_WIN64) && !defined(__LP64__)) || defined(__CUDACC__) for both wrap<size_t> and unwrap<size_t> to ensure the collision is avoided on 64-bit Unix systems as well.