### PR TITLE
Fix MATLAB size_t scalar wrapping on LP64 macOS

### DIFF
--- a/gtwrap/matlab_wrapper/mixins.py
+++ b/gtwrap/matlab_wrapper/mixins.py
@@ -16,6 +16,7 @@ class CheckMixin:
         "char",
         "unsigned char",
         "size_t",
+        "uint64_t",
         "Key",  # This is an alias for a uint64_t
     )
     # Ignore the namespace for these datatypes

--- a/gtwrap/matlab_wrapper/wrapper.py
+++ b/gtwrap/matlab_wrapper/wrapper.py
@@ -54,6 +54,7 @@ class MatlabWrapper(CheckMixin, FormatMixin):
             'ConstMatrixView': 'double',
             'int': 'numeric',
             'size_t': 'numeric',
+            'uint64_t': 'numeric',
             'Key': 'numeric',
             'bool': 'logical'
         }
@@ -64,6 +65,7 @@ class MatlabWrapper(CheckMixin, FormatMixin):
             'char': 'char',
             'unsigned char': 'unsigned char',
             'size_t': 'int',
+            'uint64_t': 'numeric',
             'int': 'int',
             'double': 'double',
             'Point2': 'double',

--- a/matlab.h
+++ b/matlab.h
@@ -37,12 +37,14 @@ extern "C" {
 #include <mex.h>
 }
 
+#include <cstdint>
 #include <limits>
 #include <list>
 #include <set>
 #include <sstream>
 #include <streambuf>
 #include <string>
+#include <type_traits>
 #include <typeinfo>
 
 using namespace std;
