### PR TITLE
Fix MATLAB MEX error handling for Octave

### DIFF
--- a/gtwrap/matlab_wrapper/templates.py
+++ b/gtwrap/matlab_wrapper/templates.py
@@ -137,6 +137,7 @@ class WrapperTemplate:
                 switch(id) {{
             {cases}    }}
               }} catch(const std::exception& e) {{
+                std::cout.rdbuf(outbuf);
                 mexErrMsgTxt(("Exception from gtsam:\\n" + std::string(e.what()) + "\\n").c_str());
               }}\n
               std::cout.rdbuf(outbuf);

--- a/matlab.h
+++ b/matlab.h
@@ -33,9 +33,7 @@ using gtsam::Matrix;
 using gtsam::Point2;
 using gtsam::Point3;
 
-extern "C" {
 #include <mex.h>
-}
 
 #include <cstdint>
 #include <limits>

--- a/tests/expected/matlab/class_wrapper.cpp
+++ b/tests/expected/matlab/class_wrapper.cpp
@@ -1380,6 +1380,7 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       break;
     }
   } catch(const std::exception& e) {
+    std::cout.rdbuf(outbuf);
     mexErrMsgTxt(("Exception from gtsam:\n" + std::string(e.what()) + "\n").c_str());
   }
 

--- a/tests/expected/matlab/enum_wrapper.cpp
+++ b/tests/expected/matlab/enum_wrapper.cpp
@@ -315,6 +315,7 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       break;
     }
   } catch(const std::exception& e) {
+    std::cout.rdbuf(outbuf);
     mexErrMsgTxt(("Exception from gtsam:\n" + std::string(e.what()) + "\n").c_str());
   }
 

--- a/tests/expected/matlab/functions_wrapper.cpp
+++ b/tests/expected/matlab/functions_wrapper.cpp
@@ -402,6 +402,7 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       break;
     }
   } catch(const std::exception& e) {
+    std::cout.rdbuf(outbuf);
     mexErrMsgTxt(("Exception from gtsam:\n" + std::string(e.what()) + "\n").c_str());
   }
 

--- a/tests/expected/matlab/geometry_wrapper.cpp
+++ b/tests/expected/matlab/geometry_wrapper.cpp
@@ -400,6 +400,7 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       break;
     }
   } catch(const std::exception& e) {
+    std::cout.rdbuf(outbuf);
     mexErrMsgTxt(("Exception from gtsam:\n" + std::string(e.what()) + "\n").c_str());
   }
 

--- a/tests/expected/matlab/inheritance_wrapper.cpp
+++ b/tests/expected/matlab/inheritance_wrapper.cpp
@@ -995,6 +995,7 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       break;
     }
   } catch(const std::exception& e) {
+    std::cout.rdbuf(outbuf);
     mexErrMsgTxt(("Exception from gtsam:\n" + std::string(e.what()) + "\n").c_str());
   }
 

--- a/tests/expected/matlab/multiple_files_wrapper.cpp
+++ b/tests/expected/matlab/multiple_files_wrapper.cpp
@@ -218,6 +218,7 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       break;
     }
   } catch(const std::exception& e) {
+    std::cout.rdbuf(outbuf);
     mexErrMsgTxt(("Exception from gtsam:\n" + std::string(e.what()) + "\n").c_str());
   }
 

--- a/tests/expected/matlab/namespaces_wrapper.cpp
+++ b/tests/expected/matlab/namespaces_wrapper.cpp
@@ -538,6 +538,7 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       break;
     }
   } catch(const std::exception& e) {
+    std::cout.rdbuf(outbuf);
     mexErrMsgTxt(("Exception from gtsam:\n" + std::string(e.what()) + "\n").c_str());
   }
 

--- a/tests/expected/matlab/special_cases_wrapper.cpp
+++ b/tests/expected/matlab/special_cases_wrapper.cpp
@@ -268,6 +268,7 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       break;
     }
   } catch(const std::exception& e) {
+    std::cout.rdbuf(outbuf);
     mexErrMsgTxt(("Exception from gtsam:\n" + std::string(e.what()) + "\n").c_str());
   }
 

--- a/tests/expected/matlab/template_wrapper.cpp
+++ b/tests/expected/matlab/template_wrapper.cpp
@@ -214,6 +214,7 @@ void mexFunction(int nargout, mxArray *out[], int nargin, const mxArray *in[])
       break;
     }
   } catch(const std::exception& e) {
+    std::cout.rdbuf(outbuf);
     mexErrMsgTxt(("Exception from gtsam:\n" + std::string(e.what()) + "\n").c_str());
   }
 

--- a/tests/test_matlab_wrapper.py
+++ b/tests/test_matlab_wrapper.py
@@ -480,6 +480,34 @@ class TestWrap(unittest.TestCase):
             '  }\n'
             '  delete self;', cpp_content)
 
+    def test_mex_error_path_restores_stream(self):
+        """MEX failures restore std::cout before leaving the gateway."""
+        file = osp.join(self.INTERFACE_DIR, 'functions.i')
+        wrapper = MatlabWrapper(
+            module_name='functions',
+            top_module_namespace=['gtsam'],
+            ignore_classes=[''],
+        )
+        wrapper.wrap([file], path=self.MATLAB_ACTUAL_DIR)
+
+        cpp_file = osp.join(self.MATLAB_ACTUAL_DIR,
+                            'functions_wrapper.cpp')
+        with open(cpp_file, 'r', encoding='UTF-8') as generated_file:
+            cpp_content = generated_file.read()
+
+        self.assertIn(
+            '} catch(const std::exception& e) {\n'
+            '    std::cout.rdbuf(outbuf);\n'
+            '    mexErrMsgTxt(', cpp_content)
+
+        matlab_header = osp.join(self.TEST_DIR, '..', 'matlab.h')
+        with open(matlab_header, 'r', encoding='UTF-8') as header_file:
+            header_content = header_file.read()
+
+        self.assertIn('#include <mex.h>', header_content)
+        self.assertNotIn('extern "C" {\n#include <mex.h>\n}',
+                         header_content)
+
     def test_size_t_round_trip(self):
         """Generated size_t wrappers use alias-safe scalar conversions."""
         file = osp.join(self.INTERFACE_DIR, 'matlab_integer_aliases.i')


### PR DESCRIPTION
## Summary

- include mex.h with normal C++ linkage so Octave headers can declare templates
- restore the original std::cout stream buffer before mexErrMsgTxt exits the generated gateway
- update MATLAB wrapper snapshots and add focused regression coverage

## Why

Octave mex.h includes C++ template declarations, which cannot appear inside an outer extern "C" block. Separately, generated gateways redirected std::cout to a stack-local mstream but restored it only after the exception handler. Because mexErrMsgTxt does not return, the error path left std::cout pointing at destroyed storage and Octave could segfault while displaying the exception.

This was reproduced while handling a failed GTSAM CustomFactor callback. With the stream restoration in place, the callback failure is reported as a normal interpreter error instead of SIGSEGV.

## Testing

- uv run pytest tests/test_matlab_wrapper.py -q (17 passed)
- uv run pytest tests -q (128 passed)
- cmake .
- rebuilt the GTSAM Octave MEX and verified the failing callback exits with an error rather than signal 11