### PR TITLE
Terminate TBB deterministically before MATLAB unloads the MEX file

### DIFF
--- a/gtwrap/matlab_wrapper/templates.py
+++ b/gtwrap/matlab_wrapper/templates.py
@@ -26,6 +26,16 @@ class WrapperTemplate:
             '''),
                                  prefix='  ')
 
+    tbb_headers = textwrap.dedent("""
+            #ifdef GTSAM_USE_TBB
+            #include <tbb/version.h>
+            #if TBB_INTERFACE_VERSION >= 12060
+            #include <tbb/global_control.h>
+            #define GTSAM_WRAP_TBB_FINALIZE 1
+            #endif
+            #endif
+        """)
+
     delete_all_objects = textwrap.dedent('''
             void _deleteAllObjects()
             {{
@@ -39,6 +49,16 @@ class WrapperTemplate:
                   "calling destructors, call \'clear all\' again if you plan to now recompile a wrap\\n"
                   "module, so that your recompiled module is used instead of the old one." << endl;
               std::cout.rdbuf(outbuf);
+            #ifdef GTSAM_WRAP_TBB_FINALIZE
+              // Terminate TBB worker threads deterministically before MATLAB unloads
+              // this MEX file. Otherwise the workers may still be winding down when
+              // the image is unmapped and touch freed code, which crashes on exit.
+              // See oneTBB issue #977. finalize() is idempotent, returns false rather
+              // than throwing if the scheduler is still referenced elsewhere, and TBB
+              // re-initializes transparently if the module is used again.
+              static tbb::task_scheduler_handle tbbHandle{{tbb::attach{{}}}};
+              tbb::finalize(tbbHandle, std::nothrow);
+            #endif
             }}
         ''')
 

--- a/gtwrap/matlab_wrapper/wrapper.py
+++ b/gtwrap/matlab_wrapper/wrapper.py
@@ -1952,9 +1952,11 @@ class MatlabWrapper(CheckMixin, FormatMixin):
         includes = textwrap.dedent("""\
             {wrapper_file_headers}
             {boost_headers}
+            {tbb_headers}
             {includes_list}
         """).format(wrapper_file_headers=self.wrapper_file_headers.strip(),
                     boost_headers=boost_headers,
+                    tbb_headers=WrapperTemplate.tbb_headers,
                     includes_list='\n'.join(map(str, includes_list)))
 
         preamble = self.generate_preamble()

--- a/tests/expected/matlab/class_wrapper.cpp
+++ b/tests/expected/matlab/class_wrapper.cpp
@@ -1,6 +1,15 @@
 #include <gtwrap/matlab.h>
 #include <map>
 
+
+#ifdef GTSAM_USE_TBB
+#include <tbb/version.h>
+#if TBB_INTERFACE_VERSION >= 12060
+#include <tbb/global_control.h>
+#define GTSAM_WRAP_TBB_FINALIZE 1
+#endif
+#endif
+
 #include <folder/path/to/Test.h>
 
 typedef Fun<double> FunDouble;
@@ -139,6 +148,16 @@ void _deleteAllObjects()
       "calling destructors, call 'clear all' again if you plan to now recompile a wrap\n"
       "module, so that your recompiled module is used instead of the old one." << endl;
   std::cout.rdbuf(outbuf);
+#ifdef GTSAM_WRAP_TBB_FINALIZE
+  // Terminate TBB worker threads deterministically before MATLAB unloads
+  // this MEX file. Otherwise the workers may still be winding down when
+  // the image is unmapped and touch freed code, which crashes on exit.
+  // See oneTBB issue #977. finalize() is idempotent, returns false rather
+  // than throwing if the scheduler is still referenced elsewhere, and TBB
+  // re-initializes transparently if the module is used again.
+  static tbb::task_scheduler_handle tbbHandle{tbb::attach{}};
+  tbb::finalize(tbbHandle, std::nothrow);
+#endif
 }
 
 void _class_RTTIRegister() {

--- a/tests/expected/matlab/enum_wrapper.cpp
+++ b/tests/expected/matlab/enum_wrapper.cpp
@@ -2,6 +2,15 @@
 #include <map>
 
 
+#ifdef GTSAM_USE_TBB
+#include <tbb/version.h>
+#if TBB_INTERFACE_VERSION >= 12060
+#include <tbb/global_control.h>
+#define GTSAM_WRAP_TBB_FINALIZE 1
+#endif
+#endif
+
+
 
 typedef gtsam::Optimizer<gtsam::GaussNewtonParams> OptimizerGaussNewtonParams;
 
@@ -44,6 +53,16 @@ void _deleteAllObjects()
       "calling destructors, call 'clear all' again if you plan to now recompile a wrap\n"
       "module, so that your recompiled module is used instead of the old one." << endl;
   std::cout.rdbuf(outbuf);
+#ifdef GTSAM_WRAP_TBB_FINALIZE
+  // Terminate TBB worker threads deterministically before MATLAB unloads
+  // this MEX file. Otherwise the workers may still be winding down when
+  // the image is unmapped and touch freed code, which crashes on exit.
+  // See oneTBB issue #977. finalize() is idempotent, returns false rather
+  // than throwing if the scheduler is still referenced elsewhere, and TBB
+  // re-initializes transparently if the module is used again.
+  static tbb::task_scheduler_handle tbbHandle{tbb::attach{}};
+  tbb::finalize(tbbHandle, std::nothrow);
+#endif
 }
 
 void _enum_RTTIRegister() {

--- a/tests/expected/matlab/functions_wrapper.cpp
+++ b/tests/expected/matlab/functions_wrapper.cpp
@@ -2,6 +2,15 @@
 #include <map>
 
 
+#ifdef GTSAM_USE_TBB
+#include <tbb/version.h>
+#if TBB_INTERFACE_VERSION >= 12060
+#include <tbb/global_control.h>
+#define GTSAM_WRAP_TBB_FINALIZE 1
+#endif
+#endif
+
+
 
 
 
@@ -20,6 +29,16 @@ void _deleteAllObjects()
       "calling destructors, call 'clear all' again if you plan to now recompile a wrap\n"
       "module, so that your recompiled module is used instead of the old one." << endl;
   std::cout.rdbuf(outbuf);
+#ifdef GTSAM_WRAP_TBB_FINALIZE
+  // Terminate TBB worker threads deterministically before MATLAB unloads
+  // this MEX file. Otherwise the workers may still be winding down when
+  // the image is unmapped and touch freed code, which crashes on exit.
+  // See oneTBB issue #977. finalize() is idempotent, returns false rather
+  // than throwing if the scheduler is still referenced elsewhere, and TBB
+  // re-initializes transparently if the module is used again.
+  static tbb::task_scheduler_handle tbbHandle{tbb::attach{}};
+  tbb::finalize(tbbHandle, std::nothrow);
+#endif
 }
 
 void _functions_RTTIRegister() {

--- a/tests/expected/matlab/geometry_wrapper.cpp
+++ b/tests/expected/matlab/geometry_wrapper.cpp
@@ -5,6 +5,15 @@
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/serialization/export.hpp>
 
+
+#ifdef GTSAM_USE_TBB
+#include <tbb/version.h>
+#if TBB_INTERFACE_VERSION >= 12060
+#include <tbb/global_control.h>
+#define GTSAM_WRAP_TBB_FINALIZE 1
+#endif
+#endif
+
 #include <gtsam/geometry/Point2.h>
 #include <gtsam/geometry/Point3.h>
 
@@ -43,6 +52,16 @@ void _deleteAllObjects()
       "calling destructors, call 'clear all' again if you plan to now recompile a wrap\n"
       "module, so that your recompiled module is used instead of the old one." << endl;
   std::cout.rdbuf(outbuf);
+#ifdef GTSAM_WRAP_TBB_FINALIZE
+  // Terminate TBB worker threads deterministically before MATLAB unloads
+  // this MEX file. Otherwise the workers may still be winding down when
+  // the image is unmapped and touch freed code, which crashes on exit.
+  // See oneTBB issue #977. finalize() is idempotent, returns false rather
+  // than throwing if the scheduler is still referenced elsewhere, and TBB
+  // re-initializes transparently if the module is used again.
+  static tbb::task_scheduler_handle tbbHandle{tbb::attach{}};
+  tbb::finalize(tbbHandle, std::nothrow);
+#endif
 }
 
 void _geometry_RTTIRegister() {

--- a/tests/expected/matlab/inheritance_wrapper.cpp
+++ b/tests/expected/matlab/inheritance_wrapper.cpp
@@ -2,6 +2,15 @@
 #include <map>
 
 
+#ifdef GTSAM_USE_TBB
+#include <tbb/version.h>
+#if TBB_INTERFACE_VERSION >= 12060
+#include <tbb/global_control.h>
+#define GTSAM_WRAP_TBB_FINALIZE 1
+#endif
+#endif
+
+
 
 typedef MyTemplate<gtsam::Point2> MyTemplatePoint2;
 typedef MyTemplate<gtsam::Matrix> MyTemplateMatrix;
@@ -87,6 +96,16 @@ void _deleteAllObjects()
       "calling destructors, call 'clear all' again if you plan to now recompile a wrap\n"
       "module, so that your recompiled module is used instead of the old one." << endl;
   std::cout.rdbuf(outbuf);
+#ifdef GTSAM_WRAP_TBB_FINALIZE
+  // Terminate TBB worker threads deterministically before MATLAB unloads
+  // this MEX file. Otherwise the workers may still be winding down when
+  // the image is unmapped and touch freed code, which crashes on exit.
+  // See oneTBB issue #977. finalize() is idempotent, returns false rather
+  // than throwing if the scheduler is still referenced elsewhere, and TBB
+  // re-initializes transparently if the module is used again.
+  static tbb::task_scheduler_handle tbbHandle{tbb::attach{}};
+  tbb::finalize(tbbHandle, std::nothrow);
+#endif
 }
 
 void _inheritance_RTTIRegister() {

--- a/tests/expected/matlab/multiple_files_wrapper.cpp
+++ b/tests/expected/matlab/multiple_files_wrapper.cpp
@@ -2,6 +2,15 @@
 #include <map>
 
 
+#ifdef GTSAM_USE_TBB
+#include <tbb/version.h>
+#if TBB_INTERFACE_VERSION >= 12060
+#include <tbb/global_control.h>
+#define GTSAM_WRAP_TBB_FINALIZE 1
+#endif
+#endif
+
+
 
 
 
@@ -44,6 +53,16 @@ void _deleteAllObjects()
       "calling destructors, call 'clear all' again if you plan to now recompile a wrap\n"
       "module, so that your recompiled module is used instead of the old one." << endl;
   std::cout.rdbuf(outbuf);
+#ifdef GTSAM_WRAP_TBB_FINALIZE
+  // Terminate TBB worker threads deterministically before MATLAB unloads
+  // this MEX file. Otherwise the workers may still be winding down when
+  // the image is unmapped and touch freed code, which crashes on exit.
+  // See oneTBB issue #977. finalize() is idempotent, returns false rather
+  // than throwing if the scheduler is still referenced elsewhere, and TBB
+  // re-initializes transparently if the module is used again.
+  static tbb::task_scheduler_handle tbbHandle{tbb::attach{}};
+  tbb::finalize(tbbHandle, std::nothrow);
+#endif
 }
 
 void _multiple_files_RTTIRegister() {

--- a/tests/expected/matlab/namespaces_wrapper.cpp
+++ b/tests/expected/matlab/namespaces_wrapper.cpp
@@ -1,6 +1,15 @@
 #include <gtwrap/matlab.h>
 #include <map>
 
+
+#ifdef GTSAM_USE_TBB
+#include <tbb/version.h>
+#if TBB_INTERFACE_VERSION >= 12060
+#include <tbb/global_control.h>
+#define GTSAM_WRAP_TBB_FINALIZE 1
+#endif
+#endif
+
 #include <gtsam/nonlinear/Values.h>
 #include <path/to/ns1.h>
 #include <path/to/ns1/ClassB.h>
@@ -81,6 +90,16 @@ void _deleteAllObjects()
       "calling destructors, call 'clear all' again if you plan to now recompile a wrap\n"
       "module, so that your recompiled module is used instead of the old one." << endl;
   std::cout.rdbuf(outbuf);
+#ifdef GTSAM_WRAP_TBB_FINALIZE
+  // Terminate TBB worker threads deterministically before MATLAB unloads
+  // this MEX file. Otherwise the workers may still be winding down when
+  // the image is unmapped and touch freed code, which crashes on exit.
+  // See oneTBB issue #977. finalize() is idempotent, returns false rather
+  // than throwing if the scheduler is still referenced elsewhere, and TBB
+  // re-initializes transparently if the module is used again.
+  static tbb::task_scheduler_handle tbbHandle{tbb::attach{}};
+  tbb::finalize(tbbHandle, std::nothrow);
+#endif
 }
 
 void _namespaces_RTTIRegister() {

--- a/tests/expected/matlab/special_cases_wrapper.cpp
+++ b/tests/expected/matlab/special_cases_wrapper.cpp
@@ -1,6 +1,15 @@
 #include <gtwrap/matlab.h>
 #include <map>
 
+
+#ifdef GTSAM_USE_TBB
+#include <tbb/version.h>
+#if TBB_INTERFACE_VERSION >= 12060
+#include <tbb/global_control.h>
+#define GTSAM_WRAP_TBB_FINALIZE 1
+#endif
+#endif
+
 #include <gtsam/geometry/Cal3Bundler.h>
 
 typedef gtsam::PinholeCamera<gtsam::Cal3Bundler> PinholeCameraCal3Bundler;
@@ -53,6 +62,16 @@ void _deleteAllObjects()
       "calling destructors, call 'clear all' again if you plan to now recompile a wrap\n"
       "module, so that your recompiled module is used instead of the old one." << endl;
   std::cout.rdbuf(outbuf);
+#ifdef GTSAM_WRAP_TBB_FINALIZE
+  // Terminate TBB worker threads deterministically before MATLAB unloads
+  // this MEX file. Otherwise the workers may still be winding down when
+  // the image is unmapped and touch freed code, which crashes on exit.
+  // See oneTBB issue #977. finalize() is idempotent, returns false rather
+  // than throwing if the scheduler is still referenced elsewhere, and TBB
+  // re-initializes transparently if the module is used again.
+  static tbb::task_scheduler_handle tbbHandle{tbb::attach{}};
+  tbb::finalize(tbbHandle, std::nothrow);
+#endif
 }
 
 void _special_cases_RTTIRegister() {

--- a/tests/expected/matlab/template_wrapper.cpp
+++ b/tests/expected/matlab/template_wrapper.cpp
@@ -2,6 +2,15 @@
 #include <map>
 
 
+#ifdef GTSAM_USE_TBB
+#include <tbb/version.h>
+#if TBB_INTERFACE_VERSION >= 12060
+#include <tbb/global_control.h>
+#define GTSAM_WRAP_TBB_FINALIZE 1
+#endif
+#endif
+
+
 
 typedef ScopedTemplate<Result> ScopedTemplateResult;
 
@@ -36,6 +45,16 @@ void _deleteAllObjects()
       "calling destructors, call 'clear all' again if you plan to now recompile a wrap\n"
       "module, so that your recompiled module is used instead of the old one." << endl;
   std::cout.rdbuf(outbuf);
+#ifdef GTSAM_WRAP_TBB_FINALIZE
+  // Terminate TBB worker threads deterministically before MATLAB unloads
+  // this MEX file. Otherwise the workers may still be winding down when
+  // the image is unmapped and touch freed code, which crashes on exit.
+  // See oneTBB issue #977. finalize() is idempotent, returns false rather
+  // than throwing if the scheduler is still referenced elsewhere, and TBB
+  // re-initializes transparently if the module is used again.
+  static tbb::task_scheduler_handle tbbHandle{tbb::attach{}};
+  tbb::finalize(tbbHandle, std::nothrow);
+#endif
 }
 
 void _template_RTTIRegister() {


### PR DESCRIPTION
MATLAB crashes on exit after a nonlinear optimization when GTSAM is built with TBB, on macOS. See borglab/gtsam#2489. The crash does not depend on TBB_NUM_THREADS, is unaffected by explicitly deleting wrapped objects, and disappears with -DGTSAM_WITH_TBB=OFF -- so it is not object lifetime.

This matches oneTBB issue #977: a library links TBB and uses a parallel construct, the host loads it dynamically, and the process crashes at exit. Reported there on Linux and macOS but not Windows, and noted as racy. The oneTBB maintainer's guidance is that dynamic library unload is a difficult moment for oneTBB, because worker threads are still finishing their routine and may touch addresses in the unmapped image; the recommendation is task_scheduler_handle with finalize() before the unload.

_deleteAllObjects is registered with mexAtExit and runs just before MATLAB clears the MEX file, which is the right point to wind the scheduler down. finalize() blocks until the workers have exited. The call is placed after the collector delete loop so that any destructor which itself uses TBB has already run.

Version guard
-------------
task_scheduler_handle, tbb::attach and finalize() are oneTBB APIs; the attach tag in particular is not present in early oneTBB. GTSAM's HandleTBB.cmake accepts TBB from 4.4 onwards, so the block is guarded on TBB_INTERFACE_VERSION >= 12060 (oneTBB 2021.6) and compiles out entirely on older TBB, leaving those builds byte-identical. Builds without TBB are unaffected via GTSAM_USE_TBB.

Verified in isolation, not against MATLAB:
  - finalize() is idempotent; calling it repeatedly is harmless
  - the std::nothrow overload returns false rather than throwing if the scheduler is still referenced elsewhere, so it cannot disturb another holder -- relevant because MATLAB ships its own TBB
  - TBB re-initializes transparently if the module is used again after a clear, so this does not affect the clear/recompile/reload workflow that mexLock() would break
  - the guarded block compiles both with the guard active and with it forced inactive