@@ -122,11 +124,31 @@ void checkArguments(const string& name, int nargout, int nargin, int expected) {
 // wrapping C++ basic types in MATLAB arrays
 //*****************************************************************************
 
-// default wrapping throws an error: only basic types are allowed in wrap
+template <typename T>
+struct IsMatlabSizeOrKeyScalar
+    : std::integral_constant<bool, std::is_same<T, size_t>::value ||
+                                       std::is_same<T, uint64_t>::value> {};
+
+// size_t and uint64_t can be the same C++ type, so handle both through the
+// primary template rather than potentially duplicate explicit specializations.
 template <typename Class>
-mxArray* wrap(const Class& value) {
+mxArray* wrapDefault(const Class& value, std::true_type) {
+  mxArray *result = scalar(mxUINT32OR64_CLASS);
+  *static_cast<Class*>(mxGetData(result)) = value;
+  return result;
+}
+
+// Unsupported types retain the generic runtime error.
+template <typename Class>
+mxArray* wrapDefault(const Class&, std::false_type) {
   error("wrap internal error: attempted wrap of invalid type");
   return 0;
+}
+
+// Default wrapping supports size/key scalars and rejects all other types.
+template <typename Class>
+mxArray* wrap(const Class& value) {
+  return wrapDefault(value, IsMatlabSizeOrKeyScalar<Class>());
 }
 
 // specialization to string
@@ -160,29 +182,11 @@ mxArray* wrap<bool>(const bool& value) {
   return result;
 }
 
-// specialization to size_t but skip Win64 size check & CUDACC check
-#if (!defined(_WIN64) && !defined(__LP64__)) || defined(__CUDACC__)
-template<>
-mxArray* wrap<size_t>(const size_t& value) {
-  mxArray *result = scalar(mxUINT32OR64_CLASS);
-  *(size_t*)mxGetData(result) = value;
-  return result;
-}
-#endif
-
 // specialization to int
 template<>
 mxArray* wrap<int>(const int& value) {
   mxArray *result = scalar(mxUINT32OR64_CLASS);
   *(int*)mxGetData(result) = value;
-  return result;
-}
-
-// specialization to gtsam::Key which is an alias for uint64_t
-template<>
-mxArray* wrap<uint64_t>(const uint64_t& value) {
-  mxArray *result = scalar(mxUINT32OR64_CLASS);
-  *(uint64_t*)mxGetData(result) = value;
   return result;
 }
 
@@ -261,12 +265,38 @@ mxArray* wrap_enum(const T x, const std::string& classname) {
 // unwrapping MATLAB arrays into C++ basic types
 //*****************************************************************************
 
-// default unwrapping throws an error
-// as wrap only supports passing a reference or one of the basic types
+// Check for 64-bit, as Mathworks says mxGetScalar only good for 32 bit
 template <typename T>
-T unwrap(const mxArray* array) {
+T myGetScalar(const mxArray* array) {
+  switch (mxGetClassID(array)) {
+    case mxINT64_CLASS:
+      return (T) *(std::int64_t*) mxGetData(array);
+    case mxUINT64_CLASS:
+      return (T) *(std::uint64_t*) mxGetData(array);
+    default:
+      // hope for the best!
+      return (T) mxGetScalar(array);
+  }
+}
+
+// size_t and uint64_t share this path whether they are aliases or distinct.
+template <typename T>
+T unwrapDefault(const mxArray* array, std::true_type) {
+  checkScalar(array, "unwrap<size_t or uint64_t>");
+  return myGetScalar<T>(array);
+}
+
+// Unsupported types retain the generic runtime error.
+template <typename T>
+T unwrapDefault(const mxArray*, std::false_type) {
   error("wrap internal error: attempted unwrap of invalid type");
   return T();
+}
+
+// Default unwrapping supports size/key scalars and rejects all other types.
+template <typename T>
+T unwrap(const mxArray* array) {
+  return unwrapDefault<T>(array, IsMatlabSizeOrKeyScalar<T>());
 }
 
 /// @brief Unwrap from matlab array to C++ enum type
@@ -299,20 +329,6 @@ string unwrap<string>(const mxArray* array) {
   return str;
 }
 
-// Check for 64-bit, as Mathworks says mxGetScalar only good for 32 bit
-template <typename T>
-T myGetScalar(const mxArray* array) {
-  switch (mxGetClassID(array)) {
-    case mxINT64_CLASS:
-      return (T) *(std::int64_t*) mxGetData(array);
-    case mxUINT64_CLASS:
-      return (T) *(std::uint64_t*) mxGetData(array);
-    default:
-      // hope for the best!
-      return (T) mxGetScalar(array);
-  }
-}
-
 // specialization to bool
 template<>
 bool unwrap<bool>(const mxArray* array) {
@@ -340,24 +356,6 @@ int unwrap<int>(const mxArray* array) {
   checkScalar(array,"unwrap<int>");
   return myGetScalar<int>(array);
 }
-
-// specialization to gtsam::Key which is an alias for uint64_t
-template<>
-uint64_t unwrap<uint64_t>(const mxArray* array) {
-  checkScalar(array,"unwrap<uint64_t>");
-  return myGetScalar<uint64_t>(array);
-}
-
-// specialization to size_t; omit it on Win64 because size_t is uint64_t there
-// and would duplicate unwrap<uint64_t>. The __CUDACC__ case intentionally
-// bypasses the Win64 guard when compiling with CUDA.
-#if (!defined(_WIN64) && !defined(__LP64__)) || defined(__CUDACC__)
-template<>
-size_t unwrap<size_t>(const mxArray* array) {
-  checkScalar(array, "unwrap<size_t>");
-  return myGetScalar<size_t>(array);
-}
-#endif
 
 // specialization to double
 template<>

--- a/tests/fixtures/matlab_integer_aliases.i
+++ b/tests/fixtures/matlab_integer_aliases.i
@@ -1,0 +1,2 @@
+size_t roundTripSizeT(size_t value);
+uint64_t roundTripUint64(uint64_t value);

--- a/tests/test_matlab_wrapper.py
+++ b/tests/test_matlab_wrapper.py
@@ -270,23 +270,37 @@ class TestWrap(unittest.TestCase):
 
     def test_size_t_round_trip(self):
         """Generated size_t wrappers use alias-safe scalar conversions."""
-        file = osp.join(self.INTERFACE_DIR, 'class.i')
+        file = osp.join(self.INTERFACE_DIR, 'matlab_integer_aliases.i')
 
         wrapper = MatlabWrapper(
-            module_name='class',
+            module_name='matlab_integer_aliases',
             top_module_namespace=['gtsam'],
             ignore_classes=[''],
         )
         wrapper.wrap([file], path=self.MATLAB_ACTUAL_DIR)
 
-        cpp_file = osp.join(self.MATLAB_ACTUAL_DIR, 'class_wrapper.cpp')
+        cpp_file = osp.join(self.MATLAB_ACTUAL_DIR,
+                            'matlab_integer_aliases_wrapper.cpp')
         with open(cpp_file, 'r', encoding='UTF-8') as generated_file:
             cpp_content = generated_file.read()
 
-        self.assertIn('size_t value = unwrap< size_t >(in[1]);', cpp_content)
+        self.assertIn('size_t value = unwrap< size_t >(in[0]);', cpp_content)
         self.assertIn(
-            'out[0] = wrap< size_t >(obj->return_size_t(value));',
+            'out[0] = wrap< size_t >(roundTripSizeT(value));',
             cpp_content)
+        self.assertIn('uint64_t value = unwrap< uint64_t >(in[0]);',
+                      cpp_content)
+        self.assertIn(
+            'out[0] = wrap< uint64_t >(roundTripUint64(value));',
+            cpp_content)
+        self.assertNotIn('unwrap_shared_ptr< uint64_t >', cpp_content)
+        self.assertNotIn('wrap_shared_ptr(std::make_shared<uint64_t>',
+                         cpp_content)
+
+        uint64_file = osp.join(self.MATLAB_ACTUAL_DIR, 'roundTripUint64.m')
+        with open(uint64_file, 'r', encoding='UTF-8') as generated_file:
+            uint64_content = generated_file.read()
+        self.assertIn("isa(varargin{1},'numeric')", uint64_content)
 
         matlab_header = osp.join(self.TEST_DIR, '..', 'matlab.h')
         with open(matlab_header, 'r', encoding='UTF-8') as header_file:

--- a/tests/test_matlab_wrapper.py
+++ b/tests/test_matlab_wrapper.py
@@ -268,6 +268,38 @@ class TestWrap(unittest.TestCase):
             actual = osp.join(self.MATLAB_ACTUAL_DIR, file)
             self.compare_and_diff(file, actual)
 
+    def test_size_t_round_trip(self):
+        """Generated size_t wrappers use alias-safe scalar conversions."""
+        file = osp.join(self.INTERFACE_DIR, 'class.i')
+
+        wrapper = MatlabWrapper(
+            module_name='class',
+            top_module_namespace=['gtsam'],
+            ignore_classes=[''],
+        )
+        wrapper.wrap([file], path=self.MATLAB_ACTUAL_DIR)
+
+        cpp_file = osp.join(self.MATLAB_ACTUAL_DIR, 'class_wrapper.cpp')
+        with open(cpp_file, 'r', encoding='UTF-8') as generated_file:
+            cpp_content = generated_file.read()
+
+        self.assertIn('size_t value = unwrap< size_t >(in[1]);', cpp_content)
+        self.assertIn(
+            'out[0] = wrap< size_t >(obj->return_size_t(value));',
+            cpp_content)
+
+        matlab_header = osp.join(self.TEST_DIR, '..', 'matlab.h')
+        with open(matlab_header, 'r', encoding='UTF-8') as header_file:
+            header_content = header_file.read()
+
+        self.assertIn('struct IsMatlabSizeOrKeyScalar', header_content)
+        self.assertIn('std::is_same<T, size_t>::value', header_content)
+        self.assertIn('std::is_same<T, uint64_t>::value', header_content)
+        self.assertNotIn('mxArray* wrap<size_t>', header_content)
+        self.assertNotIn('size_t unwrap<size_t>', header_content)
+        self.assertIn('attempted wrap of invalid type', header_content)
+        self.assertIn('attempted unwrap of invalid type', header_content)
+
     def test_enum(self):
         """Test interface file with only enum info."""
         file = osp.join(self.INTERFACE_DIR, 'enum.i')


### PR DESCRIPTION
## Summary

- route `size_t` and `uint64_t` MATLAB conversions through alias-aware primary-template dispatch
- avoid duplicate explicit specializations when the two names denote the same C++ type
- treat generated `uint64_t` arguments and results as MATLAB numeric scalars
- retain the generic runtime errors for unsupported wrap and unwrap types
- add focused generation coverage for `size_t` and `uint64_t` round trips

## Root cause

The prior preprocessor guard assumed every LP64 platform aliases `size_t` to `uint64_t`. That is true for common Linux definitions but false on 64-bit macOS, where the types have the same width but distinct underlying C++ types. As a result, macOS omitted `unwrap<size_t>` and generated calls fell through to the generic error-producing implementation.

Using C++ type traits makes the decision from actual type identity instead of platform macros, so macOS, Linux, Windows, and CUDA configurations cannot produce either a missing conversion or duplicate explicit specializations.

## Validation

- `conda run -n py312 python -m pytest tests/test_matlab_wrapper.py -q` — 12 passed
- `conda run -n py312 python -m pytest tests -q` — 111 passed
- `git diff --check`
- synced into a local GTSAM feature branch with `./update_wrap.sh codex/fix-matlab-size-t`
- built and installed the GTSAM MATLAB R2025b wrapper on arm64 macOS
- verified `gtsam.KalmanFilter(2)` constructs successfully
- verified `gtsam.symbol('x', 1)` and `gtsam.symbolIndex` round-trip successfully
- the canonical MATLAB runner passed all size/key-related tests without the former `unwrap<size_t>` error; its final optional Boost serialization test encountered a separate Homebrew Boost/`std::locale` allocator abort