### PR TITLE
Bind std::function variables as named Python functions

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -128,7 +128,12 @@ The python wrapper supports keyword arguments for functions/methods. Hence, the 
 
 - Global variables
     - Similar to global functions, the wrapper supports global variables as well.
-    - Currently we only support primitive types, such as `double`, `int`, `string`, etc.
+    - Primitive types such as `double`, `int`, and `string` become Python module attributes.
+    - Variables whose C++ type is `std::function`, including type aliases, become
+      named Python functions with signatures that `pybind11-stubgen` can discover.
+      Declare the alias in an included C++ header and use it as the variable type
+      in the interface file. Empty `std::function` values become `None`.
+      MATLAB continues to ignore global variables.
     - E.g.
         ```cpp
         const double kGravity = -9.81;

--- a/gtwrap/pybind_wrapper.py
+++ b/gtwrap/pybind_wrapper.py
@@ -47,6 +47,35 @@ pybind11::arg py_arg(const char* name) {
 }  // namespace gtwrap
 """
 
+    VARIABLE_BINDING_SUPPORT = """
+#include <pybind11/functional.h>
+
+namespace gtwrap {
+namespace internal {
+
+// Let C++ resolve aliases rather than guessing callable types in the parser.
+template <typename T>
+void bind_variable(pybind11::module_& module, const char* name, const T& value) {
+  module.attr(name) = value;
+}
+
+template <typename Return, typename... Args>
+void bind_variable(pybind11::module_& module, const char* name,
+                   const std::function<Return(Args...)>& value) {
+  if (!value) {
+    module.attr(name) = pybind11::none();
+  } else if (auto target = value.template target<Return (*)(Args...)>()) {
+    // Preserve pybind11's direct C++ callback path for function pointers.
+    module.def(name, *target);
+  } else {
+    module.def(name, value);
+  }
+}
+
+}  // namespace internal
+}  // namespace gtwrap
+"""
+
     def __init__(self,
                  module_name,
                  top_module_namespaces='',
@@ -443,7 +472,9 @@ pybind11::arg py_arg(const char* name) {
         else:
             variable_value = variable.default
 
-        return '{prefix}{module_var}.attr("{variable_name}") = {namespace}{variable_value};'.format(
+        return ('{prefix}gtwrap::internal::bind_variable('
+                '{module_var}, "{variable_name}", '
+                '{namespace}{variable_value});').format(
             prefix=prefix,
             module_var=module_var,
             variable_name=variable.name,
@@ -936,6 +967,8 @@ pybind11::arg py_arg(const char* name) {
             ])
 
         includes += self.ARG_POLICY_SUPPORT
+        if 'gtwrap::internal::bind_variable(' in wrapped_bindings:
+            includes += self.VARIABLE_BINDING_SUPPORT
 
         return self.module_template.format(
             module_def=module_def,

--- a/tests/expected/python/namespaces_pybind.cpp
+++ b/tests/expected/python/namespaces_pybind.cpp
@@ -29,6 +29,33 @@ pybind11::arg py_arg(const char* name) {
 }  // namespace internal
 }  // namespace gtwrap
 
+#include <pybind11/functional.h>
+
+namespace gtwrap {
+namespace internal {
+
+// Let C++ resolve aliases rather than guessing callable types in the parser.
+template <typename T>
+void bind_variable(pybind11::module_& module, const char* name, const T& value) {
+  module.attr(name) = value;
+}
+
+template <typename Return, typename... Args>
+void bind_variable(pybind11::module_& module, const char* name,
+                   const std::function<Return(Args...)>& value) {
+  if (!value) {
+    module.attr(name) = pybind11::none();
+  } else if (auto target = value.template target<Return (*)(Args...)>()) {
+    // Preserve pybind11's direct C++ callback path for function pointers.
+    module.def(name, *target);
+  } else {
+    module.def(name, value);
+  }
+}
+
+}  // namespace internal
+}  // namespace gtwrap
+
 
 
 
@@ -98,7 +125,7 @@ void gtwrap_bind_namespaces_py(py::module_ &m_) {
     gtwrap_class_m_ns2_ClassC
         .def(py::init<>());
 
-    m_ns2.attr("aNs2Var") = ns2::aNs2Var;
+    gtwrap::internal::bind_variable(m_ns2, "aNs2Var", ns2::aNs2Var);
     m_ns2.def("aGlobalFunction",static_cast<gtsam::Vector (*)()>(&ns2::aGlobalFunction));
     m_ns2.def("overloadedGlobalFunction",static_cast<ns1::ClassA (*)(const ns1::ClassA&)>(&ns2::overloadedGlobalFunction), gtwrap::internal::py_arg<const ns1::ClassA&>("a"));
     m_ns2.def("overloadedGlobalFunction",static_cast<ns1::ClassA (*)(const ns1::ClassA&, double)>(&ns2::overloadedGlobalFunction), gtwrap::internal::py_arg<const ns1::ClassA&>("a"), gtwrap::internal::py_arg<double>("b"));
@@ -106,7 +133,7 @@ void gtwrap_bind_namespaces_py(py::module_ &m_) {
     gtwrap_class_m__ClassD
         .def(py::init<>());
 
-    m_.attr("aGlobalVar") = aGlobalVar;
+    gtwrap::internal::bind_variable(m_, "aGlobalVar", aGlobalVar);
     pybind11::module m_gtsam = py::reinterpret_borrow<pybind11::module>(m_.attr("gtsam"));
 
     auto gtwrap_class_m_gtsam_Values = py::reinterpret_borrow<py::class_<gtsam::Values, std::shared_ptr<gtsam::Values>>>(m_gtsam.attr("Values"));


### PR DESCRIPTION
Global `std::function` variables currently become anonymous Python callables through `module.attr(...)` assignment. GTSAM’s `DefaultKeyFormatter`, for example, works at runtime but lacks function metadata, causing `pybind11-stubgen` to omit it.

Generate a C++ helper that selects `module.def(...)` for `std::function` values and attribute assignment for ordinary variables. C++ overload resolution handles aliases such as `KeyFormatter` without application-specific rules. Preserve empty functions as `None` and the direct C++ callback path for stored function pointers.

Updates documentation and expected generated output. MATLAB generation is unaffected.

Validation:

- Wrap: 132 tests passed; 2 annotation tests deselected to avoid invoking a compiler.
- Full replacement in GTSAM: all bindings regenerated; 541 stable tests passed, 6 skipped; 6 unstable tests passed.
- Manually verified callable metadata, C++ callbacks, and stub declarations and exports. Stubgen reported no errors.
- No new compiler-dependent tests or stubgen dependency.

Related: borglab/gtsam#2789.
