### PR TITLE
Use canonical pyparsing names

### DIFF
--- a/gtwrap/interface_parser/__init__.py
+++ b/gtwrap/interface_parser/__init__.py
@@ -70,4 +70,4 @@ _DIAGNOSTIC_RULES = (
 for _rule, _context, _priority in _DIAGNOSTIC_RULES:
     _track_rule(_rule, _context, _priority)
 
-pyparsing.ParserElement.enablePackrat()
+pyparsing.ParserElement.enable_packrat()

--- a/gtwrap/interface_parser/classes.py
+++ b/gtwrap/interface_parser/classes.py
@@ -46,7 +46,7 @@ class Method:
         + RPAREN  #
         + Optional(CONST("is_const"))  #
         + SEMI_COLON  # BR
-    ).setParseAction(lambda t: Method(t.template, t.name, t.return_type, t.
+    ).set_parse_action(lambda t: Method(t.template, t.name, t.return_type, t.
                                       args_list, t.is_const))
 
     def __init__(self,
@@ -98,7 +98,7 @@ class StaticMethod:
         + ArgumentList.rule("args_list")  #
         + RPAREN  #
         + SEMI_COLON  # BR
-    ).setParseAction(
+    ).set_parse_action(
         lambda t: StaticMethod(t.name, t.return_type, t.args_list, t.template))
 
     def __init__(self,
@@ -134,7 +134,7 @@ class Constructor:
         + ArgumentList.rule("args_list")  #
         + RPAREN  #
         + SEMI_COLON  # BR
-    ).setParseAction(lambda s, loc, t: Constructor(
+    ).set_parse_action(lambda s, loc, t: Constructor(
         t.name, t.args_list, t.template, source=s, location=loc))
 
     def __init__(self,
@@ -175,7 +175,7 @@ class Operator:
         + RPAREN  #
         + CONST("is_const")  #
         + SEMI_COLON  # BR
-    ).setParseAction(lambda s, loc, t: Operator(
+    ).set_parse_action(lambda s, loc, t: Operator(
         t.name,
         t.operator,
         t.return_type,
@@ -258,7 +258,7 @@ class DunderMethod:
         + ArgumentList.rule("args_list")  #
         + RPAREN  #
         + SEMI_COLON  # BR
-    ).setParseAction(lambda t: DunderMethod(t.name, t.args_list))
+    ).set_parse_action(lambda t: DunderMethod(t.name, t.args_list))
 
     def __init__(self, name: str, args: ArgumentList):
         self.name = name
@@ -291,7 +291,7 @@ class Class:
                           ^ Variable.rule  #
                           ^ Operator.rule  #
                           ^ Enum.rule  #
-                          ).setParseAction(lambda t: Class.Members(t.asList()))
+                          ).set_parse_action(lambda t: Class.Members(t.as_list()))
 
         def __init__(self, members: List[Union[Constructor, Method,
                                                StaticMethod, Variable,
@@ -330,7 +330,7 @@ class Class:
         + Members.rule("members")  #
         + RBRACE  #
         + SEMI_COLON  # BR
-    ).setParseAction(lambda t: Class(
+    ).set_parse_action(lambda t: Class(
         t.template, t.is_virtual, t.name, t.parent_class, t.members.ctors, t.
         members.methods, t.members.static_methods, t.members.dunder_methods, t.
         members.properties, t.members.operators, t.members.enums))

--- a/gtwrap/interface_parser/declaration.py
+++ b/gtwrap/interface_parser/declaration.py
@@ -23,7 +23,7 @@ class Include:
     Rule to parse #include directives.
     """
     rule = (INCLUDE + LOPBRACK + CharsNotIn('>')("header") +
-            ROPBRACK).setParseAction(lambda t: Include(t.header))
+            ROPBRACK).set_parse_action(lambda t: Include(t.header))
 
     def __init__(self, header: CharsNotIn, parent: str = ''):
         self.header = header
@@ -39,7 +39,7 @@ class ForwardDeclaration:
     """
     rule = (Optional(VIRTUAL("is_virtual")) + CLASS + Typename.rule("name") +
             Optional(COLON + Typename.rule("parent_type")) +
-            SEMI_COLON).setParseAction(lambda t: ForwardDeclaration(
+            SEMI_COLON).set_parse_action(lambda t: ForwardDeclaration(
                 t.name, t.parent_type, t.is_virtual))
 
     def __init__(self,

--- a/gtwrap/interface_parser/enum.py
+++ b/gtwrap/interface_parser/enum.py
@@ -10,7 +10,7 @@ Parser class and rules for parsing C++ enums.
 Author: Varun Agrawal
 """
 
-from pyparsing import delimitedList  # type: ignore
+from pyparsing import DelimitedList  # type: ignore
 
 from .tokens import ENUM, IDENT, LBRACE, RBRACE, SEMI_COLON
 from .type import Typename
@@ -22,7 +22,7 @@ class Enumerator:
     Rule to parse an enumerator inside an enum.
     """
     rule = (IDENT.copy().set_name("enumerator name")("enumerator")
-            ).setParseAction(lambda t: Enumerator(t.enumerator))
+            ).set_parse_action(lambda t: Enumerator(t.enumerator))
 
     def __init__(self, name):
         self.name = name
@@ -45,8 +45,8 @@ class Enum:
     """
 
     rule = (ENUM + IDENT("name") + LBRACE +
-            delimitedList(Enumerator.rule)("enumerators") + RBRACE +
-            SEMI_COLON).setParseAction(lambda t: Enum(t.name, t.enumerators))
+            DelimitedList(Enumerator.rule)("enumerators") + RBRACE +
+            SEMI_COLON).set_parse_action(lambda t: Enum(t.name, t.enumerators))
 
     def __init__(self, name, enumerators, parent=''):
         self.name = name

--- a/gtwrap/interface_parser/function.py
+++ b/gtwrap/interface_parser/function.py
@@ -12,7 +12,7 @@ Author: Duy Nguyen Ta, Fan Jiang, Matthew Sklar, Varun Agrawal, and Frank Dellae
 
 from typing import Any, Iterable, List, Union
 
-from pyparsing import Literal, Optional, ParseResults, delimitedList
+from pyparsing import Literal, Optional, ParseResults, DelimitedList
 
 from .template import Template
 from .tokens import (COMMA, DEFAULT_ARG, EQUAL, IDENT, LOPBRACK, LPAREN, PAIR,
@@ -32,7 +32,7 @@ class Argument:
     rule = ((Type.rule ^ TemplatedType.rule)("ctype")  #
             + IDENT.copy().set_name("argument name")("name")  #
             + Optional(EQUAL + DEFAULT_ARG)("default")
-            ).setParseAction(lambda t: Argument(
+            ).set_parse_action(lambda t: Argument(
                 t.ctype,  #
                 t.name,  #
                 t.default[0] if isinstance(t.default, ParseResults) else None))
@@ -61,7 +61,7 @@ class ArgumentList:
     """
     List of Argument objects for all arguments in a function.
     """
-    rule = Optional(delimitedList(Argument.rule)("args_list")).setParseAction(
+    rule = Optional(DelimitedList(Argument.rule)("args_list")).set_parse_action(
         lambda t: ArgumentList.from_parse_result(t.args_list))
 
     def __init__(self, args_list: List[Argument]):
@@ -76,7 +76,7 @@ class ArgumentList:
     def from_parse_result(parse_result: ParseResults):
         """Return the result of parsing."""
         if parse_result:
-            return ArgumentList(parse_result.asList())
+            return ArgumentList(parse_result.as_list())
         else:
             return ArgumentList([])
 
@@ -116,7 +116,7 @@ class ReturnType:
         + ROPBRACK  #
     )
     rule = (_pair ^
-            (Type.rule ^ TemplatedType.rule)("type1")).setParseAction(  # BR
+            (Type.rule ^ TemplatedType.rule)("type1")).set_parse_action(  # BR
                 lambda t: ReturnType(t.type1, t.type2))
 
     def __init__(self, type1: Union[Type, TemplatedType], type2: Type):
@@ -162,7 +162,7 @@ class GlobalFunction:
         + ArgumentList.rule("args_list")  #
         + RPAREN  #
         + SEMI_COLON  #
-    ).setParseAction(lambda t: GlobalFunction(t.name, t.return_type, t.
+    ).set_parse_action(lambda t: GlobalFunction(t.name, t.return_type, t.
                                               args_list, t.template))
 
     def __init__(self,

--- a/gtwrap/interface_parser/module.py
+++ b/gtwrap/interface_parser/module.py
@@ -13,7 +13,7 @@ Author: Duy Nguyen Ta, Fan Jiang, Matthew Sklar, Varun Agrawal, and Frank Dellae
 # pylint: disable=unnecessary-lambda, unused-import, expression-not-assigned, no-else-return, protected-access, too-few-public-methods, too-many-arguments
 
 from pyparsing import (ParseBaseException, ParseResults, ZeroOrMore,  # type: ignore
-                       cppStyleComment, stringEnd)
+                       cpp_style_comment, string_end)
 
 from .classes import Class
 from .declaration import ForwardDeclaration, Include
@@ -45,13 +45,13 @@ class Module:
                    ^ Enum.rule  #
                    ^ Variable.rule  #
                    ^ Namespace.rule  #
-                   ).setParseAction(lambda t: Namespace('', t.asList())) +
-        stringEnd)
+                   ).set_parse_action(lambda t: Namespace('', t.as_list())) +
+        string_end)
 
-    rule.ignore(cppStyleComment)
+    rule.ignore(cpp_style_comment)
 
     @staticmethod
-    def parseString(s: str, source_name: str = "<string>") -> ParseResults:
+    def parse_string(s: str, source_name: str = "<string>") -> ParseResults:
         """Parse source text and report any failure at its best known location."""
         # Imported here to avoid adding the diagnostic machinery to the grammar's
         # import cycle.
@@ -60,7 +60,7 @@ class Module:
 
         context, token = begin_diagnostics(s, source_name)
         try:
-            return Module.rule.parseString(s)[0]
+            return Module.rule.parse_string(s)[0]
         except InterfaceParseError:
             raise
         except ParseBaseException as error:

--- a/gtwrap/interface_parser/module.py
+++ b/gtwrap/interface_parser/module.py
@@ -12,8 +12,8 @@ Author: Duy Nguyen Ta, Fan Jiang, Matthew Sklar, Varun Agrawal, and Frank Dellae
 
 # pylint: disable=unnecessary-lambda, unused-import, expression-not-assigned, no-else-return, protected-access, too-few-public-methods, too-many-arguments
 
-from pyparsing import (ParseBaseException, ParseResults, ZeroOrMore,  # type: ignore
-                       cpp_style_comment, string_end)
+from pyparsing import (ParseBaseException, ZeroOrMore, cpp_style_comment,  # type: ignore
+                       string_end)
 
 from .classes import Class
 from .declaration import ForwardDeclaration, Include
@@ -51,7 +51,7 @@ class Module:
     rule.ignore(cpp_style_comment)
 
     @staticmethod
-def parse_string(s: str, source_name: str = "<string>") -> Namespace:
+    def parse_string(s: str, source_name: str = "<string>") -> Namespace:
         """Parse source text and report any failure at its best known location."""
         # Imported here to avoid adding the diagnostic machinery to the grammar's
         # import cycle.

--- a/gtwrap/interface_parser/module.py
+++ b/gtwrap/interface_parser/module.py
@@ -51,7 +51,7 @@ class Module:
     rule.ignore(cpp_style_comment)
 
     @staticmethod
-    def parse_string(s: str, source_name: str = "<string>") -> ParseResults:
+def parse_string(s: str, source_name: str = "<string>") -> Namespace:
         """Parse source text and report any failure at its best known location."""
         # Imported here to avoid adding the diagnostic machinery to the grammar's
         # import cycle.

--- a/gtwrap/interface_parser/namespace.py
+++ b/gtwrap/interface_parser/namespace.py
@@ -74,7 +74,7 @@ class Namespace:
             ^ rule  #
         )("content")  # BR
         + RBRACE  #
-    ).setParseAction(lambda t: Namespace.from_parse_result(t))
+    ).set_parse_action(lambda t: Namespace.from_parse_result(t))
 
     def __init__(self, name: str, content: ZeroOrMore, parent=''):
         self.name = name
@@ -87,7 +87,7 @@ class Namespace:
     def from_parse_result(t: ParseResults):
         """Return the result of parsing."""
         if t.content:
-            content = t.content.asList()
+            content = t.content.as_list()
         else:
             content = []
         return Namespace(t.name, content)

--- a/gtwrap/interface_parser/template.py
+++ b/gtwrap/interface_parser/template.py
@@ -12,7 +12,7 @@ Author: Duy Nguyen Ta, Fan Jiang, Matthew Sklar, Varun Agrawal, and Frank Dellae
 
 from typing import List
 
-from pyparsing import Optional, ParseResults, delimitedList  # type: ignore
+from pyparsing import Optional, ParseResults, DelimitedList  # type: ignore
 
 from .tokens import (EQUAL, IDENT, LBRACE, LOPBRACK, RBRACE, ROPBRACK,
                      SEMI_COLON, TEMPLATE, TYPEDEF)
@@ -38,10 +38,10 @@ class Template:
             + Optional(  #
                 EQUAL  #
                 + LBRACE  #
-                + ((delimitedList(TemplatedType.rule ^ Typename.rule)
+                + ((DelimitedList(TemplatedType.rule ^ Typename.rule)
                     ("instantiations")))  #
                 + RBRACE  #
-            )).setParseAction(lambda t: Template.TypenameAndInstantiations(
+            )).set_parse_action(lambda t: Template.TypenameAndInstantiations(
                 t.typename, t.instantiations))
 
         def __init__(self, typename: str, instantiations: ParseResults):
@@ -57,11 +57,11 @@ class Template:
     rule = (  # BR
         TEMPLATE  #
         + LOPBRACK  #
-        + delimitedList(TypenameAndInstantiations.rule)(
+        + DelimitedList(TypenameAndInstantiations.rule)(
             "typename_and_instantiations_list")  #
         + ROPBRACK  # BR
-    ).setParseAction(
-        lambda t: Template(t.typename_and_instantiations_list.asList()))
+    ).set_parse_action(
+        lambda t: Template(t.typename_and_instantiations_list.as_list()))
 
     def __init__(
             self,
@@ -85,7 +85,7 @@ class TypedefTemplateInstantiation:
     """
     rule = (TYPEDEF + TemplatedType.rule("templated_type") +
             IDENT("new_name") +
-            SEMI_COLON).setParseAction(lambda t: TypedefTemplateInstantiation(
+            SEMI_COLON).set_parse_action(lambda t: TypedefTemplateInstantiation(
                 t.templated_type[0], t.new_name))
 
     def __init__(self,

--- a/gtwrap/interface_parser/tokens.py
+++ b/gtwrap/interface_parser/tokens.py
@@ -12,8 +12,8 @@ Author: Duy Nguyen Ta, Fan Jiang, Matthew Sklar, Varun Agrawal, and Frank Dellae
 
 from pyparsing import Or  # type: ignore
 from pyparsing import (Keyword, Literal, OneOrMore, QuotedString, Suppress,
-                       Word, alphanums, alphas, nestedExpr, nums,
-                       originalTextFor, printables)
+                       Word, alphanums, alphas, nested_expr, nums,
+                       original_text_for, printables)
 
 # rule for identifiers (e.g. variable names)
 IDENT = Word(alphas + '_', alphanums + '_') ^ Word(nums)
@@ -28,15 +28,15 @@ DUNDER = Suppress(Literal("__"))
 # Allow anything up to ',' or ';' except when they
 # appear inside matched expressions such as
 # (a, b) {c, b} "hello, world", templates, initializer lists, etc.
-DEFAULT_ARG = originalTextFor(
+DEFAULT_ARG = original_text_for(
     OneOrMore(
         QuotedString('"') ^  # parse double quoted strings
         QuotedString("'") ^  # parse single quoted strings
-        Word(printables, excludeChars="(){}[]<>,;") ^  # parse arbitrary words
-        nestedExpr(opener='(', closer=')') ^  # parse expression in parentheses
-        nestedExpr(opener='[', closer=']') ^  # parse expression in brackets
-        nestedExpr(opener='{', closer='}') ^  # parse expression in braces
-        nestedExpr(opener='<', closer='>')  # parse template expressions
+        Word(printables, exclude_chars="(){}[]<>,;") ^  # parse arbitrary words
+        nested_expr(opener='(', closer=')') ^  # parse expression in parentheses
+        nested_expr(opener='[', closer=']') ^  # parse expression in brackets
+        nested_expr(opener='{', closer='}') ^  # parse expression in braces
+        nested_expr(opener='<', closer='>')  # parse template expressions
     ))
 
 CONST, VIRTUAL, CLASS, STATIC, PAIR, TEMPLATE, TYPEDEF, INCLUDE = map(

--- a/gtwrap/interface_parser/type.py
+++ b/gtwrap/interface_parser/type.py
@@ -15,7 +15,7 @@ Author: Duy Nguyen Ta, Fan Jiang, Matthew Sklar, Varun Agrawal, and Frank Dellae
 from typing import List, Sequence, Union
 
 from pyparsing import ParseResults  # type: ignore
-from pyparsing import Forward, Optional, Or, delimitedList
+from pyparsing import Forward, Optional, Or, DelimitedList
 
 from .tokens import (BASIC_TYPES, CONST, IDENT, LOPBRACK, RAW_POINTER, REF,
                      ROPBRACK, SHARED_POINTER)
@@ -39,10 +39,10 @@ class Typename:
         instantiations: Template parameters to the type.
     """
 
-    namespaces_name_rule = delimitedList(IDENT, "::")
+    namespaces_name_rule = DelimitedList(IDENT, "::")
     rule = (
         namespaces_name_rule("namespaces_and_name")  #
-    ).setParseAction(lambda t: Typename.from_parse_result(t))
+    ).set_parse_action(lambda t: Typename.from_parse_result(t))
 
     def __init__(self,
                  name: str,
@@ -59,7 +59,7 @@ class Typename:
             if isinstance(instantiations, Sequence):
                 self.instantiations = instantiations  # type: ignore
             else:
-                self.instantiations = instantiations.asList()
+                self.instantiations = instantiations.as_list()
         else:
             self.instantiations = []
 
@@ -152,7 +152,7 @@ class BasicType:
     ```
     """
 
-    rule = (Or(BASIC_TYPES)("typename")).setParseAction(lambda t: BasicType(t))
+    rule = (Or(BASIC_TYPES)("typename")).set_parse_action(lambda t: BasicType(t))
 
     def __init__(self, t: ParseResults):
         self.typename = Typename.from_parse_result(t)
@@ -171,7 +171,7 @@ class CustomType:
     Here `gtsam::Matrix` is a custom type.
     """
 
-    rule = (Typename.rule("typename")).setParseAction(lambda t: CustomType(t))
+    rule = (Typename.rule("typename")).set_parse_action(lambda t: CustomType(t))
 
     def __init__(self, t: ParseResults):
         self.typename = Typename.from_parse_result(t)
@@ -193,7 +193,7 @@ class Type:
         + Optional(
             SHARED_POINTER("is_shared_ptr") | RAW_POINTER("is_ptr")
             | REF("is_ref"))  #
-    ).setParseAction(lambda t: Type.from_parse_result(t))
+    ).set_parse_action(lambda t: Type.from_parse_result(t))
 
     def __init__(self, typename: Typename, is_const: str, is_shared_ptr: str,
                  is_ptr: str, is_ref: str, is_basic: bool):
@@ -278,12 +278,12 @@ class TemplatedType:
         + Typename.rule("typename")  #
         + (
             LOPBRACK  #
-            + delimitedList(Type.rule ^ rule, ",")("template_params")  #
+            + DelimitedList(Type.rule ^ rule, ",")("template_params")  #
             + ROPBRACK)  #
         + Optional(
             SHARED_POINTER("is_shared_ptr") | RAW_POINTER("is_ptr")
             | REF("is_ref"))  #
-    ).setParseAction(lambda t: TemplatedType.from_parse_result(t))
+    ).set_parse_action(lambda t: TemplatedType.from_parse_result(t))
 
     def __init__(self, typename: Typename, template_params: List[Type],
                  is_const: str, is_shared_ptr: str, is_ptr: str, is_ref: str):

--- a/gtwrap/interface_parser/variable.py
+++ b/gtwrap/interface_parser/variable.py
@@ -36,7 +36,7 @@ class Variable:
             + IDENT("name")  #
             + Optional(EQUAL + DEFAULT_ARG)("default")  #
             + SEMI_COLON  #
-            ).setParseAction(lambda t: Variable(
+            ).set_parse_action(lambda t: Variable(
                 t.ctype,  #
                 t.name,  #
                 t.default[0] if isinstance(t.default, ParseResults) else None))

--- a/gtwrap/matlab_wrapper/wrapper.py
+++ b/gtwrap/matlab_wrapper/wrapper.py
@@ -1965,7 +1965,7 @@ class MatlabWrapper(CheckMixin, FormatMixin):
 
         # Parse the contents of the interface file
         source_name = files[0] if len(files) == 1 else ";".join(files)
-        parsed_result = parser.Module.parseString(
+        parsed_result = parser.Module.parse_string(
             content, source_name=source_name)
 
         # Instantiate the module

--- a/gtwrap/pybind_wrapper.py
+++ b/gtwrap/pybind_wrapper.py
@@ -741,7 +741,7 @@ pybind11::arg py_arg(const char* name) {
             source_name: Name of the interface file for parser diagnostics.
         """
         # Parse the contents of the interface file
-        module = parser.Module.parseString(content, source_name=source_name)
+        module = parser.Module.parse_string(content, source_name=source_name)
         # Instantiate all templates
         module = instantiator.instantiate_namespace(module)
 

--- a/tests/test_interface_parser.py
+++ b/tests/test_interface_parser.py
@@ -34,39 +34,39 @@ class TestInterfaceParser(unittest.TestCase):
 
     def test_typename(self):
         """Test parsing of Typename."""
-        typename = Typename.rule.parseString("size_t")[0]
+        typename = Typename.rule.parse_string("size_t")[0]
         self.assertEqual("size_t", typename.name)
 
     def test_basic_type(self):
         """Tests for BasicType."""
         # Check basic type
-        t = Type.rule.parseString("int x")[0]
+        t = Type.rule.parse_string("int x")[0]
         self.assertEqual("int", t.typename.name)
         self.assertTrue(t.is_basic)
 
         # Check const
-        t = Type.rule.parseString("const int x")[0]
+        t = Type.rule.parse_string("const int x")[0]
         self.assertEqual("int", t.typename.name)
         self.assertTrue(t.is_basic)
         self.assertTrue(t.is_const)
 
         # Check shared pointer
-        t = Type.rule.parseString("int* x")[0]
+        t = Type.rule.parse_string("int* x")[0]
         self.assertEqual("int", t.typename.name)
         self.assertTrue(t.is_shared_ptr)
 
         # Check raw pointer
-        t = Type.rule.parseString("int@ x")[0]
+        t = Type.rule.parse_string("int@ x")[0]
         self.assertEqual("int", t.typename.name)
         self.assertTrue(t.is_ptr)
 
         # Check reference
-        t = Type.rule.parseString("int& x")[0]
+        t = Type.rule.parse_string("int& x")[0]
         self.assertEqual("int", t.typename.name)
         self.assertTrue(t.is_ref)
 
         # Check const reference
-        t = Type.rule.parseString("const int& x")[0]
+        t = Type.rule.parse_string("const int& x")[0]
         self.assertEqual("int", t.typename.name)
         self.assertTrue(t.is_const)
         self.assertTrue(t.is_ref)
@@ -74,38 +74,38 @@ class TestInterfaceParser(unittest.TestCase):
     def test_custom_type(self):
         """Tests for CustomType."""
         # Check qualified type
-        t = Type.rule.parseString("gtsam::Pose3 x")[0]
+        t = Type.rule.parse_string("gtsam::Pose3 x")[0]
         self.assertEqual("Pose3", t.typename.name)
         self.assertEqual(["gtsam"], t.typename.namespaces)
         self.assertTrue(not t.is_basic)
 
         # Check const
-        t = Type.rule.parseString("const gtsam::Pose3 x")[0]
+        t = Type.rule.parse_string("const gtsam::Pose3 x")[0]
         self.assertEqual("Pose3", t.typename.name)
         self.assertEqual(["gtsam"], t.typename.namespaces)
         self.assertTrue(t.is_const)
 
         # Check shared pointer
-        t = Type.rule.parseString("gtsam::Pose3* x")[0]
+        t = Type.rule.parse_string("gtsam::Pose3* x")[0]
         self.assertEqual("Pose3", t.typename.name)
         self.assertEqual(["gtsam"], t.typename.namespaces)
         self.assertTrue(t.is_shared_ptr)
         self.assertEqual("std::shared_ptr<gtsam::Pose3>", t.to_cpp())
 
         # Check raw pointer
-        t = Type.rule.parseString("gtsam::Pose3@ x")[0]
+        t = Type.rule.parse_string("gtsam::Pose3@ x")[0]
         self.assertEqual("Pose3", t.typename.name)
         self.assertEqual(["gtsam"], t.typename.namespaces)
         self.assertTrue(t.is_ptr)
 
         # Check reference
-        t = Type.rule.parseString("gtsam::Pose3& x")[0]
+        t = Type.rule.parse_string("gtsam::Pose3& x")[0]
         self.assertEqual("Pose3", t.typename.name)
         self.assertEqual(["gtsam"], t.typename.namespaces)
         self.assertTrue(t.is_ref)
 
         # Check const reference
-        t = Type.rule.parseString("const gtsam::Pose3& x")[0]
+        t = Type.rule.parse_string("const gtsam::Pose3& x")[0]
         self.assertEqual("Pose3", t.typename.name)
         self.assertEqual(["gtsam"], t.typename.namespaces)
         self.assertTrue(t.is_const)
@@ -113,28 +113,28 @@ class TestInterfaceParser(unittest.TestCase):
 
     def test_templated_type(self):
         """Test a templated type."""
-        t = TemplatedType.rule.parseString("Eigen::Matrix<double, 3, 4>")[0]
+        t = TemplatedType.rule.parse_string("Eigen::Matrix<double, 3, 4>")[0]
         self.assertEqual("Matrix", t.typename.name)
         self.assertEqual(["Eigen"], t.typename.namespaces)
         self.assertEqual("double", t.typename.instantiations[0].name)
         self.assertEqual("3", t.typename.instantiations[1].name)
         self.assertEqual("4", t.typename.instantiations[2].name)
 
-        t = TemplatedType.rule.parseString(
+        t = TemplatedType.rule.parse_string(
             "gtsam::PinholeCamera<gtsam::Cal3S2>")[0]
         self.assertEqual("PinholeCamera", t.typename.name)
         self.assertEqual(["gtsam"], t.typename.namespaces)
         self.assertEqual("Cal3S2", t.typename.instantiations[0].name)
         self.assertEqual(["gtsam"], t.typename.instantiations[0].namespaces)
 
-        t = TemplatedType.rule.parseString("PinholeCamera<Cal3S2*>")[0]
+        t = TemplatedType.rule.parse_string("PinholeCamera<Cal3S2*>")[0]
         self.assertEqual("PinholeCamera", t.typename.name)
         self.assertEqual("Cal3S2", t.typename.instantiations[0].name)
         self.assertTrue(t.template_params[0].is_shared_ptr)
 
     def test_empty_arguments(self):
         """Test no arguments."""
-        empty_args = ArgumentList.rule.parseString("")[0]
+        empty_args = ArgumentList.rule.parse_string("")[0]
         self.assertEqual(0, len(empty_args))
 
     def test_argument_list(self):
@@ -142,7 +142,7 @@ class TestInterfaceParser(unittest.TestCase):
         arg_string = "int a, C1 c1, C2& c2, C3* c3, "\
             "const C4 c4, const C5& c5,"\
             "const C6* c6"
-        args = ArgumentList.rule.parseString(arg_string)[0]
+        args = ArgumentList.rule.parse_string(arg_string)[0]
 
         self.assertEqual(7, len(args.list()))
         self.assertEqual(['a', 'c1', 'c2', 'c3', 'c4', 'c5', 'c6'],
@@ -155,7 +155,7 @@ class TestInterfaceParser(unittest.TestCase):
         """
         arg_string = "double x1, double* x2, double& x3, double@ x4, " \
             "const double x5, const double* x6, const double& x7, const double@ x8"
-        args = ArgumentList.rule.parseString(arg_string)[0].list()
+        args = ArgumentList.rule.parse_string(arg_string)[0].list()
         self.assertEqual(8, len(args))
         self.assertFalse(args[1].ctype.is_ptr and args[1].ctype.is_shared_ptr
                          and args[1].ctype.is_ref)
@@ -170,7 +170,7 @@ class TestInterfaceParser(unittest.TestCase):
     def test_argument_list_templated(self):
         """Test arguments list where the arguments can be templated."""
         arg_string = "std::pair<string, double> steps, vector<T*> vector_of_pointers"
-        args = ArgumentList.rule.parseString(arg_string)[0]
+        args = ArgumentList.rule.parse_string(arg_string)[0]
         args_list = args.list()
         self.assertEqual(2, len(args_list))
         self.assertEqual("std::pair<string, double>",
@@ -180,7 +180,7 @@ class TestInterfaceParser(unittest.TestCase):
 
     def test_default_arguments(self):
         """Tests any expression that is a valid default argument"""
-        args = ArgumentList.rule.parseString("""
+        args = ArgumentList.rule.parse_string("""
             string c = "", int z = 0, double z2 = 0.0, bool f = false,
             string s="hello"+"goodbye", char c='a', int a=3,
             int b, double pi = 3.1415""")[0].list()
@@ -223,7 +223,7 @@ class TestInterfaceParser(unittest.TestCase):
                        arg5=arg5,
                        arg6=arg6,
                        arg7=arg7)
-        args = ArgumentList.rule.parseString(argument_list)[0].list()
+        args = ArgumentList.rule.parse_string(argument_list)[0].list()
 
         # Test non-basic type
         self.assertEqual(args[0].default, arg0)
@@ -240,55 +240,55 @@ class TestInterfaceParser(unittest.TestCase):
     def test_return_type(self):
         """Test ReturnType"""
         # Test void
-        return_type = ReturnType.rule.parseString("void")[0]
+        return_type = ReturnType.rule.parse_string("void")[0]
         self.assertEqual("void", return_type.type1.typename.name)
         self.assertTrue(return_type.type1.is_basic)
 
         # Test basic type
-        return_type = ReturnType.rule.parseString("size_t")[0]
+        return_type = ReturnType.rule.parse_string("size_t")[0]
         self.assertEqual("size_t", return_type.type1.typename.name)
         self.assertTrue(not return_type.type2)
         self.assertTrue(return_type.type1.is_basic)
 
         # Test with qualifiers
-        return_type = ReturnType.rule.parseString("int&")[0]
+        return_type = ReturnType.rule.parse_string("int&")[0]
         self.assertEqual("int", return_type.type1.typename.name)
         self.assertTrue(return_type.type1.is_basic
                         and return_type.type1.is_ref)
 
-        return_type = ReturnType.rule.parseString("const int")[0]
+        return_type = ReturnType.rule.parse_string("const int")[0]
         self.assertEqual("int", return_type.type1.typename.name)
         self.assertTrue(return_type.type1.is_basic
                         and return_type.type1.is_const)
 
         # Test pair return
-        return_type = ReturnType.rule.parseString("pair<char, int>")[0]
+        return_type = ReturnType.rule.parse_string("pair<char, int>")[0]
         self.assertEqual("char", return_type.type1.typename.name)
         self.assertEqual("int", return_type.type2.typename.name)
 
-        return_type = ReturnType.rule.parseString("pair<Test ,Test*>")[0]
+        return_type = ReturnType.rule.parse_string("pair<Test ,Test*>")[0]
         self.assertEqual("Test", return_type.type1.typename.name)
         self.assertEqual("Test", return_type.type2.typename.name)
         self.assertTrue(return_type.type2.is_shared_ptr)
 
     def test_method(self):
         """Test for a class method."""
-        ret = Method.rule.parseString("int f();")[0]
+        ret = Method.rule.parse_string("int f();")[0]
         self.assertEqual("f", ret.name)
         self.assertEqual(0, len(ret.args))
         self.assertTrue(not ret.is_const)
 
-        ret = Method.rule.parseString("int f() const;")[0]
+        ret = Method.rule.parse_string("int f() const;")[0]
         self.assertEqual("f", ret.name)
         self.assertEqual(0, len(ret.args))
         self.assertTrue(ret.is_const)
 
-        ret = Method.rule.parseString(
+        ret = Method.rule.parse_string(
             "int f(const int x, const Class& c, Class* t) const;")[0]
         self.assertEqual("f", ret.name)
         self.assertEqual(3, len(ret.args))
 
-        ret = Method.rule.parseString(
+        ret = Method.rule.parse_string(
             "pair<First ,Second*> create_MixedPtrs();")[0]
         self.assertEqual("create_MixedPtrs", ret.name)
         self.assertEqual(0, len(ret.args))
@@ -297,27 +297,27 @@ class TestInterfaceParser(unittest.TestCase):
 
     def test_static_method(self):
         """Test for static methods."""
-        ret = StaticMethod.rule.parseString("static int f();")[0]
+        ret = StaticMethod.rule.parse_string("static int f();")[0]
         self.assertEqual("f", ret.name)
         self.assertEqual(0, len(ret.args))
 
-        ret = StaticMethod.rule.parseString(
+        ret = StaticMethod.rule.parse_string(
             "static int f(const int x, const Class& c, Class* t);")[0]
         self.assertEqual("f", ret.name)
         self.assertEqual(3, len(ret.args))
 
     def test_constructor(self):
         """Test for class constructor."""
-        ret = Constructor.rule.parseString("f();")[0]
+        ret = Constructor.rule.parse_string("f();")[0]
         self.assertEqual("f", ret.name)
         self.assertEqual(0, len(ret.args))
 
-        ret = Constructor.rule.parseString(
+        ret = Constructor.rule.parse_string(
             "f(const int x, const Class& c, Class* t);")[0]
         self.assertEqual("f", ret.name)
         self.assertEqual(3, len(ret.args))
 
-        ret = Constructor.rule.parseString(
+        ret = Constructor.rule.parse_string(
             """ForwardKinematics(const gtdynamics::Robot& robot,
                     const string& start_link_name, const string& end_link_name,
                     const gtsam::Values& joint_angles,
@@ -332,7 +332,7 @@ class TestInterfaceParser(unittest.TestCase):
         template<T = {double, int}>
         Class();
         """
-        ret = Constructor.rule.parseString(f)[0]
+        ret = Constructor.rule.parse_string(f)[0]
         self.assertEqual("Class", ret.name)
         self.assertEqual(0, len(ret.args))
 
@@ -340,7 +340,7 @@ class TestInterfaceParser(unittest.TestCase):
         template<T = {double, int}>
         Class(const T& name);
         """
-        ret = Constructor.rule.parseString(f)[0]
+        ret = Constructor.rule.parse_string(f)[0]
         self.assertEqual("Class", ret.name)
         self.assertEqual(1, len(ret.args))
         self.assertEqual("const T & name", ret.args.args_list[0].to_cpp())
@@ -360,7 +360,7 @@ class TestInterfaceParser(unittest.TestCase):
         """Test for operator overloading."""
         # Unary operator
         wrap_string = "gtsam::Vector2 operator-() const;"
-        ret = Operator.rule.parseString(wrap_string)[0]
+        ret = Operator.rule.parse_string(wrap_string)[0]
         self.assertEqual("operator", ret.name)
         self.assertEqual("-", ret.operator)
         self.assertEqual("Vector2", ret.return_type.type1.typename.name)
@@ -371,7 +371,7 @@ class TestInterfaceParser(unittest.TestCase):
 
         # Binary operator
         wrap_string = "gtsam::Vector2 operator*(const gtsam::Vector2 &v) const;"
-        ret = Operator.rule.parseString(wrap_string)[0]
+        ret = Operator.rule.parse_string(wrap_string)[0]
         self.assertEqual("operator", ret.name)
         self.assertEqual("*", ret.operator)
         self.assertEqual("Vector2", ret.return_type.type1.typename.name)
@@ -384,7 +384,7 @@ class TestInterfaceParser(unittest.TestCase):
 
     def test_typedef_template_instantiation(self):
         """Test for typedef'd instantiation of a template."""
-        typedef = TypedefTemplateInstantiation.rule.parseString("""
+        typedef = TypedefTemplateInstantiation.rule.parse_string("""
         typedef gtsam::BearingFactor<gtsam::Pose2, gtsam::Point2, gtsam::Rot2>
             BearingFactor2D;
         """)[0]
@@ -395,7 +395,7 @@ class TestInterfaceParser(unittest.TestCase):
 
     def test_base_class(self):
         """Test a base class."""
-        ret = Class.rule.parseString("""
+        ret = Class.rule.parse_string("""
             virtual class Base {
             };
             """)[0]
@@ -408,7 +408,7 @@ class TestInterfaceParser(unittest.TestCase):
 
     def test_empty_class(self):
         """Test an empty class declaration."""
-        ret = Class.rule.parseString("""
+        ret = Class.rule.parse_string("""
             class FactorIndices {};
         """)[0]
         self.assertEqual("FactorIndices", ret.name)
@@ -420,7 +420,7 @@ class TestInterfaceParser(unittest.TestCase):
 
     def test_class(self):
         """Test a non-trivial class."""
-        ret = Class.rule.parseString("""
+        ret = Class.rule.parse_string("""
         class SymbolicFactorGraph {
             SymbolicFactorGraph();
             SymbolicFactorGraph(const gtsam::SymbolicBayesNet& bayesNet);
@@ -477,7 +477,7 @@ class TestInterfaceParser(unittest.TestCase):
 
     def test_templated_class(self):
         """Test a templated class."""
-        ret = Class.rule.parseString("""
+        ret = Class.rule.parse_string("""
         template<POSE, POINT>
         class MyFactor {};
         """)[0]
@@ -487,7 +487,7 @@ class TestInterfaceParser(unittest.TestCase):
 
     def test_class_inheritance(self):
         """Test for class inheritance."""
-        ret = Class.rule.parseString("""
+        ret = Class.rule.parse_string("""
         virtual class Null: gtsam::noiseModel::mEstimator::Base {
           Null();
           void print(string s) const;
@@ -507,7 +507,7 @@ class TestInterfaceParser(unittest.TestCase):
                          ret.parent_class.namespaces)
         self.assertTrue(ret.is_virtual)
 
-        ret = Class.rule.parseString(
+        ret = Class.rule.parse_string(
             "class ForwardKinematicsFactor : gtsam::BetweenFactor<gtsam::Pose3> {};"
         )[0]
         ret = InstantiatedClass(ret,
@@ -521,7 +521,7 @@ class TestInterfaceParser(unittest.TestCase):
 
     def test_class_with_enum(self):
         """Test for class with nested enum."""
-        ret = Class.rule.parseString("""
+        ret = Class.rule.parse_string("""
         class Pet {
             Pet(const string &name, Kind type);
             enum Kind { Dog, Cat };
@@ -532,13 +532,13 @@ class TestInterfaceParser(unittest.TestCase):
 
     def test_include(self):
         """Test for include statements."""
-        include = Include.rule.parseString(
+        include = Include.rule.parse_string(
             "#include <gtsam/slam/PriorFactor.h>")[0]
         self.assertEqual("gtsam/slam/PriorFactor.h", include.header)
 
     def test_forward_declaration(self):
         """Test for forward declarations."""
-        fwd = ForwardDeclaration.rule.parseString(
+        fwd = ForwardDeclaration.rule.parse_string(
             "virtual class Test:gtsam::Point3;")[0]
 
         self.assertEqual("Test", fwd.name)
@@ -546,7 +546,7 @@ class TestInterfaceParser(unittest.TestCase):
 
     def test_function(self):
         """Test for global/free function."""
-        func = GlobalFunction.rule.parseString("""
+        func = GlobalFunction.rule.parse_string("""
         gtsam::Values localToWorld(const gtsam::Values& local,
             const gtsam::Pose2& base, const gtsam::KeyVector& keys);
         """)[0]
@@ -556,29 +556,29 @@ class TestInterfaceParser(unittest.TestCase):
 
     def test_global_variable(self):
         """Test for global variable."""
-        variable = Variable.rule.parseString("string kGravity;")[0]
+        variable = Variable.rule.parse_string("string kGravity;")[0]
         self.assertEqual(variable.name, "kGravity")
         self.assertEqual(variable.ctype.typename.name, "string")
 
-        variable = Variable.rule.parseString("string kGravity = 9.81;")[0]
+        variable = Variable.rule.parse_string("string kGravity = 9.81;")[0]
         self.assertEqual(variable.name, "kGravity")
         self.assertEqual(variable.ctype.typename.name, "string")
         self.assertEqual(variable.default, "9.81")
 
-        variable = Variable.rule.parseString(
+        variable = Variable.rule.parse_string(
             "const string kGravity = 9.81;")[0]
         self.assertEqual(variable.name, "kGravity")
         self.assertEqual(variable.ctype.typename.name, "string")
         self.assertTrue(variable.ctype.is_const)
         self.assertEqual(variable.default, "9.81")
 
-        variable = Variable.rule.parseString(
+        variable = Variable.rule.parse_string(
             "gtsam::Pose3 wTc = gtsam::Pose3();")[0]
         self.assertEqual(variable.name, "wTc")
         self.assertEqual(variable.ctype.typename.name, "Pose3")
         self.assertEqual(variable.default, "gtsam::Pose3()")
 
-        variable = Variable.rule.parseString(
+        variable = Variable.rule.parse_string(
             "gtsam::Pose3 wTc = gtsam::Pose3(1, 2, 0);")[0]
         self.assertEqual(variable.name, "wTc")
         self.assertEqual(variable.ctype.typename.name, "Pose3")
@@ -586,15 +586,15 @@ class TestInterfaceParser(unittest.TestCase):
 
     def test_enumerator(self):
         """Test for enumerator."""
-        enumerator = Enumerator.rule.parseString("Dog")[0]
+        enumerator = Enumerator.rule.parse_string("Dog")[0]
         self.assertEqual(enumerator.name, "Dog")
 
-        enumerator = Enumerator.rule.parseString("Cat")[0]
+        enumerator = Enumerator.rule.parse_string("Cat")[0]
         self.assertEqual(enumerator.name, "Cat")
 
     def test_enum(self):
         """Test for enums."""
-        enum = Enum.rule.parseString("""
+        enum = Enum.rule.parse_string("""
         enum Kind {
             Dog,
             Cat
@@ -606,7 +606,7 @@ class TestInterfaceParser(unittest.TestCase):
 
     def test_namespace(self):
         """Test for namespace parsing."""
-        namespace = Namespace.rule.parseString("""
+        namespace = Namespace.rule.parse_string("""
         namespace gtsam {
           #include <gtsam/geometry/Point2.h>
           class Point2 {
@@ -637,7 +637,7 @@ class TestInterfaceParser(unittest.TestCase):
 
     def test_module(self):
         """Test module parsing."""
-        module = Module.parseString("""
+        module = Module.parse_string("""
         namespace one {
             namespace two {
                 namespace three {

--- a/tests/test_parser_diagnostics.py
+++ b/tests/test_parser_diagnostics.py
@@ -23,7 +23,7 @@ class TestParserDiagnostics(unittest.TestCase):
                            source_name="example.i"):
         """Parse source and assert the structured diagnostic fields."""
         with self.assertRaises(InterfaceParseError) as raised:
-            Module.parseString(source, source_name=source_name)
+            Module.parse_string(source, source_name=source_name)
 
         error = raised.exception
         self.assertEqual(error.source_name, source_name)
@@ -130,10 +130,10 @@ class Foo {
 
     def test_diagnostic_state_does_not_leak(self):
         with self.assertRaises(InterfaceParseError):
-            Module.parseString("class Broken { void method(???); };",
+            Module.parse_string("class Broken { void method(???); };",
                                source_name="broken.i")
 
-        module = Module.parseString("class Valid { Valid(); };")
+        module = Module.parse_string("class Valid { Valid(); };")
         self.assertEqual(module.content[0].name, "Valid")
 
     def test_pybind_cli_prints_clean_diagnostic(self):
@@ -183,7 +183,7 @@ class Foo {
         code = """
 from gtwrap.interface_parser import InterfaceParseError, Module
 try:
-    Module.parseString(
+    Module.parse_string(
         "class Foo { Foo operator*(Foo x, Foo y) const; };")
 except InterfaceParseError:
     raise SystemExit(0)

--- a/tests/test_template_instantiator.py
+++ b/tests/test_template_instantiator.py
@@ -57,17 +57,17 @@ class TestInstantiationHelper(unittest.TestCase):
 
     def test_instantiate(self):
         """Test instantiate method."""
-        method = Method.rule.parseString("""
+        method = Method.rule.parse_string("""
             template<U={double}>
             double method(const T x, const U& param);
             """)[0]
-        cls = Class.rule.parseString("""
+        cls = Class.rule.parse_string("""
             template<T={string}>
             class Foo {};
         """)[0]
         typenames = ['T', 'U']
-        class_instantiations = [Typename.rule.parseString("string")[0]]
-        method_instantiations = [Typename.rule.parseString("double")[0]]
+        class_instantiations = [Typename.rule.parse_string("string")[0]]
+        method_instantiations = [Typename.rule.parse_string("double")[0]]
 
         parent = InstantiatedClass(cls, class_instantiations)
 
@@ -87,7 +87,7 @@ class TestInstantiationHelper(unittest.TestCase):
         Test method for multilevel instantiation
         i.e. instantiation at both the class and method level.
         """
-        cls = Class.rule.parseString("""
+        cls = Class.rule.parse_string("""
             template<T={string}>
             class Foo {
                 template<U={double}>
@@ -99,7 +99,7 @@ class TestInstantiationHelper(unittest.TestCase):
         """)[0]
 
         typenames = ['T']
-        class_instantiations = [Typename.rule.parseString("string")[0]]
+        class_instantiations = [Typename.rule.parse_string("string")[0]]
         parent = InstantiatedClass(cls, class_instantiations)
 
         helper = InstantiationHelper(InstantiatedMethod)
@@ -124,13 +124,13 @@ class TestInstantiatedGlobalFunction(unittest.TestCase):
     """Tests for the InstantiatedGlobalFunction class."""
 
     def setUp(self):
-        original = GlobalFunction.rule.parseString("""
+        original = GlobalFunction.rule.parse_string("""
             template<T={int}, R={double}>
             R function(const T& x);
         """)[0]
         instantiations = [
-            Typename.rule.parseString("int")[0],
-            Typename.rule.parseString("double")[0]
+            Typename.rule.parse_string("int")[0],
+            Typename.rule.parse_string("double")[0]
         ]
         self.func = InstantiatedGlobalFunction(original, instantiations)
 
@@ -153,13 +153,13 @@ class TestInstantiatedConstructor(unittest.TestCase):
     """Tests for the InstantiatedConstructor class."""
 
     def setUp(self):
-        constructor = Constructor.rule.parseString("""
+        constructor = Constructor.rule.parse_string("""
             template<U={double}>
             Class(C x, const U& param);
             """)[0]
         instantiations = [
-            Typename.rule.parseString("double")[0],
-            Typename.rule.parseString("string")[0]
+            Typename.rule.parse_string("double")[0],
+            Typename.rule.parse_string("string")[0]
         ]
         self.constructor = InstantiatedConstructor(constructor, instantiations)
 
@@ -170,16 +170,16 @@ class TestInstantiatedConstructor(unittest.TestCase):
 
     def test_construct(self):
         """Test the construct classmethod."""
-        constructor = Constructor.rule.parseString("""
+        constructor = Constructor.rule.parse_string("""
             template<U={double}>
             Class(C x, const U& param);
             """)[0]
-        c = Class.rule.parseString("""
+        c = Class.rule.parse_string("""
             template<C={string}>
             class Class {};
         """)[0]
-        class_instantiations = [Typename.rule.parseString("double")[0]]
-        method_instantiations = [Typename.rule.parseString("string")[0]]
+        class_instantiations = [Typename.rule.parse_string("double")[0]]
+        method_instantiations = [Typename.rule.parse_string("string")[0]]
         typenames = ['C', 'U']
         parent = InstantiatedClass(c, class_instantiations)
         instantiated_args = instantiate_args_list(
@@ -208,11 +208,11 @@ class TestInstantiatedMethod(unittest.TestCase):
     """Tests for the InstantiatedMethod class."""
 
     def setUp(self):
-        method = Method.rule.parseString("""
+        method = Method.rule.parse_string("""
             template<U={double}>
             double method(const U& param);
             """)[0]
-        instantiations = [Typename.rule.parseString("double")[0]]
+        instantiations = [Typename.rule.parse_string("double")[0]]
         self.method = InstantiatedMethod(method, instantiations)
 
     def test_constructor(self):
@@ -223,16 +223,16 @@ class TestInstantiatedMethod(unittest.TestCase):
 
     def test_construct(self):
         """Test the construct classmethod."""
-        method = Method.rule.parseString("""
+        method = Method.rule.parse_string("""
             template<U={double}>
             T method(U& param);
             """)[0]
-        method_instantiations = [Typename.rule.parseString("double")[0]]
-        c = Class.rule.parseString("""
+        method_instantiations = [Typename.rule.parse_string("double")[0]]
+        c = Class.rule.parse_string("""
             template<T={string}>
             class Class {};
         """)[0]
-        class_instantiations = [Typename.rule.parseString("string")[0]]
+        class_instantiations = [Typename.rule.parse_string("string")[0]]
 
         typenames = ['T', 'U']
         parent = InstantiatedClass(c, class_instantiations)
@@ -260,11 +260,11 @@ class TestInstantiatedStaticMethod(unittest.TestCase):
     """Tests for the InstantiatedStaticMethod class."""
 
     def setUp(self):
-        static_method = StaticMethod.rule.parseString("""
+        static_method = StaticMethod.rule.parse_string("""
             template<U={double}>
             static T staticMethod(const U& param);
             """)[0]
-        instantiations = [Typename.rule.parseString("double")[0]]
+        instantiations = [Typename.rule.parse_string("double")[0]]
         self.static_method = InstantiatedStaticMethod(static_method,
                                                       instantiations)
 
@@ -276,16 +276,16 @@ class TestInstantiatedStaticMethod(unittest.TestCase):
 
     def test_construct(self):
         """Test the construct classmethod."""
-        static_method = StaticMethod.rule.parseString("""
+        static_method = StaticMethod.rule.parse_string("""
             template<U={double}>
             static T staticMethod(U& param);
             """)[0]
-        method_instantiations = [Typename.rule.parseString("double")[0]]
-        c = Class.rule.parseString("""
+        method_instantiations = [Typename.rule.parse_string("double")[0]]
+        c = Class.rule.parse_string("""
             template<T={string}>
             class Class {};
         """)[0]
-        class_instantiations = [Typename.rule.parseString("string")[0]]
+        class_instantiations = [Typename.rule.parse_string("string")[0]]
 
         typenames = ['T', 'U']
         parent = InstantiatedClass(c, class_instantiations)
@@ -315,7 +315,7 @@ class TestInstantiatedClass(unittest.TestCase):
     """Tests for the InstantiatedClass class."""
 
     def setUp(self):
-        cl = Class.rule.parseString("""
+        cl = Class.rule.parse_string("""
             template<T={string}>
             class Foo {
                 template<C={int}>
@@ -332,11 +332,11 @@ class TestInstantiatedClass(unittest.TestCase):
                 T prop;
             };
         """)[0]
-        class_instantiations = [Typename.rule.parseString('string')[0]]
+        class_instantiations = [Typename.rule.parse_string('string')[0]]
         self.member_instantiations = [
-            Typename.rule.parseString('int')[0],
-            Typename.rule.parseString('char')[0],
-            Typename.rule.parseString('double')[0],
+            Typename.rule.parse_string('int')[0],
+            Typename.rule.parse_string('char')[0],
+            Typename.rule.parse_string('double')[0],
         ]
         self.cl = InstantiatedClass(cl, class_instantiations)
         self.typenames = self.cl.original.template.typenames
@@ -406,10 +406,10 @@ class TestInstantiatedDeclaration(unittest.TestCase):
 
     def setUp(self):
         #TODO(Varun) Need to support templated class forward declaration.
-        forward_declaration = ForwardDeclaration.rule.parseString("""
+        forward_declaration = ForwardDeclaration.rule.parse_string("""
             class FooBar;
             """)[0]
-        instantiations = [Typename.rule.parseString("double")[0]]
+        instantiations = [Typename.rule.parse_string("double")[0]]
         self.declaration = InstantiatedDeclaration(
             forward_declaration, instantiations=instantiations)
 
@@ -465,9 +465,9 @@ class TestTemplateInstantiator(unittest.TestCase):
 
     def test_instantiate_type(self):
         """Test for instantiate_type."""
-        arg = Argument.rule.parseString("const T x")[0]
+        arg = Argument.rule.parse_string("const T x")[0]
         template_typenames = ["T"]
-        instantiations = [Typename.rule.parseString("double")[0]]
+        instantiations = [Typename.rule.parse_string("double")[0]]
         cpp_typename = "ExampleClass"
         new_type = instantiate_type(arg.ctype,
                                     template_typenames,
@@ -481,10 +481,10 @@ class TestTemplateInstantiator(unittest.TestCase):
 
     def test_instantiate_args_list(self):
         """Test for instantiate_args_list."""
-        args = ArgumentList.rule.parseString("T x, double y, string z")[0]
+        args = ArgumentList.rule.parse_string("T x, double y, string z")[0]
         args_list = args.list()
         template_typenames = ['T']
-        instantiations = [Typename.rule.parseString("double")[0]]
+        instantiations = [Typename.rule.parse_string("double")[0]]
         instantiated_args_list = instantiate_args_list(
             args_list,
             template_typenames,
@@ -494,12 +494,12 @@ class TestTemplateInstantiator(unittest.TestCase):
         self.assertEqual(instantiated_args_list[0].ctype.get_typename(),
                          "double")
 
-        args = ArgumentList.rule.parseString("T x, U y, string z")[0]
+        args = ArgumentList.rule.parse_string("T x, U y, string z")[0]
         args_list = args.list()
         template_typenames = ['T', 'U']
         instantiations = [
-            Typename.rule.parseString("double")[0],
-            Typename.rule.parseString("Matrix")[0]
+            Typename.rule.parse_string("double")[0],
+            Typename.rule.parse_string("Matrix")[0]
         ]
         instantiated_args_list = instantiate_args_list(
             args_list,
@@ -511,12 +511,12 @@ class TestTemplateInstantiator(unittest.TestCase):
         self.assertEqual(instantiated_args_list[1].ctype.get_typename(),
                          "Matrix")
 
-        args = ArgumentList.rule.parseString("T x, U y, T z")[0]
+        args = ArgumentList.rule.parse_string("T x, U y, T z")[0]
         args_list = args.list()
         template_typenames = ['T', 'U']
         instantiations = [
-            Typename.rule.parseString("double")[0],
-            Typename.rule.parseString("Matrix")[0]
+            Typename.rule.parse_string("double")[0],
+            Typename.rule.parse_string("Matrix")[0]
         ]
         instantiated_args_list = instantiate_args_list(
             args_list,
@@ -532,9 +532,9 @@ class TestTemplateInstantiator(unittest.TestCase):
 
     def test_instantiate_return_type(self):
         """Test for instantiate_return_type."""
-        return_type = ReturnType.rule.parseString("T")[0]
+        return_type = ReturnType.rule.parse_string("T")[0]
         template_typenames = ['T']
-        instantiations = [Typename.rule.parseString("double")[0]]
+        instantiations = [Typename.rule.parse_string("double")[0]]
         instantiated_return_type = instantiate_return_type(
             return_type,
             template_typenames,
@@ -544,11 +544,11 @@ class TestTemplateInstantiator(unittest.TestCase):
         self.assertEqual(instantiated_return_type.type1.get_typename(),
                          "double")
 
-        return_type = ReturnType.rule.parseString("pair<T, U>")[0]
+        return_type = ReturnType.rule.parse_string("pair<T, U>")[0]
         template_typenames = ['T', 'U']
         instantiations = [
-            Typename.rule.parseString("double")[0],
-            Typename.rule.parseString("char")[0],
+            Typename.rule.parse_string("double")[0],
+            Typename.rule.parse_string("char")[0],
         ]
         instantiated_return_type = instantiate_return_type(
             return_type,
@@ -562,13 +562,13 @@ class TestTemplateInstantiator(unittest.TestCase):
 
     def test_instantiate_name(self):
         """Test for instantiate_name."""
-        instantiations = [Typename.rule.parseString("Man")[0]]
+        instantiations = [Typename.rule.parse_string("Man")[0]]
         instantiated_name = instantiate_name("Iron", instantiations)
         self.assertEqual(instantiated_name, "IronMan")
 
     def test_instantiate_namespace(self):
         """Test for instantiate_namespace."""
-        namespace = Namespace.rule.parseString("""
+        namespace = Namespace.rule.parse_string("""
             namespace gtsam {
                 #include <gtsam/nonlinear/Values.h>
                 template<T={gtsam::Basis}>


### PR DESCRIPTION
## Summary

- replace deprecated pyparsing camelCase aliases with their canonical PEP 8 names
- rename `Module.parseString` to `Module.parse_string` without a compatibility alias
- update the Python and MATLAB wrapper entrypoints and parser tests

## Why

Pyparsing 3 recommends its PEP 8 API. The older camelCase spellings are retained only as backward-compatible aliases and can trigger misleading review feedback or eventually be removed. This change uses the canonical API throughout the project while leaving the accepted `.i` grammar unchanged.

## Impact

Callers of the project parser must now use `Module.parse_string`. This is an intentional breaking rename; `Module.parseString` is not retained. `DelimitedList` remains PascalCase because it is pyparsing's canonical class name.

## Validation

- `conda run -n py312 python -m pytest tests/test_interface_parser.py tests/test_parser_diagnostics.py tests/test_template_instantiator.py` — 73 passed
- `conda run -n py312 python -m pytest tests` — 110 passed
- `git diff --check`
- verified pyparsing 3.2.5 in `py312`
