### PR TITLE
Fix shared pointer property assignment in MATLAB

### DIFF
--- a/gtwrap/matlab_wrapper/wrapper.py
+++ b/gtwrap/matlab_wrapper/wrapper.py
@@ -1750,11 +1750,14 @@ class MatlabWrapper(CheckMixin, FormatMixin):
 
                 # Setter
                 if "_set_" in method_name:
-                    is_ptr_type = not self.is_optional(extra.ctype) and \
+                    is_wrapped_value = not self.is_optional(extra.ctype) and \
                         self.can_be_pointer(extra.ctype) and \
+                        not extra.ctype.is_shared_ptr and \
+                        not extra.ctype.is_ptr and \
+                        not extra.ctype.is_ref and \
                         not self.is_enum(extra.ctype, collector_func[1])
                     return_body = '  obj->{0} = {1}{0};'.format(
-                        extra.name, '*' if is_ptr_type else '')
+                        extra.name, '*' if is_wrapped_value else '')
 
                     setter = '  checkArguments("{property_name}",nargout,nargin{min1},' \
                             '{num_args});\n' \

--- a/tests/expected/matlab/class_wrapper.cpp
+++ b/tests/expected/matlab/class_wrapper.cpp
@@ -589,7 +589,7 @@ void Test_set_model_ptr_47(int nargout, mxArray *out[], int nargin, const mxArra
   checkArguments("model_ptr",nargout,nargin-1,1);
   auto obj = unwrap_shared_ptr<Test>(in[0], "ptr_Test");
   std::shared_ptr<gtsam::noiseModel::Base> model_ptr = unwrap_shared_ptr< gtsam::noiseModel::Base >(in[1], "ptr_gtsamnoiseModelBase");
-  obj->model_ptr = *model_ptr;
+  obj->model_ptr = model_ptr;
 }
 
 void Test_get_value_48(int nargout, mxArray *out[], int nargin, const mxArray *in[])

--- a/tests/fixtures/pointer_properties.i
+++ b/tests/fixtures/pointer_properties.i
@@ -1,0 +1,4 @@
+class PointerProperties {
+  gtsam::noiseModel::Base* shared;
+  gtsam::Pose3 value;
+};

--- a/tests/test_matlab_wrapper.py
+++ b/tests/test_matlab_wrapper.py
@@ -9,6 +9,7 @@ import filecmp
 import os
 import os.path as osp
 import sys
+import tempfile
 import unittest
 
 sys.path.append(osp.dirname(osp.dirname(osp.abspath(__file__))))
@@ -350,6 +351,26 @@ class TestWrap(unittest.TestCase):
         for file in files:
             actual = osp.join(self.MATLAB_ACTUAL_DIR, file)
             self.compare_and_diff(file, actual)
+
+    def test_shared_pointer_property_setter(self):
+        """Shared-pointer properties assign handles; value properties copy."""
+        interface = osp.join(self.INTERFACE_DIR, 'pointer_properties.i')
+        wrapper = MatlabWrapper(
+            module_name='pointer_properties',
+            top_module_namespace=['gtsam'],
+            ignore_classes=[''],
+        )
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            wrapper.wrap([interface], path=output_dir)
+            cpp_file = osp.join(output_dir,
+                                'pointer_properties_wrapper.cpp')
+            with open(cpp_file, 'r', encoding='UTF-8') as generated_file:
+                cpp_content = generated_file.read()
+
+        self.assertIn('obj->shared = shared;', cpp_content)
+        self.assertNotIn('obj->shared = *shared;', cpp_content)
+        self.assertIn('obj->value = *value;', cpp_content)
 
     def test_size_t_round_trip(self):
         """Generated size_t wrappers use alias-safe scalar conversions."""


### PR DESCRIPTION
## Summary

- distinguish shared-pointer and reference properties from wrapped value properties in MATLAB setter generation
- assign unwrapped shared ownership handles directly instead of dereferencing them
- retain value-copy behavior for wrapped value properties
- add focused regression coverage and update the existing generated fixture

## Testing

- python3 -m pytest -o addopts='' -q tests: 113 passed
- git diff --check