### PR TITLE
Skip bundled pybind11 install for system builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ set(INSTALL_BIN_DIR bin/${PROJECT_NAME})
 set(INSTALL_INCLUDE_DIR include/${PROJECT_NAME})
 
 option(GTWRAP_ADD_DOCSTRINGS "Whether to add docstrings to the Python bindings from Doxygen-generated XML located at {project_root}/xml" OFF)
+option(GTWRAP_USE_SYSTEM_PYBIND "Find and use system-installed pybind11 instead of installing the bundled copy" OFF)
 
 # ##############################################################################
 # Package Configuration
@@ -65,9 +66,11 @@ configure_file(${PROJECT_SOURCE_DIR}/templates/matlab_wrapper.tpl.in
 # for wrapping.
 install(DIRECTORY gtwrap DESTINATION "${GTWRAP_LIB_INSTALL_DIR}")
 
-# Install pybind11 directory to `CMAKE_INSTALL_PREFIX/lib/gtwrap/pybind11` This
-# will allow the gtwrapConfig.cmake file to load it later.
-install(DIRECTORY pybind11 DESTINATION "${GTWRAP_LIB_INSTALL_DIR}")
+# Install pybind11 so gtwrapConfig.cmake can load it when not using a system
+# installation.
+if(NOT GTWRAP_USE_SYSTEM_PYBIND)
+  install(DIRECTORY pybind11 DESTINATION "${GTWRAP_LIB_INSTALL_DIR}")
+endif()
 
 # Install wrapping scripts as binaries to `CMAKE_INSTALL_PREFIX/bin` so they can
 # be invoked for wrapping. We use DESTINATION (instead of TYPE) so we can

--- a/cmake/gtwrapConfig.cmake.in
+++ b/cmake/gtwrapConfig.cmake.in
@@ -18,7 +18,11 @@ include(@PACKAGE_INSTALL_CMAKE_DIR@/GtwrapUtils.cmake)
 set_and_check(PYBIND_WRAP_SCRIPT "@PACKAGE_INSTALL_BIN_DIR@/pybind_wrap.py")
 set_and_check(MATLAB_WRAP_SCRIPT "@PACKAGE_INSTALL_BIN_DIR@/matlab_wrap.py")
 
-# Load the pybind11 code from the library installation path
-add_subdirectory(@PACKAGE_INSTALL_LIB_DIR@/pybind11 pybind11)
+# Load the same pybind11 provider selected when gtwrap was configured.
+if(@GTWRAP_USE_SYSTEM_PYBIND@)
+  find_package(pybind11 REQUIRED)
+else()
+  add_subdirectory(@PACKAGE_INSTALL_LIB_DIR@/pybind11 pybind11)
+endif()
 
 check_required_components(gtwrap)


### PR DESCRIPTION
This is to avoid introducing another (potentially confusing) copy of `pybind11` if GTSAM is built to use system pybind